### PR TITLE
docs: define SQLite Library Core architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,14 @@ Capture your social/rss/newsletter feeds locally. Tune the ranking algo yourself
 
 ## Architecture
 
+Freed uses SQLite everywhere. Freed Desktop and the headless Primary share one
+native Rust core. The PWA runs official SQLite WebAssembly over OPFS. Every
+view uses bounded typed queries, and synchronization exchanges normalized
+signed logical objects rather than database files or a monolithic Library
+document. See
+[the Library Core architecture](docs/LIBRARY-CORE-ARCHITECTURE.md) and
+[the detailed contract](docs/LIBRARY-CORE-CONTRACT.md).
+
 ```
   Capture Layers              Sync                    Clients
  ─────────────────      ─────────────────      ─────────────────
@@ -39,7 +47,11 @@ Capture your social/rss/newsletter feeds locally. Tune the ranking algo yourself
                                                 Extension
 ```
 
-**Desktop App is the hub.** It runs capture, hosts the sync relay, and provides the reader UI. Phone PWA syncs to it for mobile reading. OpenClaw users can run capture headlessly instead.
+One active Primary admits canonical mutations. The Primary may run inside
+Freed Desktop or the headless service. Freed Desktop and PWA followers keep
+fully queryable local SQLite replicas, apply edits through durable signed
+intent overlays, and choose independently which large content to stream,
+cache, pin offline, or exclude.
 
 ---
 
@@ -80,7 +92,7 @@ Local WebSocket relay + cloud backup.
 
 **HIGHEST PRIORITY** — Native apps (macOS, Windows, Linux, iOS, Android) bundling capture, sync, and reader UI.
 
-### [Phase 6: PWA Reader](docs/PHASE-6-PWA.md) 🚧
+### [Phase 6: PWA](docs/PHASE-6-PWA.md) 🚧
 
 Mobile companion at [app.freed.wtf](https://app.freed.wtf), with the dev channel at `dev-app.freed.wtf`.
 
@@ -116,14 +128,14 @@ Compose and publish through your own site.
 
 ## Key Decisions
 
-1. **Desktop App as hub** — Capture + sync + UI in one installable package
-2. **Zero external infrastructure** — Local relay + user's cloud storage (GDrive, Dropbox, iCloud)
-3. **Local-first sync** — Devices reconcile without a server; your cloud storage is backup, not the source of truth
-4. **Shared React codebase** — `packages/pwa/` embedded in Desktop AND deployed standalone
-5. **TypeScript capture via subprocess** — Capture packages run as TypeScript, not compiled into Tauri's Rust core. Easier to extend, easier to debug.
-6. **Ranking on core, display on edge** — Desktop/OpenClaw computes `priority`, PWA just displays
-7. **Capture layer pattern** — Each source normalizes to unified `FeedItem`
-8. **Next.js for marketing site** — SSG for SEO, React for consistency with app codebase
+1. **One active Primary:** Freed Desktop or the headless service admits canonical mutations through the same native Library Core
+2. **No Freed content backend:** Synchronization uses storage owned by the user
+3. **SQLite everywhere:** Every client queries a local SQLite Library through one generated contract
+4. **Shared React views:** `packages/ui` consumes platform-neutral typed query and mutation adapters
+5. **Typed capture boundary:** Provider packages normalize bounded values and submit registered mutations
+6. **Ranking in the Primary:** Canonical ranking policy is materialized once and queried locally on every client
+7. **Logical-object sync:** Devices exchange signed normalized records and selective content, never database files
+8. **Next.js for the marketing site:** The public site remains isolated in the `www` lane
 
 ---
 
@@ -152,7 +164,7 @@ npm run website:dev    # Dev server at http://localhost:3000
 npm run website:build  # Production build
 ```
 
-### PWA Reader
+### PWA
 
 ```bash
 npm run pwa:dev    # Dev server at http://localhost:5173

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,159 +1,256 @@
 # Freed Technical Architecture
 
-Accurate as of 2026-07-23. This document describes the system as shipped, not as aspired to. GitHub Issues carrying the `debt` label are the sole canonical backlog for known defects and program-tracked limitations. Durable stability policy lives in [STABILITY-PROGRAM.md](STABILITY-PROGRAM.md).
+Freed uses SQLite everywhere. Freed Desktop, the headless Primary, and the PWA
+all query a local SQLite Library through the same generated contract. React
+holds visible result windows and ephemeral interface state only.
 
-## What Freed is
+The complete Library model lives in
+[LIBRARY-CORE-ARCHITECTURE.md](LIBRARY-CORE-ARCHITECTURE.md). Exact durable
+contracts live in [LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md). Current
+delivery checkpoints live in
+[STORAGE-ARCHITECTURE-ROADMAP.md](STORAGE-ARCHITECTURE-ROADMAP.md) and the
+affected `PHASE` documents. Durable stability policy lives in
+[STABILITY-PROGRAM.md](STABILITY-PROGRAM.md).
 
-Freed Desktop captures the user's own social feeds (X, Facebook, Instagram, LinkedIn, Substack beta, Medium beta, YouTube, RSS, saved articles) on their machine using their own authenticated sessions, stores everything locally in one Automerge document, and presents a user-controlled unified feed. A companion PWA at `app.freed.wtf` is the mobile reader. There is no Freed content backend: sync rides on a LAN relay inside the desktop app and on the user's own cloud storage (Google Drive, Dropbox). Small serverless endpoints handle narrow operations such as OAuth token exchange without receiving the Automerge document.
+## System shape
 
-Earlier drafts of this document described a browser add-on capture layer and direct peer-to-peer device sync; neither was ever shipped, and nothing here is aspirational.
+```text
+Provider capture and user actions
+                |
+                v
+       registered mutations
+                |
+                v
+     active Primary Library Core
+      Rust plus bundled SQLite
+                |
+        signed logical objects
+                |
+       user-owned Google Drive
+                |
+         +------+------+
+         |             |
+         v             v
+  Freed Desktop       PWA
+  local SQLite     SQLite WASM
+                    plus OPFS
+```
 
-## Repo layout
+One active Primary admits canonical mutations for a Library and writer epoch.
+The Primary can run inside Freed Desktop or the provider-neutral headless
+service. Editable follower clients keep complete queryable local replicas and
+submit signed mutation intents. The Primary validates each intent, commits it
+atomically, and publishes a signed result.
 
-npm workspaces monorepo (`packages/*`, `skills/*`, `website`), Node pinned by `.nvmrc`. Boundary rules live in AGENTS.md and are binding:
+SQLite files are private local implementation artifacts. Synchronization never
+copies a database, WAL, SHM, or rollback journal. It transfers typed normalized
+records, operation segments, signed intents and results, authenticated
+manifests, content descriptors, and content-addressed blobs.
 
-| Package | Role |
-| ------- | ---- |
-| `packages/shared` | Pure functions + types, including the Automerge schema (`src/schema.ts`, backward-compatible changes only). Zero runtime deps. No React. |
-| `packages/ui` | Platform-agnostic React UI (feed, reader, map via MapLibre, search via MiniSearch, zustand stores). Ships raw `.tsx`; no build step. No platform stores, no Tauri APIs. |
-| `packages/sync` | Storage-agnostic sync: IndexedDB and filesystem storage adapters, cloud providers (`cloud/gdrive.ts`, `cloud/dropbox.ts`, `cloud/merge.ts`), LAN relay client (`network/local-relay.ts`). Works in browser and Node. |
-| `packages/capture-*` | Isolated provider extraction, parsing, and normalization helpers. Capture packages never import each other. |
-| `packages/library-core-native` | Runtime-neutral Rust library for the signed SQLite authority journal, actor enrollment, authority epochs, deterministic product projection, staged logical checkpoint activation, exact local status and closed backup receipts, the local process lease, and the fixed-fd native authority sidecar. The sidecar opens its lease and private directories relative to inherited descriptors, pins the physical SQLite directory inode before SQLite starts, rechecks bounded control descriptors after exact reads, and validates internal backup leaves before retention deletion. It has no Tauri, provider, or network dependency. |
-| `packages/desktop` | Tauri shell: React renderer plus `src-tauri/src/lib.rs` (~13k lines of Rust). Imports the capture packages used by its native and scheduled providers, plus `@freed/ui`, `@freed/shared`, and `@freed/sync`. |
-| `packages/pwa` | Mobile reader app shell (Vite + React + vite-plugin-pwa/Workbox). Never imports Tauri APIs. |
-| `website` | Marketing site (Next.js App Router) at `freed.wtf`. Lives on the `www` branch lane. |
-| `.agents/skills/`, `automation/`, `scripts/` | Governed agent skills, continuous actor prompts and specifications, evidence schemas, and automation or release tooling. |
+## Runtime ownership
 
-## Desktop app
+### Native Library Core
 
-Tauri 2 (Rust backend, WKWebView renderer on macOS). Two runtime halves:
+`packages/library-core-native` owns the native data plane. It contains the
+schema, migrations, mutation executor, named query executor, authority journal,
+checkpoint import and export, content-vault interface, process exclusion, and
+recovery logic. It has no Tauri, React, provider, or network dependency.
 
-**The React renderer is the orchestrator.** The main window runs the scheduler (`background-runtime-coordinator.ts` job kinds include `rss-poll`, content fetching, cloud upload), the RSS poller, the content fetcher, provider capture drivers (`fb-capture.ts`, `instagram-capture.ts`, `li-capture.ts`, `substack-capture.ts`, `medium-capture.ts`, `youtube-capture.ts`, X via `capture.ts`), provider health tracking, and the Automerge worker host. This is a load-bearing architectural fact: killing the main renderer kills every in-flight background job. Issue #1071 tracks recovery settlement, and issues #1080 and #1081 track scheduler and job settlement.
+Freed Desktop and the headless Primary call this same Rust library. Their host
+layers provide windows, lifecycle, credentials, scheduling, network adapters,
+and platform capabilities. They do not contain alternate Library semantics.
 
-**Rust (`src-tauri/src/lib.rs`) owns native substrate:** window management including hidden scraper WebViews, the LAN sync relay, the renderer watchdog and memory recovery, `runtime-health.jsonl` telemetry, the dev sync trigger watcher, tray/updater/global-shortcut plumbing, and utility commands such as `fetch_binary_url`.
+### Browser Library Core
 
-### Capture strategies per provider
+The PWA runs official SQLite WebAssembly in a dedicated worker and persists the
+Library in OPFS. It consumes the same schema catalog, named SQL, result DTOs,
+mutation definitions, protocol registry, and conformance vectors as native
+hosts. A narrow browser key store may hold nonextractable cryptographic keys.
+IndexedDB is not a Library database, transport, fallback, or rollback path.
 
-Capture uses provider-specific transports. Anything that would change provider-visible behavior, including loads, navigation, request frequency, cookies, headers, extractor scripts, embeds, or provider API calls, requires the explicit approval lane in AGENTS.md and STABILITY-PROGRAM.md.
+iOS 17 is the supported browser durability floor. Physical iPhone acceptance
+covers storage persistence, quota pressure, suspension, worker replacement,
+checkpoint activation, intent recovery, and selective offline media.
 
-- **X:** hidden authenticated WebView calls X's own GraphQL API (`x.com/i/api/graphql`, endpoint definitions in `capture-x/src/endpoints.ts`) and normalizes timeline responses. No DOM scraping.
-- **Authenticated websites:** isolated WebView data stores keep each provider session on the user's device. Provider pages are loaded and normalized by the matching `capture-*` package. DOM extractors can change frequently, so the stability program favors diagnostics over speculative hardening.
-- **YouTube:** an isolated authenticated session captures the user's subscription roster and saved playlists through the YouTube-specific native bridge and `capture-youtube` normalization package. Playback remains a reader surface, not a background preload loop.
-- **Substack and Medium beta:** isolated authenticated WebView sessions capture
-  bounded rendered roster, activity, and essay records. Browser-safe capture
-  packages normalize records, and one atomic Automerge change reconciles
-  follow-roster accounts with visible activity. The graph run rejects browser
-  chrome and essay links, and caps itself at 500 unique identities. Missing
-  rows never imply an unfollow. Subscriber management and private communication
-  surfaces are blocked. Essay excerpts embedded inside restacks, likes, and
-  claps are not archived. A dedicated randomized scheduler runs both beta
-  providers outside the RSS poll job. The next allowed capture time is stored
-  outside auth state so cooldowns survive a restart or disconnect. User-added
-  RSS remains the preferred path for full public essay bodies, with canonical
-  reconciliation consolidating legacy duplicates without losing user state.
-- **RSS:** `rss-poller.ts` on the renderer scheduler; parsing in `capture-rss`.
-- **Save-for-later:** URL/clipboard capture through `capture-save` (Readability extraction); also used by the PWA.
-- Facebook, Instagram, and LinkedIn social scrapes are currently nested inside
-  the `rss-poll` job, which serializes them behind a Rust mutex and causes the
-  recurring "job timed out kind=rss-poll" cycle. Issue #1080 tracks un-nesting.
-  Substack and Medium use their dedicated scheduler and do not enter that nested
-  path.
+### React applications
 
-### Auth state
+`packages/ui` owns platform-neutral product views. A view asks its platform
+adapter for a bounded named query and receives a closed typed DTO. The adapter
+may stream subsequent pages, but it never returns the Library corpus.
 
-Session cookies live in the scraper WebViews' data stores. Issue #1077 tracks X 401/403 responses that are treated as transport failures and retried. Issue #1078 tracks logged-out Instagram and LinkedIn sessions that are not classified as authentication failures.
+React may retain:
 
-## Data model and sync
+- visible and adjacent result windows
+- current navigation and selection
+- draft form state
+- transient request and error state
+- device-local presentation settings
 
-One Automerge document holds items, preferences, and social graph data (`packages/shared/src/schema.ts`). Schema changes must be backward compatible: add optional fields, never delete.
+React may not retain an authoritative Library, full search index, full result
+set, mutation shadow, or synchronization document.
 
-The document only stores state whose meaning survives moving to another device. Content, subscriptions, identity relationships, user-authored organization, ranking policy, capture policy, and accessibility preferences belong in Automerge. Window geometry, shell visibility, view modes, sort and filter selections, graph pin coordinates, machine endpoints, connection scheduling, and transient operation status stay in device-local storage. Central mutation guards enforce this boundary before preference, person, account, feed, or Story Wall changes reach Automerge. Legacy schema fields remain optional and deprecated so older documents still load, but current clients neither create nor update them. The synchronized metadata identifies the document itself. Runtime timestamps, presence, and machine-local settings do not belong in the document.
+## Data model
 
-A minimal Freed Desktop registration map is the deliberate exception because its meaning is cross-device coordination. It lets a library detect that more than one Freed Desktop installation has been configured and warn that provider polling may be duplicated. Each opaque installation identifier originates in local native storage. The synced map records only the stable identifier and first registration time. It does not record PWA readers, online presence, last-seen heartbeats, provider credentials, or machine details.
+The Library is normalized around stable identities and explicit relationships.
+The schema includes:
 
-Older documents can still contain full reader HTML and RSS retry fields. Current clients never create or update those fields in Automerge. Reader HTML remains read-only compatibility data so an upgrade cannot delete another device's only reader copy. It stays out of hydrated list state, is fetched from the worker only for the active reader, and is then cached locally. Deprecated synchronized RSS retry, error, and validator fields are ignored so one device's old failure cannot throttle another device.
+- items, item state, sources, feeds, authors, people, accounts, and identities
+- tags, item-tag edges, relationships, follows, blocks, and graph state
+- ranking policy, capture policy, synchronized preferences, and user-created
+  organization
+- registered mutation occurrences, actor chains, tombstones, receipts, and
+  authority epochs
+- checkpoint state, imported frontiers, operation segments, and follower
+  intent and result state
+- content descriptors, renditions, chunk indexes, cache policy, and local
+  hydration state
 
-RSS subscriptions and the last successful content refresh time sync. Retry windows, failure counters, and fetch errors stay local to the polling device. Deprecated synchronized HTTP validator fields are ignored. The current transport does not persist validators. If conditional requests are added later, their validators must stay local too. A failed network request on one machine must not delay another machine's scheduler.
+Device-local state such as window geometry, graph pin coordinates, temporary
+filters, provider session cookies, retry timers, machine endpoints, and cache
+residency remains outside synchronized Library state.
 
-Graph pin coordinates are migrated once from legacy Person and Account fields into a versioned local layout store. Current person and account mutations strip those fields at the store, optimistic projection, and schema boundaries. Rendering removes any stale synchronized coordinates before overlaying the current device's layout.
+No `shellJson`, `DocState`, monolithic FeedItem record, generic JSON patch, or
+equivalent catch-all object is part of the runtime model.
 
-- **Worker ownership:** each app runs the document inside a dedicated worker (`automerge.worker.ts` in desktop and PWA). Mutations go through worker messages; `STATE_UPDATE` fans hydrated state back to subscribers. Persistence is IndexedDB with incremental appends plus periodic snapshots (`automerge-persistence.ts`, `snapshots.ts`).
-- **LAN relay:** the desktop Rust side runs a WebSocket relay (default port 8765, `FREED_SYNC_PORT` override). The PWA pairs via QR code and connects as a client. Today the relay broadcasts desktop state to clients but never merges client pushes into the desktop document, and the PWA pushes only once per connection. Phone-to-desktop convergence over LAN does not exist yet and rides on cloud sync instead. Issue #1072 owns the inbound path.
-- **Cloud sync:** full-document snapshots to the user's Google Drive or Dropbox with download, merge, and upload behavior in `sync/src/cloud/`. The shipped Freed Desktop heads guard suppresses merge-back upload echoes while preserving genuine mutations. Issue #1066 owns bounded re-verification, issue #1068 owns the matching PWA damper, issue #1069 owns Google Drive self-write filtering, and issue #1076 owns moving CRDT merge work off the main renderer thread.
-- **Transport cost:** every synced mutation ships the whole document binary as a boxed `number[]` through two JavaScript heaps plus JSON Tauri IPC. Issue #1087 owns raw binary transport. Issue #1082 owns unbounded history and cloud-safe eviction.
+## Query and mutation contracts
 
-## Watchdog and recovery
+One executable contract source generates Rust and TypeScript bindings. It
+registers every durable field, table, mutation, query, checkpoint record,
+protocol object, content descriptor, locality rule, and deletion obligation.
 
-The Rust watchdog supervises the renderer via heartbeats (`renderer-heartbeat.ts` to `renderer_heartbeat` events), native memory samples, and WebKit process telemetry. Runtime health now writes daily files on Unix, keeps a stable `runtime-health.jsonl` symlink for readers, and retains recent history. Non-Unix builds retain the bounded single-file fallback. Recovery actions include renderer restart and scraper-window recycling.
+Named queries define:
 
-Known limitations are tracked in issues #1089 through #1091, #1071, and #1070. They cover diagnostics under the renderer-health lock, WebKit process attribution, invalid CPU gates, recovery before scrape settlement, and scraper recycling without an active-session check. **Do not tune watchdog thresholds** while those measurement and demand-side issues remain open.
+- closed input and output types
+- stable keyset ordering
+- maximum page size and byte budget
+- required indexes
+- authorization and locality
+- invalidation topics
+- failure variants
 
-## PWA reader
+Registered mutations define:
 
-Vite + React + `vite-plugin-pwa` (Workbox) at `app.freed.wtf` (Vercel). Imports `@freed/ui`, `@freed/shared`, `@freed/sync`, and `@freed/capture-save`. Runs its own Automerge worker and IndexedDB persistence, connects to the Freed Desktop relay over LAN through QR pairing, and can sync against the same cloud snapshot. Issue #1068 tracks its cloud-loop damper, and issue #1086 tracks its full-document save, hydration, and merge work.
+- closed typed input
+- actor capability
+- canonical validation
+- transaction scope
+- merge algebra or conflict rule
+- tombstone and cascade behavior
+- materialized tables and indexes
+- emitted operation and invalidation records
+- idempotency and receipt behavior
 
-## Website
+All product reads and writes use these contracts. There is no unbounded query,
+whole-corpus subscription, generic patch route, or hidden JavaScript cascade.
 
-Next.js App Router marketing site at `freed.wtf` (`website/`), deployed to Vercel under the `aubreyfs-projects` scope only. Public roadmap data lives in `website/src/app/roadmap/RoadmapContent.tsx` and mirrors `docs/PHASE-*.md` statuses. Marketing changes ride the `www` branch lane, never `dev`.
+## Synchronization
 
-## Release lanes and shipping
+The active Primary publishes immutable normalized checkpoints and append-only
+operation segments through the user's Google Drive `appDataFolder`. One small
+authenticated control tuple identifies the current writer epoch, checkpoint,
+frontier, schema, and protocol version.
 
-Three long-lived branches: `dev` (product work, default), `main` (production releases), `www` (public marketing + published changelog). Versioning is CalVer `YY.M.DDBUILD` (AGENTS.md has the encoding). Dev release prep starts from current `origin/dev` and returns through a reviewed PR to `dev`. Production release prep starts from current `origin/main` after any required `dev` promotion and returns through a release-only PR to `main`. `release-publish.sh` tags only the exact merged remote commit. Pushing that tag triggers `.github/workflows/release.yml` for validation, platform builds, updater metadata, publication, and website or PWA deployment. Desktop self-updates via `tauri-plugin-updater`. The full operator flow is the `freed-ship-build` skill.
+Checkpoint identity is the stable registry entry plus the record's typed
+primary key. Page position is transport metadata only. A page contains no more
+than 128 records and no more than 2,097,152 decoded canonical bytes. Each
+logical record is capped at the protocol's measurement-gated 131,072-byte
+ceiling. Legal values that exceed the ceiling use content descriptors and
+bounded content-addressed chunks.
 
-## Testing and validation
+Follower edits use closed signed intent envelopes. An intent binds the Library,
+writer epoch, actor, capability, transaction, ordered operations, predecessor,
+and idempotency key. The Primary either commits the complete transaction and
+publishes its canonical result, or rejects it with a signed typed reason.
+Clients retain a sparse durable optimistic overlay until canonical checkpoint
+or result evidence resolves the intent.
 
-- Desktop e2e: Playwright against plain Chromium with a mocked Tauri layer (`VITE_TEST_TAURI=1`; see AGENTS.md "Desktop E2E Testing" and `packages/desktop/tests/e2e/README.md`), including a perf suite gated in CI against `perf-baselines.json` / `perf-budgets.json`.
-- Validation tiers: `npm run validate:feature` (path-scoped, feature branches), `validate:dev` (integration), `validate:release` (release prep). CI is `.github/workflows/ci.yml`.
-- Tooling smoke: `npm run test:scripts` covers the automation scripts in `scripts/`.
+Protocol and physical schema versions are independent. Unsupported protocol,
+registry, schema, or capability versions fail closed before activation. A new
+protocol version never revives a shell or dual-write bridge.
 
-## Automation substrate
+## Content plane
 
-- `scripts/lib/automation-control.mjs` and `scripts/automation-control.mjs`:
-  canonical task state, authenticated actor policy, short-lived leases, provider
-  approval state, append-only events, pending outcome reservations, and atomic
-  lifecycle transitions under `~/.freed/automation/`.
-- `automation/specs/` and `automation/prompts/`: checked-in contracts for the
-  nightly runner, runtime observer, release verifier, scaffolding maintainer,
-  and stability controller. `scripts/validate-automation-specs.mjs` checks the
-  repository contract. `scripts/validate-host-automations.mjs` audits the saved
-  host actors and their owner-supplied overlays without installing them.
-- `scripts/nightly-self-improve.mjs`: planner and executor that turns verified
-  soak, canary, triage, CI, and program evidence into ranked work. Strict
-  `scripts/doctor.mjs --strict` preflight gates mutation and publishing.
-- `scripts/doctor.mjs`: machine preflight for the pinned Node toolchain, GitHub
-  CLI, credential helpers, Python, Xcode license state, automation state, and
-  optional trusted publisher readiness. Worktree setup may warn, but continuous
-  mutation loops stop on strict failures. Missing optional broker provisioning
-  is a warning unless the caller explicitly requires that profile.
-- `scripts/soak-collect.mjs` and `scripts/soak-assert.mjs`: exclusive installed
-  soak collection, raw evidence mirroring, build attribution, source-health
-  checks, comparable workload context, and machine-readable verdicts. See
-  docs/SOAK-AND-TRIGGERS.md.
-- `scripts/canary-context.mjs` and `scripts/canary-summarize.mjs`: rebuild a
-  stored soak, preserve runtime and collector sidecars, compare only verified
-  historical cohorts, and write portable canary ledger bundles.
-- `scripts/build-outcome-verdict.mjs` and `scripts/record-outcome.mjs`: derive
-  task effects from raw registered evidence, then commit one authenticated
-  outcome transaction to the canonical ledger and control event stream.
-- `scripts/triage.mjs`: fold attributable alarms, soak failures, verified
-  canary regressions, and CI issues into one immutable ranked candidate
-  generation while preserving duplicate event multiplicity.
-- `scripts/trusted-publisher-host.swift` and
-  `scripts/trusted-worktree-publish.sh`: optional root-provisioned publisher broker,
-  one-use scoped capabilities, exact leases, pinned executable identities, and
-  final branch and PR rechecks. No reusable publisher secret enters an agent
-  process.
-- `scripts/lib/provider-visible-paths.mjs`, `.github/CODEOWNERS`, and
-  `.github/rulesets/`: canonical provider-risk classification and branch
-  governance. Ruleset creation remains an explicit post-merge owner action.
-- `scripts/stability-artifact.mjs` and `automation/artifact-schemas/`: versioned,
-  content-addressed interchange manifests for evidence capture, memory
-  profiles, sync replays, provider reviews, and controller decisions.
-- `scripts/dev-sync-trigger.mjs`: terminal-driven provider sync trigger for installed dev builds (same doc).
-- `.agents/skills/` contains the governed operational workflows.
-  `scripts/validate-skills.mjs` checks safe invocation, referenced commands,
-  local links, and agent metadata.
-- GitHub Issues carrying the `debt` label are the sole canonical engineering
-  debt backlog. Continuous actors reconcile eligible issues through the control
-  plane. The active execution manifest references each issue and never becomes
-  a parallel backlog.
+Large content lives outside logical row records. Metadata checkpoints carry
+descriptors with content identity, media type, byte length, digest, rendition,
+chunk or range index, and availability policy.
+
+Each device independently chooses one policy per asset or rendition:
+
+- metadata only
+- stream on demand
+- partial cache
+- full cache
+- pinned offline
+- excluded
+
+Freed Desktop can pre-download long-form video and place it in a local content
+vault. Another client can stream the same rendition from Google Drive, hydrate
+only a range, or exclude it. Descriptor convergence does not imply byte
+hydration. Garbage collection preserves bytes reachable from canonical
+descriptors, pinned policies, retained checkpoints, backups, or active
+transfers.
+
+## Capture and providers
+
+Provider packages extract and normalize bounded records. They never own the
+Library. Capture results enter the registered mutation boundary and commit in
+the active Primary.
+
+Authenticated sessions remain isolated by provider. Provider-visible behavior,
+including navigation, requests, headers, cookies, extraction scripts, timing,
+and media loading, follows the separate provider-risk rules in `AGENTS.md` and
+[STABILITY-PROGRAM.md](STABILITY-PROGRAM.md). Library architecture changes do
+not alter provider traffic by implication.
+
+## Package boundaries
+
+| Package | Responsibility |
+| --- | --- |
+| `packages/shared` | Pure generated types, codecs, SQL catalog metadata, validation, and cross-runtime vectors. No React or platform APIs. |
+| `packages/library-core-native` | Runtime-neutral Rust Library Core for native hosts. |
+| `packages/ui` | Platform-neutral React views over typed query and mutation adapters. |
+| `packages/sync` | Storage-neutral protocol orchestration and cloud transport ports. No Library authority. |
+| `packages/desktop` | Tauri host, native adapter, scheduling, credentials, windows, and provider integration. |
+| `packages/pwa` | Browser host, SQLite worker adapter, OPFS lifecycle, service worker, and mobile shell. |
+| `packages/capture-*` | Isolated provider extraction and normalization. Capture packages never import each other. |
+| `website` | Marketing site in the separate `www` lane. |
+
+## Failure semantics
+
+Durable state changes are atomic SQLite transactions. Crashes before commit
+leave no accepted mutation. Crashes after commit recover from journal and
+receipt state without replaying a non-idempotent effect. Checkpoint imports use
+a staging database and activate only after complete manifest, registry,
+frontier, row, content-root, and integrity verification.
+
+Unknown versions, missing fields, invalid signatures, broken actor chains,
+split writer epochs, oversized records, stale cursors, source movement, and
+content digest mismatches return closed typed failures. A client never repairs
+these conditions by loading a compatibility engine.
+
+## Observability and performance
+
+Every query, mutation, checkpoint page, intent, result, import, export, and
+content transfer records bounded structured telemetry. Events include build,
+schema, protocol, registry, query or mutation name, duration, row count, byte
+count, cursor outcome, transaction identity, and typed failure code. Telemetry
+never includes provider credentials or private content bodies.
+
+Performance gates cover 25,000-item and 100,000-item Libraries. They enforce
+bounded renderer memory, bounded worker memory, indexed query plans, fixed page
+and response budgets, bounded startup work, and recovery without corpus
+materialization.
+
+## Release and operations
+
+Product work flows through `dev`, production promotion through `main`, and the
+public website through `www`. Release, installation, deployment, live-data
+migration, writer-epoch cutover, destructive cleanup, and provider-visible
+changes retain their own explicit operational authority.
+
+Validation uses path-scoped feature checks during implementation, complete
+integration checks at the `dev` boundary, release checks for promotion, native
+and browser conformance vectors, crash and response-loss fault injection,
+physical iPhone storage evidence, and installed Freed Desktop evidence.
+
+GitHub Issues labeled `debt` remain the sole engineering debt backlog.

--- a/docs/LIBRARY-CORE-ARCHITECTURE.md
+++ b/docs/LIBRARY-CORE-ARCHITECTURE.md
@@ -1,0 +1,1196 @@
+# Freed Library Core Architecture
+
+This document defines Freed's durable Library architecture across Freed
+Desktop, the provider-neutral headless Primary, and the PWA.
+
+## Documentation map
+
+This overview is the navigation and decision record. It is not the only place
+where the architecture is specified. The repo documentation divides authority
+as follows:
+
+- This file defines the whole-system model, ownership boundaries, performance
+  budgets, deletion target, delivery sequence, and estimates.
+- [LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md) defines exact durable
+  authority, mutation, query, checkpoint, intent, result, content, migration,
+  failure, and recovery contracts.
+- [STORAGE-ARCHITECTURE-ROADMAP.md](STORAGE-ARCHITECTURE-ROADMAP.md) defines the
+  current implementation sequence and delivery checkpoints.
+- [PHASE-4-SYNC.md](PHASE-4-SYNC.md),
+  [PHASE-5-DESKTOP.md](PHASE-5-DESKTOP.md),
+  [PHASE-6-PWA.md](PHASE-6-PWA.md),
+  [PHASE-11-OPENCLAW.md](PHASE-11-OPENCLAW.md), and
+  [PHASE-12-ADDITIONAL-PLATFORMS.md](PHASE-12-ADDITIONAL-PLATFORMS.md) define
+  delivery state by product surface.
+- [YOUTUBE-INTEGRATION.md](YOUTUBE-INTEGRATION.md) defines provider-specific
+  media acquisition boundaries and consumes the shared selective-content
+  contract.
+- [TURSO-EVALUATION.md](TURSO-EVALUATION.md) records the measured database
+  engine decision.
+- `library-core-activation-manifest.json` records release activation gates. It
+  must describe the SQLite-only storage epoch before that epoch is activated.
+- `roadmap-status.json` is the machine-readable status mirror for product
+  phases. The public website roadmap remains in its separate `www` lane.
+
+The contract and phase documents must be updated in the same change as the
+behavior they govern.
+
+The target is one logical Library Core implemented with stock SQLite in every
+operational environment. Freed Desktop and the headless Primary run SQLite
+through the extracted native Rust core. The PWA runs official SQLite
+WebAssembly in a worker and persists the database in the Origin Private File
+System, or OPFS.
+
+SQLite database files remain local implementation artifacts. Synchronization
+exchanges signed mutations, normalized checkpoints, authenticated manifests,
+and content-addressed blobs. It never copies, uploads, merges, or restores a
+live SQLite database file, WAL, SHM, or rollback journal.
+
+## 1. Governing decisions
+
+The architecture has these non-negotiable properties:
+
+1. `shellJson`, `DocState`, and every equivalent Library shell cease to exist
+   as runtime authority, transport, fallback, rollback evidence, or
+   compatibility state.
+2. There is no dual write between another Library engine and SQLite.
+3. Every Freed Desktop view reads through bounded typed SQLite queries.
+4. The PWA uses SQLite WebAssembly and OPFS for Library rows. IndexedDB is not
+   a Library database fallback.
+5. React retains visible result windows and ephemeral interface state only.
+6. Google Drive carries immutable protocol objects and one small authenticated
+   control tuple. It never carries SQLite filesystem state.
+7. One active writer epoch admits canonical mutations. Followers submit
+   signed mutation intents to the designated Primary.
+8. Every checkpoint record has a stable registry identity and typed primary
+   key. Page ordinals never become logical identity.
+9. Every canonical logical wire record is bounded. Large content uses the
+   separate content plane.
+10. Content synchronization is selective per device. Descriptor replication
+    does not require byte hydration.
+11. Desktop, headless, and PWA behavior derives from one executable contract
+    source and the same checked-in SQL.
+12. Source migration logic is short lived and isolated. It is not a
+   permanent runtime compatibility engine.
+
+## 2. Outcome
+
+The completed system has this shape:
+
+```text
+                            Google Drive appDataFolder
+                     immutable protocol objects and blobs
+                                      |
+                    authenticated manifest and control tuple
+                                      |
+              +-----------------------+-----------------------+
+              |                                               |
+     Designated Primary                              Editable follower
+     Freed Desktop or headless                       Desktop or PWA
+              |                                               |
+     native Library Core                               Library client
+              |                                               |
+       bundled SQLite                        native SQLite or SQLite WASM
+              |                                               |
+      accepted authority                      accepted replica plus local
+      journal and rows                         signed-intent overlay
+```
+
+Every device queries its own SQLite database. No view reconstructs a complete
+Library object. No synchronization pass reconstructs a complete Library
+object. No browser worker retains the corpus merely to answer a page query.
+
+## 3. Package ownership
+
+- `packages/library-core-native` owns native schema, migrations, mutations,
+  queries, journaling, authority, checkpoint staging, backup, process
+  exclusion, and content-vault access.
+- `packages/shared/src/library-core` owns generated TypeScript contracts,
+  canonical codecs, registry constants, SQL metadata, and cross-runtime
+  vectors.
+- `packages/sync` owns protocol orchestration and cloud transport ports. It
+  does not own Library rows or canonical mutation authority.
+- `packages/desktop` owns the Tauri host adapter, windows, platform lifecycle,
+  credentials, scheduling, and native capability wiring.
+- `packages/pwa` owns the browser host adapter, SQLite worker lifecycle, OPFS,
+  service worker, browser credentials, and mobile application shell.
+- `packages/ui` owns product views over typed query and mutation adapters. It
+  has no storage engine or synchronization authority.
+- `packages/capture-*` own isolated extraction and normalization. Captured
+  values enter the Library through registered mutations.
+
+The explicit runtime deletion list is in section 21. Current delivery state is
+tracked in [STORAGE-ARCHITECTURE-ROADMAP.md](STORAGE-ARCHITECTURE-ROADMAP.md),
+not in this architecture.
+
+## 4. One executable contract source
+
+The final Library is defined by one machine-readable contract IDL. The IDL is
+data, not handwritten Rust or TypeScript code.
+
+The IDL defines:
+
+- Logical entity and child-table schemas
+- Stable registry IDs and registry keys
+- Primary-key shapes and byte codecs
+- Field locality, authority, validation, and merge algebra
+- Mutation types, payloads, capabilities, and effects
+- Query IDs, parameters, result DTOs, limits, and invalidations
+- Checkpoint record types and inclusion rules
+- Wire formats, protocol versions, and canonical digest domains
+- Content descriptors and authenticated range-index types
+- Backup, export, redaction, and deletion rules
+- Memory, byte, count, and nesting limits
+- Protocol compatibility and cutover rules
+
+Generation produces:
+
+- Rust structs, enums, codecs, validators, and dispatch tables
+- TypeScript types, codecs, validators, and client bindings
+- Registry constants and fingerprints
+- Canonical cross-runtime vectors
+- Documentation tables
+- Compile-time exhaustive switches for mutations, queries, and records
+
+SQL remains executable source. Each schema migration, named query, and SQL
+materializer exists once as a checked-in SQL file. Rust consumes it with
+`include_str!`. The PWA build imports the same bytes. The IDL binds each SQL
+file to its typed parameters, expected columns, cardinality, and result DTO.
+
+CI must fail when:
+
+- Generated Rust or TypeScript is stale
+- A registry key is duplicated, removed, or reused
+- A public query or mutation lacks a contract entry
+- Rust and TypeScript produce different canonical bytes
+- A SQL result shape differs from its DTO
+- Desktop and browser schema catalogs differ
+- A named query lacks its registered index plan
+
+No generated API becomes public before a production entry point consumes it.
+
+## 5. Runtime ownership
+
+### 5.1 Native Rust core
+
+The extracted native crate owns:
+
+- Database location, opening, identity, and catalog verification
+- Schema migration and migration receipts
+- Active epoch and writer admission
+- Actor enrollment, retirement, and capability verification
+- Mutation verification and materialization
+- Operation journal and exact retry receipts
+- Bounded query execution
+- Checkpoint export and import
+- Replication, intent, and result outboxes
+- Content descriptor and blob-vault coordination
+- Backup, restore, repair, and integrity verification
+- Query change feed and durable background work queues
+- Metrics and typed failures
+
+Tauri owns only command registration, serialization, cancellation, and host
+capability wiring. The headless Primary calls the same crate without Tauri.
+
+Rust uses a bundled, pinned SQLite release with the required features. Runtime
+behavior must not depend on whichever SQLite happens to ship with an operating
+system.
+
+### 5.2 PWA core
+
+The PWA uses the official SQLite WebAssembly distribution with:
+
+- OPFS `opfs-sahpool`
+- One SharedWorker owning the SQLite connection
+- A dedicated-worker recovery route if SharedWorker startup is unavailable
+- One connection generation that fences stale tabs and old application code
+- One browser-level writer lock for the exact Library root
+- Durable transaction completion before acknowledgment
+- Reopen and recovery after worker suspension or termination
+- Persistent-storage request, quota inspection, and storage-pressure handling
+
+The supported floor is iOS 17 because it supplies the complete
+Storage API and persistent-storage behavior required by the product contract.
+The underlying SQLite path works on Safari 16.4 and later, but that does not
+make every earlier storage policy acceptable for Freed.
+
+Private Browsing does not receive an IndexedDB fallback. Freed reports that a
+durable local Library is unavailable in that context.
+
+IndexedDB may remain only as a narrow browser keystore for nonextractable
+WebCrypto key objects when WebKit supplies no appropriate alternative. It may
+not contain Library rows, checkpoints, cursors, operations, content metadata,
+or compatibility state.
+
+### 5.3 React
+
+React owns:
+
+- Active filters and navigation
+- Visible bounded row windows
+- Current reader content window
+- Pending interaction feedback
+- Dialog, focus, selection, and presentation state
+- Small bounded query summaries
+
+React does not own:
+
+- The Library corpus
+- Durable entities
+- Mutation history
+- Search indexes
+- Synchronization state
+- Checkpoint staging
+- Blob inventories
+- Long-lived worker projections
+
+## 6. SQLite storage model
+
+One Library has one SQLite database and one content-addressed local blob vault.
+
+### 6.1 Control and authority tables
+
+- Library metadata and database identity
+- Schema migration history
+- Accepted authority epochs
+- Active epoch pointer
+- Writer admission
+- Actor enrollments and retirements
+- Actor capabilities
+- Actor accepted and quarantined tips
+- Transition, recovery, migration, and cutover receipts
+
+### 6.2 Immutable journal tables
+
+- Transaction headers
+- Canonical operation members
+- Operation causal tips
+- Actor-chain state
+- Exact operation and transaction receipts
+- Replication outbox
+- Intent-result outbox
+- Quarantine evidence
+
+Canonical operation bytes are stored once. Outboxes reference immutable
+journal rows by primary key rather than copying canonical payloads.
+
+### 6.3 Normalized product tables
+
+The final table set covers every retained product field under:
+
+- Feed items
+- RSS feeds
+- People
+- Accounts
+- Preferences
+- Tags and other keyed collections
+- Relationships
+- Highlights, notes, logs, and other stable child entities that remain part of
+  the final product
+
+Frequently filtered, sorted, joined, or rendered values receive typed
+columns. Repeated collections receive child tables. Large content receives a
+descriptor and content-plane reference. Unknown historical fields do not
+become permanent `rest` JSON. Migration either classifies them into the final
+model or records an explicit exclusion that the owner can review.
+
+### 6.4 Merge metadata
+
+- Per-field causal assignments
+- Keyed collection membership assignments
+- Entity generations
+- Tombstones
+- Relationship effects
+- Preserved conflicts
+- Repair provenance
+
+SQL statement order is never merge policy. Each synchronized field uses its
+registered algebra:
+
+- Causal register
+- Element map
+- Keyed collection
+- Immutable content
+- Delete-wins entity tombstone
+- Explicit causal restore
+- Device-local register
+- Derived value
+
+### 6.5 Derived query structures
+
+- FTS5 search indexes
+- RTree indexes where spatial queries justify them
+- Feed ordering keys
+- Facet summaries
+- Navigation summaries
+- Query invalidation feed
+- Durable bounded work queues
+
+These structures are rebuildable and normally excluded from checkpoints.
+
+### 6.6 Database safety
+
+Every authoritative connection must:
+
+- Verify `application_id`, schema version, and the complete catalog
+- Open with URI interpretation disabled
+- Use private cache and no-follow behavior
+- Enable foreign keys, defensive mode, cell checks, and untrusted-schema
+  protection
+- Disable double-quoted string-literal compatibility
+- Apply explicit runtime limits
+- Use bounded busy handling
+- Use durability settings appropriate to acknowledged authority
+- Recheck database identity on the exact writable handle
+
+One operating-system lease protects one Library data root per process. Cloud
+writer authority remains separate from local process exclusion.
+
+## 7. Query architecture
+
+Views call generated named query methods through a platform-neutral
+`LibraryClient`. They do not receive arbitrary SQL and they do not receive a
+shell assembled from many queries.
+
+Every query contract declares:
+
+- Query ID and version
+- Typed request DTO
+- Typed result DTO
+- Maximum rows
+- Maximum serialized bytes
+- Keyset cursor codec
+- Required indexes
+- Projection revision semantics
+- Cancellation behavior
+- Query and facet invalidation keys
+- Expected query-plan properties
+
+A cursor binds query version, normalized filters, ordering keys, projection
+revision, and storage generation. A stale cursor returns a typed stale result.
+It never walks across mixed revisions.
+
+One view may request a query bundle when several small related results must
+come from one read transaction. This avoids client waterfalls while retaining
+a bounded response.
+
+Representative query families are:
+
+- Feed pages
+- Saved and archived pages
+- Search pages
+- Reader content
+- Person timelines
+- Friends surfaces
+- Map viewport rows
+- Navigation counts
+- Facet summaries
+- Account and feed management
+- Preference sections
+- Export and repair enumeration
+
+Ordinary pages admit at most the registered row and byte ceilings. Full reader
+content is ID-addressed and streamed when it exceeds the ordinary DTO budget.
+
+Stores subscribe only to a compact change feed containing revision, bounded
+changed IDs, invalidation keys, and `resetRequired`. The feed contains no
+hydrated entity rows.
+
+## 8. Exhaustive mutation architecture
+
+The mutation registry is exhaustive. The existing set of canonical operations
+is a starting inventory, not the final product surface.
+
+Every durable user action, capture action, import action, synchronization
+transition, deletion, restore, and repair receives a named typed mutation.
+
+Each mutation declares:
+
+- Mutation type and version
+- Actor capability
+- Entity type and typed primary key
+- Closed payload schema
+- Preconditions
+- Touched field-registry entries
+- Merge algebra
+- Relationship and cascade effects
+- Blob dependencies
+- SQL materializer
+- Idempotency identity
+- Receipt shape
+- Query invalidations
+- Replication disposition
+- Provider-side-effect classification
+
+The initial registry inventory is deliberately broad. It includes at least the
+following distinct semantic mutations, with separate versions where payload or
+merge meaning differs:
+
+| family | mutation inventory |
+| --- | --- |
+| FeedItem identity and content | `feed_item_capture`, `feed_item_replace_content`, `feed_item_set_published_time`, `feed_item_set_author`, `feed_item_set_feed`, `feed_item_set_source`, `feed_item_set_story_kind`, `feed_item_add_media`, `feed_item_remove_media`, `feed_item_set_preserved_text`, `feed_item_remove`, `feed_item_restore` |
+| Reader state | `item_assign_read`, `item_assign_saved`, `item_assign_archived`, `item_assign_liked`, `item_set_read_position`, `item_set_playback_position`, `item_add_highlight`, `item_update_highlight`, `item_remove_highlight`, `item_add_note`, `item_update_note`, `item_remove_note` |
+| Organization | `item_add_tag`, `item_remove_tag`, `tag_create`, `tag_rename`, `tag_move`, `tag_remove`, `collection_create`, `collection_rename`, `collection_add_item`, `collection_remove_item`, `collection_remove` |
+| Feeds and sources | `feed_create`, `feed_update_identity`, `feed_rename`, `feed_set_enabled`, `feed_set_unread_tracking`, `feed_set_refresh_policy`, `feed_remove`, `feed_remove_with_items`, `source_set_capture_policy`, `source_set_ranking_policy` |
+| People and accounts | `person_create`, `person_update_profile`, `person_set_relationship`, `person_record_reach_out`, `person_remove`, `account_create`, `account_update_profile`, `account_link_person`, `account_unlink_person`, `account_remove`, `identity_merge`, `identity_split` |
+| Preferences and ranking | `preference_assign`, `ranking_weight_assign`, `ranking_rule_create`, `ranking_rule_update`, `ranking_rule_remove`, `accessibility_preference_assign`, `content_policy_assign`, `synced_hydration_intent_assign` |
+| Imports and maintenance | `saved_link_capture`, `markdown_import_batch`, `sample_seed_batch`, `sample_clear_batch`, `bulk_mark_read`, `bulk_archive`, `bulk_unarchive`, `bulk_remove`, `duplicate_consolidate`, `repair_relationship`, `repair_content_reference` |
+| Content plane | `content_descriptor_register`, `content_descriptor_replace`, `content_reference_attach`, `content_reference_detach`, `content_availability_confirm`, `content_tombstone` |
+| Authority and actors | `actor_enroll`, `actor_retire`, `actor_capability_replace`, `writer_epoch_transfer`, `intent_accept`, `intent_reject`, `quarantine_accept`, `quarantine_reject`, `repair_certificate_apply`, `compaction_commit` |
+
+This inventory is not a license to combine operations behind generic payloads.
+Contract generation must census every durable call site and fail until each
+one maps to a closed registered mutation or is deleted. Device-local interface
+state does not enter this registry.
+
+The authority boundary forbids:
+
+- Generic JSON patch
+- Toggle operations
+- Unkeyed increments
+- Arbitrary SQL writes from views
+- Boolean parameters that hide cascade behavior
+- Mutation types absent from the registry
+
+Bulk actions freeze one exact selected set through a durable bulk-intent
+identity and process it in bounded stable-key batches. The renderer never
+receives the complete selected ID set.
+
+## 9. Canonical operation journal
+
+One canonical mutation transaction contains:
+
+- Stable transaction and operation IDs
+- Library and active epoch identity
+- Actor identity, sequence, and predecessor
+- Branch-qualified causal frontier
+- Transaction member count and indexes
+- Mutation type, entity key, and typed payload
+- Blob references
+- Canonical payload, member, transaction, and chain digests
+- Actor signature
+
+The receiver verifies the complete transaction before applying any member.
+Partial transactions may be retained as incomplete evidence but cannot
+materialize, advance tips, produce acknowledgments, or enter an outbound
+manifest.
+
+One SQLite write transaction commits:
+
+1. Immutable journal rows
+2. Actor-tip compare-and-swap
+3. Materialized normalized rows
+4. Field clocks, relationships, conflicts, and tombstones
+5. Monotone ingest sequence
+6. Materializer frontier
+7. Exact retry receipt
+8. Replication outbox
+9. Query invalidations
+10. Materialized-state commitment updates
+
+A response-loss retry uses the same identity and returns the stored receipt.
+Changed bytes under the same identity are quarantined.
+
+## 10. Editable follower protocol
+
+Followers hold an accepted local replica but do not admit canonical writes for
+the active writer epoch. An edit creates a signed mutation-intent transaction.
+
+### 10.1 Intent records
+
+An intent transaction is represented by bounded canonical records:
+
+```text
+intent_transaction_header
+intent_transaction_member[0..n]
+intent_blob_reference[0..n]
+```
+
+The header binds:
+
+- Protocol version
+- Library and target epoch
+- Actor identity
+- Stable intent and transaction IDs
+- Previous intent-chain identity
+- Observed accepted frontier
+- Base projection revision
+- Member count and aggregate digest
+- Signature
+
+Each member uses the same generated semantic mutation payload as a Primary
+local mutation. The wrapper records that the member is proposed rather than
+accepted authority.
+
+### 10.2 Primary admission
+
+The Primary:
+
+1. Parses duplicate-preserving canonical bytes within limits.
+2. Verifies library, epoch, actor enrollment, capability, signature, sequence,
+   predecessor, and transaction completeness.
+3. Verifies referenced content exists and is remotely durable.
+4. Rechecks active writer admission inside the SQLite write transaction.
+5. Constructs canonical accepted operations from the semantic members.
+6. Applies the registered merge algebra.
+7. Commits journal, normalized rows, frontier, receipts, and outbox together.
+8. Publishes a signed intent result.
+
+### 10.3 Intent results
+
+A result is:
+
+- Accepted
+- Permanently rejected with a typed reason
+- Deferred for a missing dependency
+- Quarantined for identity or chain conflict
+- Unknown pending response resolution
+
+An accepted result binds the exact intent digest to accepted operation IDs,
+transaction digest, projection revision, and frontier.
+
+### 10.4 Durable follower overlay
+
+Editable followers keep accepted state separate from pending local intent.
+Their SQLite database contains:
+
+- Accepted replicated rows
+- Pending signed-intent journal
+- Sparse provisional field or row overlay
+- Intent-result inbox
+
+Generated query SQL composes accepted rows with only the sparse local overlay.
+It does not clone the accepted database.
+
+When an accepted operation arrives, the follower applies it to accepted rows,
+matches its source-intent digest, removes the provisional overlay, advances the
+revision, and emits bounded invalidations. A rejection leaves accepted rows
+untouched and preserves a user-visible correction path.
+
+## 11. Synchronization protocol
+
+SQLite is synchronized logically, never physically.
+
+The cloud protocol contains:
+
+1. Normalized checkpoints for bootstrap and compaction
+2. Canonical operation segments after the checkpoint frontier
+3. Follower intent segments
+4. Signed intent-result segments
+5. Content descriptors, authenticated range indexes, and content bytes
+6. Authority, actor, repair, compaction, backup, and transition evidence
+
+Immutable objects are content addressed. One small authenticated manifest
+names persistent roots. One small compare-and-swap control tuple selects the
+current manifest and writer epoch.
+
+A follower refresh:
+
+1. Fetches and authenticates the current control tuple.
+2. Verifies the transition and manifest predecessor chain.
+3. Chooses checkpoint bootstrap or incremental operation replay.
+4. Downloads required descriptor and operation objects.
+5. Optionally hydrates content according to local policy.
+6. Verifies complete operations.
+7. Applies accepted transactions idempotently to local SQLite.
+8. Publishes pending signed intents.
+9. Downloads signed intent results.
+10. Reconciles the sparse local overlay.
+11. Reruns only invalidated bounded queries.
+
+The Primary additionally reads actor-scoped intent heads, admits or rejects
+complete intent transactions, publishes result segments, and advances the
+authenticated manifest.
+
+Google Drive remains an injected transport. This architecture does not change
+Drive endpoints, headers, OAuth, retries, range behavior, or polling cadence.
+
+## 12. Normalized checkpoints
+
+The checkpoint format is `freed_normalized_checkpoint_v2`.
+
+### 12.1 Registry identity
+
+One append-only registry defines each record family:
+
+- Stable numeric registry ID
+- Stable registry key
+- Typed primary-key schema
+- Primary-key byte codec
+- Typed value schema
+- Checkpoint ordering index
+- Inclusion and exclusion rules
+- Materialized-commitment contribution
+- Import destination
+- Large-content policy
+
+The initial final registry covers:
+
+- Accepted frontiers
+- Quarantined frontiers
+- Feed items
+- RSS feeds
+- People
+- Accounts
+- Preferences
+- Registered child entities and keyed collections
+- Field clocks
+- Relationships
+- Tombstones
+- Actor states
+- Receipt records
+- Content descriptors
+- Registry exclusions
+
+FTS, RTree, SQLite internals, local intent overlays, provider sessions, local
+work queues, caches, and hydration state are excluded.
+
+Record identity is derived from the registry ID and canonical typed primary
+key. It is stable across page composition, export attempts, devices, and
+transports. Page ordinal is transport metadata only.
+
+### 12.2 Logical record ceiling
+
+One canonical logical record is at most 131,072 bytes, exactly 128 KiB.
+
+This ceiling contains parser allocation, hashing, schema validation, native
+boundary amplification, and corruption blast radius. It is not a product
+content limit. Typical records should be much smaller.
+
+The exact count is provisional until physical iPhone and Desktop measurements
+compare 64 KiB, 128 KiB, and 256 KiB. The architecture recommends 128 KiB
+unless measurement finds a concrete problem.
+
+The byte count is exact canonical UTF-8 before compression. Character count,
+source-object size, and compressed size do not determine admission.
+
+### 12.3 Page boundaries
+
+One decoded checkpoint page contains at most:
+
+- 128 logical records
+- 2,097,152 canonical decoded bytes
+
+The producer flushes before either next boundary would be crossed. The record
+limit contains object-count overhead. The byte limit contains large-record
+overhead. Compression occurs only after both checks.
+
+One native response contains at most 1,048,576 source bytes. A checkpoint page
+may therefore use several native responses. The native response limit protects
+IPC and never becomes a row or content limit.
+
+The producer records exact canonical bytes before append. It never estimates
+from JavaScript strings or compressed output.
+
+### 12.4 Manifest
+
+The checkpoint manifest binds:
+
+- Library, epoch, schema, registry, and canonical-codec versions
+- Exact source frontier and materialized-state commitment
+- Total and per-registry record counts
+- Contiguous page indexes
+- First and last record identities
+- Decoded and stored byte lengths
+- Stored-byte digests
+- Verified transport object IDs
+- Referenced content-root commitment
+
+The manifest contains no product rows or media bytes.
+
+### 12.5 Import
+
+Import writes a fresh staging generation. It verifies every manifest field,
+page, record identity, registry entry, primary key, canonical payload,
+relationship, count, frontier, content descriptor, and final materialized
+commitment before selecting that generation.
+
+The importer retains one compressed page, one decoded page, one prior identity,
+and one bounded staging transaction. Partial generations are never queryable.
+
+## 13. Selective content synchronization
+
+Content has a separate plane because checkpoint completion and local byte
+hydration are different facts.
+
+Every follower synchronizes small content descriptors and authoritative
+references. Each device independently decides which bytes to hydrate.
+
+### 13.1 Descriptor
+
+A content descriptor includes:
+
+- Content digest
+- Exact byte length
+- Media type and encoding
+- Rendition or variant identity
+- Authenticated range-index root
+- Range granularity
+- Playback metadata needed before hydration
+- Cloud availability commitment
+
+The normalized entity row references the descriptor. It does not embed large
+content or a complete chunk list.
+
+### 13.2 Local hydration states
+
+The final device-local enum will distinguish at least:
+
+- Metadata only
+- Streamable
+- Partially cached
+- Fully cached
+- Pinned offline
+- Excluded by local policy
+- Unavailable
+- Corrupt
+
+Hydration state never enters normalized checkpoints or canonical Library
+mutations.
+
+### 13.3 Device policy
+
+A device may choose:
+
+- Stream on demand
+- Cache ranges after playback
+- Prefetch on unmetered connections
+- Prefetch saved items
+- Prefetch selected feeds or creators
+- Maintain a device-local byte budget
+- Pin selected media offline
+- Exclude a media class from local queries and presentation
+- Place the Desktop media vault on a selected local volume
+
+A synchronized preference may express a general intent such as making saved
+videos available offline where space permits. Actual byte presence and
+eviction remain device local.
+
+### 13.4 Long-form video
+
+A video hundreds of megabytes or several gigabytes is one logical immutable
+content object. Google Drive may store it as one immutable file supporting
+authenticated range reads.
+
+The client does not need to download the complete video before playback. A
+paged authenticated range map contains byte offsets, lengths, and range
+digests. Optional container and time metadata can improve seeking.
+
+The range map uses a Merkle or authenticated radix structure. Each index node
+obeys the logical-record ceiling. Media ranges do not. Their size is selected
+by physical measurement across Drive overhead, seeking, Desktop disk, OPFS,
+iPhone memory, and resumable recovery.
+
+The initial benchmark compares 1 MiB, 4 MiB, 8 MiB, and 16 MiB media ranges.
+No range size becomes protocol law before that measurement.
+
+Streaming verifies each fetched range against the authenticated range map.
+Complete-file digest verification closes full offline hydration.
+
+### 13.5 Reachability and garbage collection
+
+Cloud retention follows authoritative references, checkpoints, backups,
+quarantine, and compaction receipts. Local retention follows device policy.
+
+- Local eviction never mutates Library authority.
+- Local pinning never changes another device's cache.
+- An existing verified cloud object is not reuploaded by another client.
+- Cloud deletion is never inferred from connected-client cache state.
+- Pinned offline bytes are not automatically evicted without an explicit
+  local policy transition.
+
+A follower can fully authenticate a checkpoint while holding zero media bytes.
+It must know that every required authoritative content object exists remotely,
+but local hydration is optional.
+
+## 14. Backups and restore
+
+A complete backup captures one normalized checkpoint, its reachable content
+root set, authority evidence, and exact frontier. It does not copy the live
+SQLite database.
+
+Device-local provider sessions, OAuth tokens, actor private keys, authority
+private keys, caches, free pages, and provisional local overlays do not enter
+portable backup objects.
+
+Restore stages a fresh SQLite database and content plan, verifies the complete
+logical commitment, and selects the generation only after its exact receipt
+closes. Restoring into a new installation creates a new installation identity
+and actor enrollment. It does not clone actor private authority.
+
+## 15. Protocol version boundaries
+
+These versions remain independent:
+
+- Contract IDL version
+- Physical SQLite schema version
+- Field and mutation registry version
+- Query version
+- Checkpoint registry and format version
+- Operation segment version
+- Intent segment version
+- Intent-result version
+- Manifest version
+- Content-plane version
+- Storage epoch
+- Transport adapter version
+
+The cutover creates one new storage epoch that accepts only the final
+SQLite protocol family. Runtime code does not parse the historical shell or
+checkpoint format as a fallback.
+
+An unsupported newer protocol fails closed. An older client may preserve its
+local work as orphan recovery input, but it cannot write into current
+authority.
+
+## 16. Migration and cutover
+
+The shortest safe path is one direct migration into the final model. It does
+not create a new temporary shadow authority, IndexedDB intermediary, shell
+checkpoint, or dual-write bridge.
+
+### 16.1 Migration executable
+
+One short-lived native migration executable:
+
+1. Pins the exact immutable historical source and frontier.
+2. Streams it through bounded external-memory staging.
+3. Classifies every retained field through the final registry.
+4. Writes the final normalized SQLite schema and content descriptors.
+5. Builds the final journal, clocks, relationships, tombstones, and
+   commitments.
+6. Verifies full-field parity and explicit exclusions.
+7. Produces the normalized checkpoint and accepted transition candidate.
+8. Produces an exact migration receipt.
+
+It never calls a source-sized Automerge load and never turns its source decoder
+into a permanent application service.
+
+### 16.2 Cutover
+
+Cutover:
+
+1. Prepares all corpus-sized work outside the authority barrier.
+2. Drains accepted old-epoch work to one exact source frontier.
+3. Durably journals any new user intent in epoch-neutral form.
+4. Rechecks source, local control, transition candidate, and cloud tuple.
+5. Performs one compound compare-and-swap to the new writer epoch and
+   authenticated genesis manifest.
+6. Selects the verified local SQLite generation.
+7. Replays epoch-neutral intents exactly once into the winner.
+8. Publishes a normalized checkpoint and exact receipt.
+
+There is no period in which both stores acknowledge authoritative writes.
+
+### 16.3 Rollback
+
+The old source remains immutable until the rollback window closes. Rollback is
+valid only to an exact same-frontier receipt. Once accepted new-epoch writes
+advance beyond that frontier, recovery rolls forward.
+
+The historical shell is never rollback evidence.
+
+## 17. Failure semantics
+
+The system fails closed for:
+
+- Missing, foreign, future, or altered SQLite identity
+- Catalog drift
+- Integrity failure
+- Unknown protocol or schema version
+- Stale writer epoch
+- Actor gap, fork, retirement, or invalid capability
+- Partial transaction
+- Changed bytes under an existing identity
+- Missing or corrupt content dependency
+- Oversized logical record
+- Checkpoint identity, count, order, or digest drift
+- Stale query cursor
+- Storage exhaustion
+- OPFS or worker recovery failure
+- Incomplete migration or restore generation
+- Ambiguous response loss
+
+An unreadable database never becomes an empty Library.
+
+Response-loss recovery reads back the exact durable identity. It does not
+create a replacement operation, transaction, intent, checkpoint, or transition
+identity.
+
+## 18. Observability
+
+The implementation records bounded metadata for:
+
+- Database, schema, epoch, build, and process identity
+- Query ID, version, duration, row count, response bytes, and revision
+- Query-plan identity and temporary-sort rejection
+- Mutation type, duration, member count, canonical bytes, and receipt status
+- SQLite busy, WAL, cache, checkpoint, and integrity behavior
+- Native boundary row and byte counts
+- PWA worker starts, restarts, and connection generations
+- OPFS persistence, quota, and storage pressure
+- Checkpoint record, page, and manifest sizes
+- Segment, intent, result, and actor verification failures
+- Pending intent age and overlay cardinality
+- Blob range fetch, verification, cache hit, miss, eviction, and pin state
+- Migration progress, memory, staging bytes, and receipts
+
+Logs and telemetry exclude user content, canonical payloads, provider tokens,
+cookies, actor private keys, authority private keys, and secrets.
+
+## 19. Performance budgets
+
+Initial gates are:
+
+| Operation | Budget |
+| --- | ---: |
+| Warm bounded page query p95 | 50 ms |
+| Cold bounded page query p95 | 150 ms |
+| Navigation counts p95 | 100 ms |
+| Search p95 | 150 ms |
+| Commit and materialize 1,000 captured items | 500 ms |
+| Settled renderer Library DTO state | 48 MiB |
+| Burst renderer Library DTO state | 64 MiB |
+| Native checkpoint response | 1 MiB source bytes |
+| Decoded checkpoint page | 2 MiB and 128 records |
+| Logical checkpoint record | Initial 128 KiB protocol ceiling, frozen after required physical measurements |
+
+Every page query must return its first bounded result without decoding or
+scanning the complete corpus. Larger corpus validation runs at 100,000 items.
+
+PWA admission includes physical iPhone testing of reopen, worker termination,
+quota pressure, large search, range playback, cache eviction, and offline pin
+behavior.
+
+## 20. Test architecture
+
+One conformance suite runs the same fixture against native SQLite and browser
+SQLite.
+
+It proves:
+
+- Exact schema catalog parity
+- Generated contract parity
+- Canonical codec and digest parity
+- Mutation result and receipt parity
+- Query result, ordering, cursor, and revision parity
+- Merge convergence under duplicate, reordered, concurrent, and offline work
+- Complete transaction rejection
+- Actor enrollment, retirement, gap, and fork behavior
+- Normalized checkpoint identity and cross-import parity
+- Selective content hydration without authority drift
+- Verified range streaming and complete offline hydration
+- Exact retry after response loss
+- Native crash atomicity
+- Browser worker termination recovery
+- Migration full-field parity and explicit exclusion closure
+- No whole-corpus renderer, worker, or native response
+- Query-plan use of registered indexes
+
+Fault injection covers every authoritative commit boundary. Performance tests
+record exact fixture, build, runtime, process generation, and storage identity.
+
+## 21. Explicit deletion list
+
+The final change deletes:
+
+- Every `shellJson` and `shell_json` field
+- `DesktopLibraryShell` and shell read or replacement commands
+- Monolithic `DocState` runtime authority
+- Library shell synchronization and checkpoint records
+- Whole FeedItem JSON as ordinary checkpoint transport
+- Whole-corpus renderer and long-lived worker state
+- Whole-corpus subscriptions and mutation refreshes
+- PWA IndexedDB Library databases
+- IndexedDB checkpoint-generation and overlay implementations replaced by
+  SQLite
+- Shadow-store schemas, naming, feature flags, and compatibility leases
+- Ordinal checkpoint identities
+- Automerge runtime load, save, merge, head, and worker protocols
+- Automerge authority vocabulary that no longer describes retained evidence
+- Dual-write and fallback bridges
+- Generic JSON patch and toggle mutation routes
+- SQLite, WAL, SHM, and rollback-journal cloud transport
+- Unregistered localStorage, Cache API, Tauri store, and native JSON
+  authorities
+- Historical imports, rebuilds, repair paths, flags, and exports with no final
+  caller
+- Emergency rollback flags that revive the retired architecture
+- Tests that protect only deleted compatibility behavior
+
+Immutable migration receipts, source evidence, and backup provenance remain.
+Historical runtime code does not.
+
+## 22. Shortest path to total victory
+
+The program uses multiple reviewable commits because authority and data
+integrity require exact evidence. It does not build temporary product
+architectures between them. Every implementation stage lands final-model
+artifacts that the completed system retains.
+
+### Stage 1: Executable contract and generation
+
+Deliverable:
+
+- Final field, mutation, query, locality, checkpoint, content, and deletion
+  registries
+- Contract IDL
+- Rust and TypeScript generation
+- Shared SQL binding
+- Cross-runtime vectors and drift checks
+
+No temporary storage engine or protocol is introduced.
+
+Estimated machine time: 2 to 4 focused conversations, approximately 1 to 2
+hours.
+
+### Stage 2: Complete native-core extraction and final database foundation
+
+Deliverable:
+
+- Tauri reduced to a host adapter
+- Headless entry point using the same native crate
+- Final SQLite schema, opener, catalog verification, and migrations
+- Final content-vault interface
+- Process and writer authority boundaries
+
+Estimated machine time: 3 to 5 focused conversations, approximately 2 to 3
+hours.
+
+### Stage 3: Exhaustive mutations and normalized materialization
+
+Deliverable:
+
+- Every retained product write routed through the generated mutation registry
+- Complete merge algebra, tombstones, relationships, and receipts
+- Large content externalized
+- Generic patches, shell updates, and hidden cascades removed
+
+Estimated machine time: 5 to 8 focused conversations, approximately 3 to 5
+hours.
+
+### Stage 4: Bounded queries and complete view cutover
+
+Deliverable:
+
+- Every Freed Desktop and shared product view uses named SQLite queries
+- Paged search, feed, map, Friends, reader, counts, facets, and settings
+- Compact invalidation feed
+- Renderer corpus removed
+
+Estimated machine time: 5 to 8 focused conversations, approximately 3 to 5
+hours.
+
+### Stage 5: Normalized checkpoint, operation, intent, result, and content wire
+
+Deliverable:
+
+- Stable normalized checkpoint registry and primary-key identities
+- Typed native export and browser import
+- Operation segments
+- Signed follower intents and results
+- Selective content descriptors and authenticated range indexes
+- Google Drive adapter integration without behavior changes
+
+Estimated machine time: 4 to 7 focused conversations, approximately 3 to 5
+hours.
+
+### Stage 6: PWA SQLite and editable follower behavior
+
+Deliverable:
+
+- Official SQLite WebAssembly worker
+- OPFS durability and recovery
+- Generated query and mutation-intent client
+- Sparse durable overlay
+- Selective media streaming, caching, and offline pinning
+- IndexedDB Library state removed
+
+Estimated machine time: 4 to 7 focused conversations, approximately 3 to 5
+hours.
+
+### Stage 7: Direct migration, one epoch cutover, and historical deletion
+
+Deliverable:
+
+- External-memory migration directly into the final schema
+- Full-field and content closure
+- One coordinated storage-epoch cutover
+- Normalized Primary checkpoint and follower import receipt
+- Shell, Automerge runtime, shadow store, IndexedDB rows, fallbacks, and unused
+  compatibility paths deleted
+
+Estimated machine time: 6 to 10 focused conversations, approximately 4 to 7
+hours.
+
+### Stage 8: Acceptance and release handoff
+
+Deliverable:
+
+- Native and PWA conformance
+- Crash and response-loss fault injection
+- 25,000-item and 100,000-item performance evidence
+- Physical iPhone storage and media evidence
+- Installed Desktop proof
+- PHASE documents and `roadmap-status.json` reconciled
+- Exact release and activation handoff, without performing those actions unless
+  separately authorized
+
+Estimated machine time: 4 to 7 focused conversations, approximately 3 to 5
+hours of execution. Physical-device access, soak windows, CI queue time, owner
+review, release, and activation waits are external elapsed time and are not
+included.
+
+### Total initial estimate
+
+From the executable contract through an exact release-ready candidate:
+
+- 33 to 56 focused implementation conversations
+- Approximately 22 to 37 hours of machine execution
+- External review, physical-device access, soak duration, CI queues, release,
+  installation, and activation are excluded
+
+This estimate is intentionally front-loaded toward total removal rather than
+temporary adapters. It will be revised from measured stage receipts, not from
+calendar intuition.
+
+## 23. Operational authority boundaries
+
+The architecture does not itself authorize:
+
+- Provider traffic or provider-observable behavior changes
+- Google Drive endpoint, header, retry, OAuth, or cadence changes
+- Publication of a pull request
+- Merge
+- Release
+- Installation
+- Deployment
+- Live-data migration
+- Writer-epoch cutover
+- Destructive cleanup
+
+Each authority transition retains its operational review and receipt
+requirements. Product implementation updates affected PHASE documents and
+`docs/roadmap-status.json`. It does not edit the website roadmap lane.
+
+## 24. Architectural decisions
+
+The Library Core follows these decisions:
+
+1. Stock SQLite is the only Library row engine in Desktop, headless, and PWA.
+2. iOS 17 is the supported PWA durability floor.
+3. Followers submit signed intents. Only the active Primary admits canonical
+   operations.
+4. Checkpoints carry normalized records and content descriptors, never content
+   bytes that a follower may choose not to hydrate.
+5. The logical-record ceiling begins at 128 KiB and remains subject to physical
+   measurement before protocol freeze.
+6. Media range size remains a measured content-plane parameter rather than the
+   logical-record size.
+7. Migration moves directly into the final schema with no dual write or
+   compatibility authority.
+8. Same-frontier rollback is the only rollback. Later recovery rolls forward.
+9. Historical runtime paths and emergency fallbacks are deleted after verified
+   cutover.
+10. The program prioritizes the shortest path to complete replacement, even
+    when that makes individual implementation stages larger.

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -1,7 +1,5 @@
 # Library Core Contract
 
-Status: **Approved architecture. The SQLite cutover is active; installed sync acceptance remains gated.**
-
 This contract defines Freed's durable library, mutation, query, migration, and
 replication behavior. It replaces the assumption that one in-memory Automerge
 document can remain the database, search index, sync payload, backup format,
@@ -10,6 +8,47 @@ and UI state for an arbitrarily large library.
 The objective is a bounded-memory library that preserves every supported
 field, converges across devices, survives interruption at every boundary, and
 can prove which storage epoch owns a write.
+
+## Core invariants
+
+The complete architecture is described in
+[LIBRARY-CORE-ARCHITECTURE.md](LIBRARY-CORE-ARCHITECTURE.md). This contract is
+the detailed companion to that overview. These rules govern the complete
+contract:
+
+1. Stock SQLite is the only Library row engine. Freed Desktop and the headless
+   Primary use the extracted native Rust core. The PWA uses official SQLite
+   WebAssembly with OPFS.
+2. Every product view uses a bounded named query. React owns only visible
+   windows and ephemeral interface state.
+3. `shellJson`, `DocState`, whole FeedItem checkpoint rows, and equivalent
+   Library shells are not authority, transport, fallback, rollback proof, or
+   compatibility state.
+4. Automerge and the derived shadow-store architecture are source migration
+   inputs only. They are not part of the runtime.
+5. There is no dual write, compatibility bridge, rollback flag that revives a
+   retired engine, or IndexedDB Library fallback.
+6. Synchronization exchanges logical protocol objects. It never exchanges a
+   SQLite database, WAL, SHM, or rollback-journal file.
+7. Checkpoint records use a stable registry identity plus typed primary key.
+   Ordinals are page framing only and never logical identity.
+8. Large legal fields use content-addressed descriptors, chunks, and
+   authenticated range indexes. Every canonical logical checkpoint record is
+   bounded independently of content size.
+9. Editable followers commit local intent overlays, then submit signed intents
+   to the active Primary. The Primary alone admits canonical operations.
+10. A follower can stream, partially cache, fully cache, pin offline, or exclude
+    content independently of metadata replication.
+11. Rust, TypeScript, SQLite schema, named queries, mutations, checkpoint
+    records, and canonical vectors derive from one executable contract source.
+12. Migration writes directly into the final model and activates one storage
+    epoch after proof. Same-frontier rollback is the only rollback. Later
+    recovery rolls forward.
+
+Every section is governed by these invariants. Automerge and IndexedDB may be
+named only as bounded source-migration inputs. They never name a runtime
+authority, Library row engine, follower store, transport, fallback, or rollback
+path.
 
 ## Non-negotiable outcomes
 
@@ -135,13 +174,16 @@ protocol, but it cannot maintain an independent active pointer. Drive file IDs
 are locators. Names and app properties describe objects, but never establish
 authority.
 
-PWA installations are intent producers in v1, not canonical writers. Their
-required MVP store is a bounded row-oriented IndexedDB adapter. SQLite WASM and
-OPFS are not on the MVP critical path. They may be added later behind the same
-adapter and conformance suite. The designated Desktop verifies and accepts an
-intent into canonical SQLite before publishing an acceptance receipt. Provider
-acceptance is separate from provider completion. A PWA cannot display provider
-success until the Desktop records the actual provider result.
+PWA installations are intent producers, not canonical writers. Their Library
+store is official SQLite WebAssembly persisted through OPFS and owned by one
+worker. The PWA uses the same schema catalog, named SQL, result DTOs, mutation
+intent codecs, and conformance vectors as the native core. IndexedDB is not a
+Library row-store fallback. A narrow IndexedDB keystore may hold
+nonextractable WebCrypto keys only when WebKit offers no suitable alternative.
+The designated Primary verifies and accepts an intent into canonical SQLite
+before publishing an acceptance receipt. Provider acceptance is separate from
+provider completion. A PWA cannot display provider success until the Primary
+records the actual provider result.
 
 The package-internal immutable transport contract closes one flat namespace for
 epoch and enrollment JSON, checkpoint manifests and pages, canonical operation
@@ -263,37 +305,35 @@ A stale starting control tuple uploads nothing. A later failure can leave
 immutable unreachable objects, but it cannot publish a partial checkpoint or
 infer authority from their presence.
 
-The registered `library_core_logical_checkpoint_v1` dataset is the complete
-portable row-store stream. Record zero is one closed
-`logical_checkpoint_header` carrying the library, epoch, schema and codec
-versions, authority anchor, promoted receipt digests, materializer frontier
-and state digests, and exact count of every logical collection. The remaining
-records are closed `logical_checkpoint_entry` values for accepted and
-quarantined frontiers, materialized rows, field clocks, relationships,
-tombstones, actor states, receipt records, blob roots, and explicit registry
-exclusions. Entries carry a contiguous collection-local ordinal. Their wire
-identity is the fixed collection order plus that ordinal, while the verifier
-also enforces each collection's semantic sort order from the logical
-checkpoint contract.
+The final normalized checkpoint dataset is the complete portable row-store
+stream. It contains closed typed records for authority anchors, accepted and
+quarantined frontiers, normalized materialized tables, field clocks,
+relationships, tombstones, actor states, receipts, operation tips, content
+descriptors, and explicit registry exclusions. It contains no Library shell
+and no whole FeedItem JSON record. Every record identity is the tuple of its
+stable registry key and canonical typed primary key. Page number, record
+position, and collection ordinal are framing metadata only. They never become
+logical identity.
+
+Each canonical logical record is at most 131,072 bytes. A legal field that can
+exceed that ceiling is represented through a content descriptor and bounded
+content-addressed chunks or an authenticated range index. Large content bytes
+do not enter the metadata checkpoint. The 131,072-byte ceiling remains a
+proposed protocol parameter until measurement compares 65,536, 131,072, and
+262,144 byte candidates. The final protocol freezes one value before
+activation.
 
 The portable producer validates that stream while retaining at most 128
-records, encodes each page through the existing canonical frame and gzip
-object, and sends the prepared pages through the exact manifest and control
-publication path. The portable importer verifies the authenticated manifest
-and every page, stages only bounded pages through an injected row-store
-writer, and refuses selection until the writer returns a staging receipt
-matching the exact library, epoch, frontier digest, materialized-state digest,
-and complete record count. A malformed collection, missing record, reordered
-row, header or manifest mismatch, or false staging receipt aborts the staged
-import. The writer remains responsible for recomputing semantic commitments
-from its staged SQLite or IndexedDB rows before issuing that receipt. This is
-the shared interchange path for Desktop SQLite and PWA IndexedDB. It has no
-product caller and does not activate replacement replication.
-
-For the MVP, PWA IndexedDB is the primary Library Core row store. SQLite WASM
-and OPFS are not release dependencies. A future adapter must pass the same
-checkpoint, operation, search, intent, and result conformance suite and rebuild
-from immutable objects into a verified fresh generation.
+records and 2,097,152 canonical decoded bytes per page. One native export
+response contains at most 1,048,576 source bytes. It encodes each page through
+the registered canonical frame and sends prepared pages through the exact
+manifest and control publication path. The portable importer verifies the
+authenticated manifest and every page, stages only bounded pages into SQLite,
+and refuses activation until SQLite recomputes the exact library, epoch,
+frontier, normalized-state, registry-count, and content-root commitments. A
+malformed registry, missing record, duplicate primary key, reordered identity,
+manifest mismatch, oversized record, or false staging receipt aborts import.
+The same stream is imported by native SQLite and PWA SQLite WebAssembly.
 
 Active Google Drive synchronization remains confined to `appDataFolder`.
 SQLite backup files remain local to the device that created them. No cloud
@@ -3487,13 +3527,11 @@ side-effect execution.
 
 ## PWA durable store
 
-The PWA implements the same logical operation and materialization contract
-behind one browser storage adapter. IndexedDB is the required MVP engine. It
-stores bounded record pages, tombstones, search postings, cursors, intent
-queues, and result receipts without holding the corpus in JavaScript memory.
-
-SQLite WASM with OPFS may be added later as a measured adapter only after the
-supported browser matrix proves:
+The PWA implements the same logical operation, schema, query, and
+materialization contract in official SQLite WebAssembly over OPFS. One worker
+owns the connection. Tabs, service workers, and obsolete application versions
+are fenced by one connection generation and browser-level Library writer lock.
+The browser implementation must prove:
 
 - durable reopen and crash recovery;
 - worker-only access where required;
@@ -3502,23 +3540,24 @@ supported browser matrix proves:
 - correct behavior without cross-origin isolation where Freed must run;
 - a visible answer from `navigator.storage.persisted()`.
 
-The future adapter must pass the same conformance suite and rebuild from
-immutable cloud objects into a verified generation. It never mutates or
-translates an active IndexedDB store in place.
+The PWA passes the same schema, mutation, query, checkpoint, operation, search,
+intent, result, and crash conformance suite as the native core. It rebuilds
+from immutable protocol objects into a verified staging database, then
+activates that database atomically. It never mutates or translates an active
+IndexedDB Library store in place.
 
 Freed requests persistent storage when the user enables a local library and
 reports whether the browser granted it. A denial is a durability warning, not a
 silent success.
 
-One dedicated worker owns the PWA adapter connection. Tabs, service workers,
-and obsolete application versions are fenced from concurrent local intent
-writes. Existing but unreadable storage enters recovery, never an empty-library
-bootstrap.
-
-IndexedDB commits each intent envelope, local rows, tombstones, ingest cursor,
-receipt, and intent outbox atomically before acknowledgment. Its crash proof
-injects failure at every adapter-specific commit boundary and reopens the
-store. A future SQLite WASM adapter cannot borrow IndexedDB or Desktop evidence.
+SQLite commits each intent envelope, sparse local overlay, tombstone, ingest
+cursor, receipt, and intent outbox atomically before acknowledgment. Crash
+proof injects failure at every browser-specific commit boundary, terminates
+the worker, reopens the database, and verifies exact retry. IndexedDB may
+remain only as a narrow keystore for nonextractable WebCrypto key objects when
+WebKit supplies no suitable alternative. It may not contain Library rows,
+checkpoint records, cursors, operations, content metadata, or compatibility
+state.
 
 ## Replication protocol
 

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -112,9 +112,11 @@ Freed now has a real global command palette, opened with `Cmd/Ctrl+K`, mounted f
 
 Freed Desktop now supplies SearchJump tags, archive facets, scope counts, and
 selected-item context from bounded Library Core readers. On the healthy default
-native path, focusing the palette does not mount the complete item corpus. A
-native reader failure or device-local rollback key restores the Desktop
-compatibility path. PWA keeps its existing resident-row path.
+native path, focusing the palette does not mount the complete item corpus. The
+final runtime has no compatibility rollback reader. A failure returns a typed
+unavailable or stale-source result and leaves the last verified visible window
+intact. The PWA uses the same bounded named query contract through SQLite
+WebAssembly over OPFS.
 
 The command palette now covers:
 
@@ -437,7 +439,7 @@ Reward security researchers for responsible disclosure.
 | 10.2  | Statistics dashboard              | Medium     |
 | 10.3  | Export to JSON                    | Low        |
 | 10.4  | Export to CSV                     | Low        |
-| 10.5  | Keyboard shortcuts                | Medium     | ✓ Complete (PWA reader keys, command palette, navigation history keys, and Freed Desktop Save Content shortcut) |
+| 10.5  | Keyboard shortcuts                | Medium     | ✓ Complete (PWA content-view keys, command palette, navigation history keys, and Freed Desktop Save Content shortcut) |
 | 10.6  | Screen reader support             | Medium     |
 | 10.7  | Reduced motion support            | Low        | ✓ Complete (Appearance animation intensity controls plus global app motion gating)                              |
 | 10.8  | Color contrast audit              | Low        |
@@ -530,7 +532,7 @@ Reward security researchers for responsible disclosure.
 - [x] Shared bug report actions now reflect the selected bundle privacy tier, bulk-toggle private diagnostics, and disable public GitHub issue drafts while private artifacts are selected
 - [x] Shared bug reports can submit redacted text and selected stack traces to the private GitHub vulnerability inbox after an explicit click, while keeping the diagnostic zip on the user's device and avoiding automatic retries
 - [x] Settings keeps Support out of the primary section list and opens the existing report composer from a dedicated Support modal launched at the top of Danger Zone
-- [x] Factory reset clears device preferences, selected provider sessions and sync credentials, recovery copies, diagnostics, relay-held document bytes, and the local document in a failure-aware order. It preserves local request history, retry and receipt ledgers, encrypted AI keys, local AI files, media archives, installation identity, and legal acceptance. It rotates the relay pairing token, rejects pre-reset mobile sessions, requires existing PWA readers to scan the current pairing QR code again, and leaves mobile sync paused if document deletion is uncertain.
+- [x] Factory reset clears device preferences, selected provider sessions and sync credentials, recovery copies, diagnostics, relay-held document bytes, and the local document in a failure-aware order. It preserves local request history, retry and receipt ledgers, encrypted AI keys, local AI files, media archives, installation identity, and legal acceptance. It rotates the relay pairing token, rejects pre-reset mobile sessions, requires existing PWA clients to scan the current pairing QR code again, and leaves mobile sync paused if document deletion is uncertain.
 
 ---
 

--- a/docs/PHASE-11-OPENCLAW.md
+++ b/docs/PHASE-11-OPENCLAW.md
@@ -1,6 +1,13 @@
 # Phase 11: Headless Library Authority and Agent Integrations
 
 > **Status:** 🚧 In Progress (the shared Primary coordinator, reusable native SQLite authority and checkpoint store, local process lease, native and PWA actor capability enforcement, fail-closed service supervisor, and descriptor-bound native sidecar startup have landed; installed headless checkpoint ingress, production v2 issuance and retirement, and capture workers remain open)
+
+> **Architecture:** The headless Primary and Freed Desktop consume the
+> same extracted native Rust Library Core and the same stock SQLite contract.
+> PWA and Desktop followers query local SQLite replicas and submit signed
+> intents. No role opens another device's database, transfers SQLite files, or
+> reconstructs a Library shell.
+
 > **Dependencies:** Phase 2 (Capture layers), Phase 4 (Sync)
 
 ---
@@ -24,7 +31,7 @@ The complete product has four roles:
 2. Editable followers apply local edits immediately, publish signed intents,
    and import canonical results from the Primary.
 3. Reader clients import verified immutable checkpoints into bounded local
-   storage. The production PWA uses IndexedDB.
+   SQLite. The production PWA uses official SQLite WebAssembly over OPFS.
 4. Capability-bounded workers submit only the operation types and source scope
    granted by the Primary.
 
@@ -59,7 +66,9 @@ The complete product has four roles:
 The current product already provides the protocol foundation:
 
 - Freed Desktop stores the active Library in bounded SQLite.
-- The PWA imports authenticated immutable checkpoints into IndexedDB.
+- The current PWA transition candidate imports authenticated immutable
+  checkpoints into IndexedDB. The final architecture replaces that store with
+  SQLite WebAssembly over OPFS and deletes the IndexedDB Library paths.
 - Editable Freed Desktop followers exchange signed intents and canonical
   results without becoming the writer.
 - The Primary publishes immutable checkpoints and a durable exact revision
@@ -157,7 +166,7 @@ Headless Library service
 Google Drive
         |
         + Freed Desktop editable followers
-        + authenticated PWA IndexedDB readers
+        + authenticated PWA SQLite readers
 ```
 
 ### Native Library package
@@ -366,7 +375,8 @@ provider-ready.
    compare and swap.
 6. Confirm that the former Primary refreshes control, loses writer admission,
    and continues as an editable follower.
-7. Confirm that the authenticated PWA imports the same manifest into IndexedDB.
+7. Confirm that the authenticated PWA imports the same manifest into SQLite
+   WebAssembly over OPFS.
 
 The former Primary is never restored by copying its database into the service.
 The service is never seeded from an older follower database.
@@ -422,7 +432,7 @@ review before implementation.
 | 11.5 | Open | Add Drive PKCE setup and platform-safe secret stores |
 | 11.6 | In Progress | Share exact staged checkpoint import, local status, closed backup, and structured receipt primitives; construct them behind the descriptor-bound native sidecar, then add installed headless checkpoint ingress |
 | 11.7 | Open | Add exact writer promotion and 60-second Primary actor processing |
-| 11.8 | Complete | Enforce actor capability certificates and the fixed legacy editor policy in native SQLite and PWA IndexedDB, with production issuance dormant |
+| 11.8 | Complete | Prove actor capability certificates and the frozen transition policy in native SQLite. Phase 6 carries the same proof into PWA SQLite before activation. |
 | 11.9 | Open | Add signed retirement application and checkpoint propagation |
 | 11.10 | Open | Add a private local actor socket with bounded request and replay controls |
 | 11.11 | Open | Add bounded agent search, read, and signed edit APIs |

--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -1,7 +1,32 @@
 # Phase 12: Additional Platforms
 
 > **Status:** 🚧 In Progress: LinkedIn and YouTube are integrated, and authenticated Substack and Medium capture is available in beta with local sessions, visible roster and activity extraction, provider health controls, and connection-only identity ingestion
+
+> **Library and media target:** Every captured record enters the exhaustive
+> Library Core mutation registry and normalized SQLite schema. Large media does
+> not enter checkpoint rows. Synced metadata carries typed content descriptors
+> and authenticated range indexes. Each device may stream, partially cache,
+> fully cache, pin offline, or exclude a rendition. Provider acquisition and
+> Library replication remain separate authority and traffic decisions.
+
 > **Dependencies:** Phase 5 (Desktop App), Phase 7 (Facebook/Instagram patterns)
+
+## Selective long-form media work
+
+- [ ] Represent each rendition as a content-addressed logical blob with typed
+      codec, duration, byte length, digest, and range-index descriptors.
+- [ ] Verify independently retrievable ranges through a paged authenticated
+      range map so multi-gigabyte media never becomes one logical wire record.
+- [ ] Let Freed Desktop pre-download or pin large video without forcing PWA or
+      follower hydration.
+- [ ] Let a client stream selected ranges through the approved user-owned
+      storage transport, keep a partial cache, complete the cache, or exclude
+      the rendition entirely.
+- [ ] Keep hydration and eviction state device-local. Synchronize only content
+      identity, availability descriptors, and canonical metadata.
+- [ ] Require separate provider-risk approval before any new resolver request,
+      page load, click, timing pattern, header, cookie use, or background media
+      acquisition is implemented.
 
 ---
 

--- a/docs/PHASE-3-SAVE-FOR-LATER.md
+++ b/docs/PHASE-3-SAVE-FOR-LATER.md
@@ -9,9 +9,10 @@
 > has full article extraction, local HTML caching, Markdown import/export,
 > background fetch healing, user-visible AI controls, and hierarchical tag
 > navigation. PWA saves sync-healed stubs for Freed Desktop to hydrate. Saved
-> content is pinned in the device-local reader cache by default. The PWA now
-> pages the complete Saved collection from IndexedDB in all four sort modes and
-> computes its exact overview outside the 512-card renderer window.
+> content is pinned in the device-local reader cache by default. The current
+> PWA transition implementation pages the complete Saved collection from
+> IndexedDB. The Library Core stores it in SQLite
+> WebAssembly over OPFS while preserving the bounded query contract.
 
 ---
 
@@ -23,8 +24,9 @@ architecture is now:
 1. Save a URL from desktop or PWA by writing a lightweight stub item.
 2. Pull metadata plus article content in the background with Readability-safe
    browser parsing where the platform can fetch the page.
-3. Keep full HTML in a device-local cache, never in Automerge.
-4. Sync compact preserved text through Automerge for cross-device fallback.
+3. Keep full HTML in the device-local content vault, never in checkpoint rows.
+4. Sync typed content descriptors and normalized preserved-text records through
+   the Library Core protocol.
 5. Render reader content through a layered waterfall:
    1. Local cached HTML
    2. Synced preserved text
@@ -91,7 +93,7 @@ architecture is now:
 | 3.9 | Broader mobile validation across hostile sites | ☐ Ongoing | Fallback stub mode remains intentional for blocked or oversized pages |
 | 3.10 | Saved content pinned in local reader cache | ✓ Complete | Saved URLs, saved posts, and saved stories enter the high-priority local cache path |
 | 3.11 | Bound Saved overview analytics on Freed Desktop | ✓ Complete | The overview now reads exact source, content, and time-bucket aggregates from the authenticated SQLite generation without retaining the Library corpus; stale or unavailable derived state falls back to the existing Automerge-compatible reducer |
-| 3.12 | Complete bounded Saved reads on the PWA | ✓ Complete | IndexedDB query generations page every visible Saved item in date saved, date published, recommended, and shortest read order, while exact analytics scan the selected checkpoint in bounded pages |
+| 3.12 | Complete bounded Saved reads on the PWA transition store | ✓ Complete | IndexedDB query generations proved the bounded contract. Phase 6 replaces the engine with SQLite WebAssembly over OPFS while preserving the named queries and ordering. |
 
 ---
 

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -1,290 +1,130 @@
 # Phase 4: Sync Layer
 
 > **Status:** 🚧 In Progress
+
+> **Architecture:** This phase is governed by
+> [LIBRARY-CORE-ARCHITECTURE.md](LIBRARY-CORE-ARCHITECTURE.md) and
+> [LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md).
+> Google Drive synchronizes immutable typed protocol objects, never a SQLite
+> file or Library shell. Checkpoints contain normalized records identified by
+> stable registry plus typed primary key. Editable followers publish signed
+> mutation intents and import canonical results from the active Primary. Large
+> content uses optional content-addressed blobs and authenticated range maps.
+> Automerge, ordinal checkpoint identity, IndexedDB Library rows, shell
+> records, shadow stores, and compatibility paths are not part of this
+> architecture.
+
 > **Dependencies:** Phase 1-2 (Capture layers ✓)
 >
-> Local relay, Google Drive cloud sync, desktop local snapshot rotation, "Sync Now" button, "Last synced" indicator, proxied Google token exchange for Freed Desktop with a built-in production proxy default, durable Google OAuth refresh, recoverable Google Contacts token-refresh failures, a production callback relay for dev and preview PWA Google OAuth, appDataFolder Drive polling, cloud sync health diagnostics, visible Drive transfer diagnostics in Settings, manual Drive sync from Desktop and PWA Settings, cloud sync activity timelines, global background activity visibility for Desktop cloud work, initial Drive download auth-refresh recovery, merged-upload local convergence, destructive Automerge merge blocking, pinned explicit local wins and cloud wins recovery actions, PWA local-change cloud uploads, PWA document-init-gated cloud startup, runtime-gated cloud upload waits, mobile-safe Drive upload bodies, the multi-Desktop request warning, the no-cloud-sync launch banner, revision-fenced chunked IndexedDB v3 persistence, stale worker retirement, a production-located compatibility bridge that writes exact Automerge revisions into crash-safe immutable SQLite shadow generations, a receipt-bound external decode path through graph staging, FeedItem reconstruction, lossless row projection, bounded shadow-generation population, and source-fenced product reads from SQLite are implemented. Automerge remains the sole authority. Before the first Automerge decode, Freed Desktop can resume an admitted canonical legacy revision through exact 1 MiB IndexedDB chunks into a native spool, authenticate the finalized bytes with a device-held Ed25519 source-admission key, reconstruct them through disk-backed SQLite, and select one verified immutable derived generation. macOS credential access suppresses all user interaction and fails closed instead of opening a Keychain prompt. The default renderer now evicts the full item corpus and uses bounded SQLite readers or compact native aggregates for all migrated surfaces. Remaining specialized views acquire one shared temporary compatibility projection streamed from the authenticated selected SQLite generation instead of cloned from the Automerge worker. The all-content Freed Desktop feed, when it is not searching, can materialize and select an exact query-specific generation and page compact cards from SQLite. Its materializer preserves exact source enumeration and sends only 128-row pages to SQLite. The non-Saved Friends-only feed, when no search is active, uses the versioned `feed_browse_page_v2` request and evaluates the Person-first Friends predicate before publishing its filtered generation. Version 1 and its all-content callers remain unchanged. The reader pins at most two authenticated immutable generations for at most 60 seconds, caps each SQLite cache at 2 MiB, releases exhausted, cancelled, failed, or replaced sessions, and returns source-bound canonical cursors through the closed protocol. The Saved feed uses a dedicated source-fenced SQLite reader for all four user-facing sort modes, returns 128-row pages, and retains at most two pages while traversing the complete result. Its versioned order pins one recommendation clock and binary global-ID ties without a corpus-sized source-order index; the Freed Desktop compatibility fallback uses the same contract while the PWA remains unchanged. Source changes fail closed to Automerge. Device-local rollback switches restore the compatibility paths. Elected migration authority, remaining compatibility-surface conversion, bounded conversion of the temporary compatibility readers, and replacement-replication activation remain blocked. These are active Gate D SQL read transitions, not the final authority cutover. Dropbox remains behind a coming-soon gate while its provider work is finished. iCloud is the remaining core document-sync item. Large offline media uses a separate future transport plan.
-
-> **Current Library Core cutover:** Freed Desktop imports the retained Automerge library once into native SQLite schema v12, then initializes, queries, mutates, searches, exports, diagnoses, and creates 24 retained daily backups without starting the Automerge worker or retaining the item corpus in React. Schema v5 gives both visible-only and all-item timeline paging an order-compatible partial index, schema v6 adds bounded per-source indexes, schema v7 reserves isolated editable-follower authority, enrollment, signed-intent, and result state without granting writer admission, schema v8 binds follower overlay replay to the exact actor tip contained by the imported checkpoint, schema v9 stages checkpoint imports outside the active materialization before one atomic activation transaction, schema v10 binds each staged checkpoint and follower anchor to the exact immutable manifest reference, schema v11 records the one signed native protocol correction for a historical legacy authority certificate, and schema v12 binds every admitted actor to an explicit operation capability. Already signed native schema v11 authority certificates remain valid after migration without changing their canonical bytes. A fresh SQLite Library now signs native genesis with `library_core_v1`, `op_segments_v1`, and `freed_logical_checkpoint_v1` fields plus one exact captured source manifest. It never invents an Automerge document identity or head. An existing signed legacy certificate remains immutable historical evidence, while one idempotent forward correction references its digest and preserves the Library ID, authority key lineage, epoch records, actors, Drive namespace, intents, results, and checkpoints. Startup reads the accepted journal authority and persisted cloud identity before deriving any fresh identity. Missing authority admission, mismatched source lineage, multiple active local authorities, or a competing correction fails closed. The old LAN relay and Automerge cloud loops are disabled. The retained Automerge bytes are a pre-import rollback source only. The replacement Google Drive path is enabled by default and streams one exact SQLite revision into bounded logical checkpoint pages, verifies immutable uploads, advances one provisioned control file through its exact ETag, imports a newer remote checkpoint back into SQLite, and transfers the non-expiring writer epoch through one confirmed compare-and-swap backed by a native signed epoch certificate. Its Primary conductor now lives in `@freed/sync` behind injected authority, durable revision state, credential, clock, scheduler, fetch, publication, and diagnostics ports. Freed Desktop consumes that coordinator with the same immediate publication, 15-second local revision watch, 60-second inbound actor refresh, ownership stop, and public command DTOs. No headless host, credential export, provider capture, or new Drive request is enabled by this extraction. Every completed publication now preserves the local SQLite revision, item count, total immutable checkpoint bytes, exact control revision, full authenticated control pointer, manifest digest, and Drive object ID as one durable local receipt. A verified control read after a lost commit response is accepted as success instead of being misreported as a connection failure. The last verified cloud control tuple is durable in SQLite, and native product writes, canonical journal commits, actor enrollment, and provider outbox execution reject a retired Desktop before mutation. Freed Desktop retains 24 closed, integrity-checked SQLite backups on the local device only. Google Drive receives logical checkpoint objects and must never receive SQLite, WAL, SHM, or rollback-journal files. Complete off-device backup remains open until it is rebuilt from logical checkpoint objects and content-addressed media blobs. The PWA discovers the sole published control, authenticates and imports its immutable checkpoint into IndexedDB, and exposes the selected IndexedDB generation's exact manifest digest, object key, Drive object ID, generation, selection sequence, Library ID, epoch, record count, FeedItem count, total checkpoint bytes, and imported revision as a durable local receipt. It hydrates a bounded initial product window without starting its Automerge worker, pages the complete ordinary feed directly from the selected IndexedDB generation, scans the complete selected generation in bounded pages for full-library search and shared aggregate surfaces, retains a nonextractable per-Library actor key, publishes a proof-only enrollment request, installs the Desktop-countersigned enrollment, and enqueues signed read, saved, archived, liked, FeedItem removal, and saved-link capture intents without writing Automerge. Saved links materialize immediately in IndexedDB and local search, then the designated Desktop verifies the complete FeedItem envelope and atomically commits its SQLite row, acceptance receipt, and replication outbox entry without foreground article fetching. FeedItem removal evicts the selected IndexedDB row and local search document immediately, then the designated Desktop verifies the signed operation and commits its SQLite tombstone, acceptance receipt, and replication outbox entry atomically. Normal PWA startup no longer creates or precaches the legacy worker or its WASM runtime, and the shared cloud entrypoint loads the CRDT merge code only if an explicit legacy upload calls it. Freed Desktop accepts each verified intent into canonical SQLite and commits its actor-and-epoch-scoped Accepted receipt in the same transaction, then publishes immutable epoch-scoped result segments through an exact result-head compare-and-swap. The PWA imports those results atomically into epoch-scoped IndexedDB rows and preserves them across restart. The follower Desktop now keeps its anchor and actor outside canonical writer state, signs local operations through its platform key, queues exact transactions durably, materializes user-state, bulk maintenance, feed, preference, Person, Account, capture, and removal edits without writer admission, emits only bounded transaction-complete publication candidates, and advances its local publication and result cursors only through exact replay-safe receipts. Continuous immutable generation refresh, cloud result reconciliation, user controls, Drive transport activation, and live acceptance evidence remain in progress.
+> **Current implementation checkpoint:**
 >
-> **SQLite-only runtime candidate:** The active cutover branch removes the legacy Desktop and PWA workers, the Automerge package and WASM dependency, mutable CRDT cloud merge, WebSocket relay, legacy persistence, legacy snapshot restore, and the native external Automerge decoder and shadow projection stack. Freed Desktop serves feed, Saved, search, item detail, Friends, map, analytics, export, mutation, backup, and cloud publication directly from native SQLite. The PWA serves its Library from bounded IndexedDB pages and immutable Library Core objects. Fresh production bundles contain no Automerge package or WASM asset. Historical contract vocabulary remains available only through source-level verification, migrations, and the required legacy-presence loss fence. The public Library Core entrypoint no longer exposes retired census or registry modules, the PWA service worker no longer registers the retired `/sync` cache route, and release artifact inspection rejects those runtime payloads if they return. Stable keyset cursors and optional route-level bundle splitting are tracked separately in issues #1452 and #1453. This candidate still requires exact-head validation, a dev release, installation, and live runtime verification before the cutover is declared complete.
-> **PWA bounded read parity:** The selected portable checkpoint now feeds source-fenced IndexedDB query generations for the complete ordinary, Saved, and Friends feeds. Archived, provider, feed, tag, signal, author, hidden, post, and story filters no longer fall back to the 512-card renderer window. Facets, Saved analytics, Friends graph and timelines, Map, and Story Wall scan the same selected generation in bounded pages. The browser read model neither restores a CRDT bridge nor writes Drive.
-> **PWA local intent overlay:** Checkpoint activation, cached generation reselection, and restart retain unresolved local transactions until the immutable checkpoint generation's actor tip proves their exact operation and chain containment. Accepted and provider result statuses do not remove local edits. Startup and checkpoint selection use the same atomic reconciliation path, preserve response-loss retry behavior, reject Library or epoch crossings, and cap retained overlay state at 512 transactions, 4,096 operations, and 16,777,216 canonical bytes. IndexedDB v9 migration preserves every historical intent row and the current selected materialization. It examines at most 128 historical transactions per resumable pass and uses an immutable actor tip to skip contained sequence ranges without a second full scan. Each scheduled sync advances one pass even when Drive still points to the already selected complete generation. Intent publication remains fenced until recovery reaches ready. If pending history exceeds the caps, startup keeps the selected Library readable, exposes capped lower-bound recovery counts, blocks local writes and unsafe activation, and lets cloud refresh continue until a later candidate checkpoint canonically contains enough complete transactions. Overlay replay merges read timestamps with the canonical imported row and the local read receipt using the minimum-present algebra. Archive replay deletes a feed projection when the updated row is no longer visible. RSS removal uses a generation and feed keyed materialized-row index instead of scanning the complete generation during startup or checkpoint selection. An authority-signed canonical rejection status does not exist yet, so rejection-based removal remains unavailable. This changes no Drive or provider request and no request cadence.
-> PWA RSS feed add, rename, and removal now use the same signed intent path. IndexedDB updates immediately, authenticated replay reproduces the change, and Freed Desktop commits the SQLite shell update, optional item tombstones, acceptance receipt, and replication outbox atomically.
-> PWA Person add, bounded batch add, and synchronized profile updates now use one whole-record signed intent contract. Device-local graph coordinates are stripped before signing, IndexedDB updates the selected shell immediately and on authenticated replay, and Freed Desktop commits the Person materialization, acceptance receipt, and replication outbox atomically in native SQLite.
+> The repository contains native SQLite authority, journal, bounded-reader,
+> follower-intent, checkpoint-staging, Drive-control, receipt, backup, and
+> browser semantic foundations. The final generated registry, normalized v2
+> exporter and importer, complete mutation and query cutover, PWA SQLite
+> runtime, selective content plane, one-epoch migration, retired-runtime
+> deletion, and physical-device acceptance remain open.
+
+## Current SQLite sync work
+
+- [ ] Freeze one generated protocol registry for normalized checkpoint records,
+      operation segments, signed intents, results, content descriptors, range
+      indexes, manifests, and control tuples.
+- [ ] Remove the Library shell checkpoint record and every whole FeedItem JSON
+      checkpoint row.
+- [ ] Export and import typed normalized records through bounded native and
+      browser SQLite transactions.
+- [ ] Enforce the initial 131,072-byte canonical logical-record ceiling,
+      128-record and 2,097,152-byte decoded page ceilings, and 1,048,576-byte
+      native source-response ceiling, subject to the pre-freeze benchmark.
+- [ ] Represent larger legal fields through content descriptors and bounded
+      content-addressed chunks or authenticated range indexes.
+- [ ] Let each client stream, partially cache, fully cache, pin offline, or
+      exclude content without changing checkpoint authority.
+- [ ] Delete Automerge cloud merge, LAN document relay, compatibility control,
+      shell, ordinal identity, dual-engine rollback, and SQLite file transport
+      paths after verified one-epoch cutover.
+- [ ] Preserve current Google Drive endpoints, headers, retries, OAuth behavior,
+      and cadence unless separately approved.
 
 ---
 
-## Overview
+## Sync architecture
 
-Device-to-device sync via Automerge CRDT. Two sync modes, zero external infrastructure.
+One active Primary owns canonical mutation admission for a Library and writer
+epoch. The Primary runs inside Freed Desktop or the headless service and uses
+the shared native SQLite Library Core. Freed Desktop and PWA followers keep
+local SQLite replicas and submit signed mutation intents.
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                           SYNC LAYER                            │
-│                                                                 │
-│  HOME NETWORK (instant sync):                                   │
-│  ┌─────────────┐    WebSocket    ┌─────────────┐               │
-│  │   Desktop   │◄──────────────►│  Phone PWA  │               │
-│  │   :8765     │    (<100ms)     │             │               │
-│  └──────┬──────┘                 └─────────────┘               │
-│         │                                                       │
-│         ▼                                                       │
-│  ┌─────────────┐                                                │
-│  │ Cloud Sync  │  (GDrive / iCloud / Dropbox)                  │
-│  │  (backup)   │  User's own account                           │
-│  └─────────────┘                                                │
-│                                                                 │
-│  AWAY FROM HOME (5-30s sync):                                   │
-│  ┌─────────────┐    Cloud File    ┌─────────────┐              │
-│  │   Desktop   │◄────────────────►│  Phone PWA  │              │
-│  └─────────────┘                  └─────────────┘              │
-└─────────────────────────────────────────────────────────────────┘
-```
+### Logical protocol
 
----
+Synchronization exchanges only closed typed logical objects:
 
-## Architecture
+- normalized checkpoint records
+- append-only operation segments
+- actor enrollment and retirement certificates
+- signed follower intents
+- signed Primary acceptance, rejection, and provider-result records
+- authenticated checkpoint, operation, result, and content manifests
+- content descriptors, content-addressed chunks, and authenticated range indexes
+- one small authenticated control tuple
 
-**Key decisions:**
+The protocol never exchanges SQLite files, WAL files, SHM files, rollback
+journals, a Library shell, monolithic `DocState`, or whole FeedItem JSON rows.
 
-- No relay server we operate (reduces legal attack surface)
-- Desktop App / OpenClaw is the source of truth + runs ranking algorithm
-- Cloud storage = backup + away-from-home sync
-- Images cached locally per device (not synced via cloud)
+Checkpoint records are identified by stable registry key plus typed canonical
+primary key. Pages carry at most 128 records and 2,097,152 decoded canonical
+bytes. Each record uses the initial 131,072-byte canonical ceiling until the
+required benchmark freezes the protocol value. Larger legal values use the
+content plane.
 
----
+### Google Drive
 
-## Package Structure
+Google Drive `appDataFolder` stores immutable protocol objects and one
+compare-and-swap control file. The control tuple binds the Library, writer
+epoch, schema version, protocol version, registry fingerprint, checkpoint,
+operation frontier, and content root.
 
-```
-packages/sync/
-├── src/
-│   ├── index.ts              # Public API
-│   ├── repo.ts               # automerge-repo wrapper
-│   ├── storage/
-│   │   ├── indexeddb.ts      # Browser storage adapter
-│   │   └── filesystem.ts     # Node/Bun storage adapter
-│   ├── network/
-│   │   ├── local-relay.ts    # WebSocket server
-│   │   └── cloud.ts          # Cloud storage sync
-│   └── status.ts             # Sync status observables
-├── package.json
-└── tsconfig.json
-```
+Publication uploads immutable dependencies first, verifies their stored bytes,
+then advances the exact prior control revision. A lost commit response is
+resolved by authenticated readback. Unreachable immutable objects are safe to
+collect after retention and reachability proof.
 
----
+This phase preserves existing Google Drive endpoints, headers, OAuth behavior,
+retry policy, and cadence. Changing those behaviors requires separate scope and
+evidence.
 
-## Core Implementation
+### Editable followers
 
-### Local WebSocket Relay
+A follower commits its signed intent and sparse optimistic overlay atomically
+in local SQLite. The intent binds the Library, epoch, actor, capability,
+transaction, ordered operations, actor-chain predecessor, and idempotency key.
 
-```typescript
-// packages/sync/src/network/local-relay.ts
-import { WebSocketServer } from "ws";
-import { Repo } from "@automerge/automerge-repo";
-import { NodeWSServerAdapter } from "@automerge/automerge-repo-network-websocket";
+The Primary verifies the complete envelope and either commits the whole
+transaction or rejects it. It publishes a signed result that the follower
+applies atomically. Provider acceptance and provider completion are distinct.
+A client cannot display provider success until the Primary records the actual
+provider result.
 
-const DEFAULT_PORT = 8765;
+### Selective content
 
-/**
- * Start local WebSocket relay
- * PWA connects via ws://192.168.x.x:8765 or ws://desktop.local:8765
- */
-export function startLocalRelay(repo: Repo, port = DEFAULT_PORT): void {
-  const wss = new WebSocketServer({ port });
-  const adapter = new NodeWSServerAdapter(wss);
-  repo.networkSubsystem.addNetworkAdapter(adapter);
+Metadata convergence does not require content hydration. Each client chooses
+metadata-only, stream, partial-cache, full-cache, pinned-offline, or excluded
+behavior for each asset or rendition. Multi-gigabyte media uses authenticated
+range indexes and bounded chunks. Content bytes never enlarge a logical
+checkpoint record.
 
-  console.log(`Freed sync relay running on ws://localhost:${port}`);
-}
-```
+### Failure behavior
 
-### PWA Client Connection
+Invalid signatures, stale writer epochs, split authority, unknown versions,
+registry drift, gaps, changed replay, oversized records, incomplete manifests,
+content digest mismatch, and stale cursors fail closed. Checkpoint imports
+stage into SQLite and activate only after complete registry, frontier, state,
+content-root, and integrity verification.
 
-```typescript
-// packages/sync/src/network/client.ts
-import { BrowserWebSocketClientAdapter } from "@automerge/automerge-repo-network-websocket";
-
-export async function connectToLocalRelay(
-  repo: Repo,
-  host: string,
-  port = 8765
-): Promise<boolean> {
-  const url = `ws://${host}:${port}`;
-
-  try {
-    const ws = new WebSocket(url);
-    await new Promise((resolve, reject) => {
-      ws.onopen = resolve;
-      ws.onerror = reject;
-      setTimeout(reject, 2000);
-    });
-    ws.close();
-
-    const adapter = new BrowserWebSocketClientAdapter(url);
-    repo.networkSubsystem.addNetworkAdapter(adapter);
-    return true;
-  } catch {
-    return false; // Fall back to cloud sync
-  }
-}
-```
-
-### Cloud Storage Sync
-
-```typescript
-// packages/sync/src/network/cloud.ts
-import * as A from "@automerge/automerge";
-
-interface CloudConfig {
-  provider: "gdrive" | "icloud" | "dropbox";
-  credentials: OAuthCredentials;
-}
-
-export async function syncToCloud(
-  doc: A.Doc<unknown>,
-  config: CloudConfig
-): Promise<void> {
-  const binary = A.save(doc);
-
-  switch (config.provider) {
-    case "gdrive":
-      await syncToGoogleDrive(binary, config.credentials);
-      break;
-    case "icloud":
-      await syncToICloud(binary, config.credentials);
-      break;
-    case "dropbox":
-      await syncToDropbox(binary, config.credentials);
-      break;
-  }
-}
-
-export async function syncFromCloud(
-  localDoc: A.Doc<unknown>,
-  config: CloudConfig
-): Promise<A.Doc<unknown>> {
-  const remoteBinary = await fetchFromCloud(config);
-  if (!remoteBinary) return localDoc;
-
-  const remoteDoc = A.load(remoteBinary);
-  return A.merge(localDoc, remoteDoc);
-}
-```
-
-### Sync Status API
-
-```typescript
-// packages/sync/src/status.ts
-export interface SyncStatus {
-  mode: "local" | "cloud" | "offline";
-  state: "idle" | "syncing" | "error";
-  lastSyncAt: number | null;
-  localRelayConnected: boolean;
-  cloudProvider?: "gdrive" | "icloud" | "dropbox";
-  error?: string;
-}
-
-export function createSyncManager(repo: Repo): SyncManager {
-  return {
-    async sync(): Promise<void> {
-      if (await this.tryLocalRelay()) return;
-      await this.syncCloud();
-    },
-    subscribe(listener: (status: SyncStatus) => void): () => void {
-      /* ... */
-    },
-    async tryLocalRelay(): Promise<boolean> {
-      /* ... */
-    },
-    async syncCloud(): Promise<void> {
-      /* ... */
-    },
-    getStatus(): SyncStatus {
-      /* ... */
-    },
-  };
-}
-```
-
----
-
-## Sync Flow
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                        PWA OPENS                                 │
-│                            │                                     │
-│              ┌─────────────┴─────────────┐                      │
-│              ▼                           ▼                      │
-│     Try local relay              Load from IndexedDB            │
-│     (ws://desktop:8765)              │                          │
-│              │                        │                         │
-│      ┌───────┴───────┐                │                         │
-│      ▼               ▼                │                         │
-│   Success         Fail                │                         │
-│   (instant)       │                   │                         │
-│      │            ▼                   │                         │
-│      │     Try cloud sync             │                         │
-│      │     (5-30s)                    │                         │
-│      │            │                   │                         │
-│      └────────────┼───────────────────┘                         │
-│                   ▼                                             │
-│            Merge & display                                      │
-└─────────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Device Pairing
-
-1. **QR code** — Desktop displays QR with local IP + pairing token, phone scans
-2. **Manual entry** — User copies full URL (including `?t=<token>`) from desktop settings
-3. **mDNS discovery** — PWA auto-discovers `desktop.local` (not yet implemented)
-
-### Pairing Security
-
-The relay requires a 256-bit token in the WebSocket upgrade URI (`?t=<base64url>`).
-
-- Token is generated on first launch, persisted to the app data directory, and re-used across restarts so paired devices auto-reconnect.
-- QR code is rendered locally via `react-qr-code` — the user's LAN IP and token are never sent to a third party.
-- "Reset Pairing Token" button (desktop Settings → Mobile Sync) rotates the token and persists the new value; connected devices remain unaffected until they disconnect and attempt to reconnect.
-- Factory reset rotates the token, disconnects active relay clients, clears relay-held document bytes, and requires existing PWA readers to scan the current QR code again.
-- New devices must scan the current QR code to obtain a valid token.
-
----
-
-## Cloud Provider Strategy
-
-**All three providers supported from day one:**
-
-| Provider     | Complexity | Notes                                           |
-| ------------ | ---------- | ----------------------------------------------- |
-| Google Drive | Medium     | Well-documented APIs, OAuth works from browser  |
-| Dropbox      | Low        | Simple OAuth, good cross-platform support       |
-| iCloud       | High       | Best for Apple users, web API access is limited |
-
-Each provider stores a single Automerge binary file. CRDT handles merge conflicts automatically.
-
-### Future Large Media Transfer
-
-Automerge and the current document relay are not media pipes. Future offline
-audio and video packages must stay outside the Freed document, snapshots, logs,
-and bug reports.
-
-The planned transfer order is a dedicated authenticated LAN endpoint, then
-chunk-encrypted objects in the user's configured cloud when Freed Desktop is
-unreachable. The PWA verifies and stores each package in device-local media
-storage. A Freed-hosted relay requires a separate owner decision after the
-device-owned paths have been measured for reliability, privacy, provider
-visibility, bandwidth, and cost.
-
-See [YouTube Focus and Offline Integration](YOUTUBE-INTEGRATION.md) for the
-first audio-oriented use case, security model, iPhone constraints, failure
-recovery, telemetry, milestones, and acceptance tests.
-
----
+A crash before a SQLite commit leaves no accepted mutation. A crash after
+commit recovers from the durable receipt and idempotency record. No failure
+loads an alternate Library engine or compatibility path.
 
 ## Tasks
 
@@ -380,7 +220,7 @@ recovery, telemetry, milestones, and acceptance tests.
 | 4.88 | Canonical normalized feed-filter contract shared by the current renderer and future bounded adapters, with exact archived, hidden, source, author, feed, post/story, saved, tag, and signal semantics | ✓ | Medium |
 | 4.89 | Canonical recommendation-order contract shared by both current workers, preserving priority, published-time, and source-enumeration tie semantics for future bounded adapters | ✓ | Medium |
 | 4.90 | Dormant query-specific PWA browse projection with normalized filter and ranking-clock source identity, exact recommendation-order index keys, 128-row staging bounds, IndexedDB v1 upgrade preservation, and no product caller | ✓ | Medium |
-| 4.91 | Closed dormant `feed_browse_page_v1` protocol and PWA reader with canonical filter and ranking-clock binding, full physical keyset cursor, shared two-session and 60-second lifecycle bounds, exact worker transport, and no product caller | ✓ | Medium |
+| 4.91 | Closed dormant `feed_browse_page_v1` protocol and PWA query adapter with canonical filter and ranking-clock binding, full physical keyset cursor, shared two-session and 60-second lifecycle bounds, exact worker transport, and no product caller | ✓ | Medium |
 | 4.92 | Crash-resumable native SQLite browse generation with exact filter, ranking-clock, and source binding, 128-row and 2 MiB staging bounds, replay receipts, index-backed physical keyset order, and no runtime caller | ✓ | Medium |
 | 4.93 | Dormant Freed Desktop browse-generation writer transport with one session-bound active generation, exact progress recovery after response loss, replay-safe bounded pages, explicit cancellation, factory-reset quiescence, and no worker or product caller | ✓ | Medium |
 | 4.94 | Dormant Freed Desktop browse materializer with exact durable Automerge source authentication, normalized filter and ranking-clock generation identity, closed feed-card validation, iterator-backed 128-row pages, native receipt recovery, and no product caller | ✓ | Medium |
@@ -477,7 +317,7 @@ not mean those internal stages remain unreachable.
 - [x] Desktop surfaces cloud sync health with retry/reconnect actions, recent failures, and debug charts
 - [x] Desktop no-cloud-sync launch banner self-dismisses after 15 seconds with a gentle countdown ring
 - [x] Desktop writes rotating local snapshots and can restore an older Automerge copy from Settings
-- [x] Each Freed Desktop installation keeps its opaque identity locally, registers durable topology metadata after document initialization and merges, and warns in Sync setup when another Freed Desktop could duplicate RSS or authenticated provider requests. PWA readers do not count toward the warning.
+- [x] Each Freed Desktop installation keeps its opaque identity locally, registers durable topology metadata after document initialization and merges, and warns in Sync setup when another Freed Desktop could duplicate RSS or authenticated provider requests. PWA clients do not count toward the warning.
 - [x] The dormant Library Core census makes current synchronized fields, shared store surfaces, Desktop and PWA worker messages, planned operations and queries, and retained local authorities reviewable without changing the active Automerge writer or claiming Gate A activation
 - [x] The dormant legacy epoch bootstrap contract closes the exact digest-addressed in-document record occurrence, complete bounded current and historical reserved-root scan with deleted-root rejection, source-descended prepared owner operation, local control, completion receipt, identity codecs, current-frontier tracking, creator and TOFU read-only adopter states, response-loss readback, partial-transaction rejection, conflict behavior, and the activation block on value-only Automerge history rebuilds without adding provider objects or requests, generating authority keys, writing storage, choosing a creator at startup, or activating Library Core
 - [x] IndexedDB v2 preserves v1 Automerge bytes at revision zero, returns an exact generation and save revision with every load, rejects stale saves and clears through one atomic compare-and-swap, closes on version change, blocks unsafe upgrades, and exposes repeatable `saveSince` persistence that advances committed bytes and heads only after storage commit. Failed decodes retain the exact loaded revision, distinguish corruption from memory exhaustion, and cannot clear a newer concurrent save. Worker integration remains a separate activation step.

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -1,8 +1,35 @@
 # Phase 5: Desktop & Mobile App (Tauri)
 
 > **Status:** 🚧 In Progress (direct desktop distribution live, macOS signing and notarization live in releases, Windows signing plan scaffolded, legal consent gate shipped, tri-state sidebar chrome shipped, local snapshot restore shipped, public-safe bug reporting shipped, runtime memory telemetry shipped, native startup recovery shipped, bundled recovery updater flow shipped, permanent local social media vault shipped, desktop hot-path side-effect scheduling shipped, event-aware outbox drains shipped, incremental item-patch state updates shipped, incremental RSS feed metadata updates shipped, safe optimistic user mutations shipped, visible-scope bulk archive shipped, background runtime coordination shipped, renderer recovery safe mode shipped, blocked-preflight crash-loop protection shipped, deep local WebKit diagnostics shipped, adaptive high-memory scrape budgets shipped, classifier health notification isolation shipped, idle Automerge worker recycling shipped, bounded SQLite maintenance scans shipped, explicit local-only primary Library authority shipped, SQLite-backed sample-data accounting, Story Wall candidates, Saved analytics, and full-library native search shipped, the four-mode Saved feed and non-Saved Friends-only feed moved onto bounded Gate D SQLite reads, the ordinary all-content feed moved onto bidirectional bounded SQLite paging, bounded scheduled RSS refresh shipped, density-aware fixed-height unified feed rows shipped, local interface zoom controls shipped, settings changelog preview shipped, fingerprinted sample-data cleanup shipped, visible cloud transfer diagnostics shipped, destructive cloud merge recovery shipped, manual Drive sync and activity timelines shipped, multi-Desktop provider request warnings shipped, cloud upload waits behind active outbox work shipped, production-default Google token proxy fallback shipped, recoverable Google Contacts refresh failures shipped, global background activity monitoring shipped, native terminal sync soaks shipped, and sync relay port handoff retries shipped)
+
+> **Architecture:** Freed Desktop is a bounded SQLite client and a host
+> for the shared native Library Core. Every view calls a named typed query.
+> Every durable product edit calls a registered mutation. React retains only
+> visible windows and ephemeral interface state. Tauri owns command wiring and
+> host capabilities, not Library semantics. Automerge, whole-corpus renderer
+> state, Library shells, shadow readers, and compatibility leases are deleted
+> at the verified SQLite-only cutover.
 > **Dependencies:** Phase 4 (Sync Layer)  
 > **Priority:** 🎯 HIGHEST — Universal liberation tool
+
+## Current SQLite Desktop work
+
+- [ ] Complete extraction of Library semantics into
+      `packages/library-core-native` so Freed Desktop and the headless Primary
+      call the same Rust core.
+- [ ] Generate Rust and TypeScript bindings from one executable contract source
+      and consume one checked-in SQL catalog.
+- [ ] Route feed, Saved, search, item detail, Friends, map, analytics, Story
+      Wall, settings, exports, and diagnostics through bounded named queries.
+- [ ] Route the exhaustive mutation registry through atomic native
+      journal-plus-materialization transactions with exact retry receipts.
+- [ ] Replace whole-corpus subscriptions with a compact bounded invalidation
+      feed and query reruns.
+- [ ] Keep large content in a content-addressed vault with per-device hydration
+      policy and verified range reads.
+- [ ] Remove `shellJson`, `DocState`, whole FeedItem transport, Automerge
+      workers, shadow stores, compatibility flags, and unconsumed migration
+      exports after one-epoch activation proof.
 
 ---
 
@@ -270,7 +297,7 @@ export async function captureDomFeed(
 - [x] Local desktop preview now defaults to the mocked browser harness, while tracked preview slots keep concurrent local threads to one desktop preview at a time unless native Tauri behavior is explicitly requested, native preview windows carry a visible worktree and thread label, and feature previews auto-accept local legal gates plus seed sample data
 - [x] Desktop navigation history supports browser-style back and forward shortcuts for views and reader state
 - [x] Freed Desktop registers a device-local OS-wide Save Content shortcut that opens the existing Save Content dialog, pre-fills the URL field from the clipboard when it holds an HTTP or HTTPS link, opens the saved item in reader mode after stub persistence, and pulls readable details in the background
-- [x] Freed Desktop factory reset closes Automerge admission, settles document work already accepted by the worker, and rejects later mutations before deletion. It clears device display and AI choices, snapshots, runtime diagnostics, shortcut configuration, local provider sessions, active cloud credentials, and the local document. A durable cleanup barrier keeps automatic cloud sync paused after failed cloud deletion until reset succeeds or the user explicitly reconnects. The relay rotates its pairing token, clears held document bytes, disconnects old mobile sessions, and stays paused whenever document deletion is uncertain. Existing PWA readers must scan the current pairing QR code again after a successful reset. Local discovery and request history, backoff and receipt ledgers, encrypted AI keys, local model files, the media vault, scraper window modes, and provider user agent identity stay intact. Legal acceptance, release channel, and installation identity also remain installation state.
+- [x] Freed Desktop factory reset closes Automerge admission, settles document work already accepted by the worker, and rejects later mutations before deletion. It clears device display and AI choices, snapshots, runtime diagnostics, shortcut configuration, local provider sessions, active cloud credentials, and the local document. A durable cleanup barrier keeps automatic cloud sync paused after failed cloud deletion until reset succeeds or the user explicitly reconnects. The relay rotates its pairing token, clears held document bytes, disconnects old mobile sessions, and stays paused whenever document deletion is uncertain. Existing PWA clients must scan the current pairing QR code again after a successful reset. Local discovery and request history, backoff and receipt ledgers, encrypted AI keys, local model files, the media vault, scraper window modes, and provider user agent identity stay intact. Legal acceptance, release channel, and installation identity also remain installation state.
 - [x] Settings and crash recovery surfaces can export public-safe bug report bundles
 - [x] Private diagnostic bundles are opt-in, redacted, and steered toward email instead of public GitHub attachment
 - [x] Bug report actions now label whether they download a public-safe or private bundle, bulk-toggle private diagnostics, and block public GitHub issue drafts while private diagnostics remain selected
@@ -286,7 +313,7 @@ export async function captureDomFeed(
 - [x] Production release prep and publish refuse stale `main` snapshots until current `dev` has been promoted into `main`, and PRs targeting `main` reject direct product edits outside the promotion flow
 - [x] Debug panel Health tab charts provider reliability plus daily and hourly pull volume across RSS, X, Facebook, Instagram, LinkedIn, Google Drive, and Dropbox
 - [x] Desktop Settings > Sync shows local item count, local document size, Drive stage, last download, last upload, remote bytes, uploaded bytes, cloud errors, pending upload explanations, a manual Drive `Sync now` action, and a recent activity timeline
-- [x] Desktop Settings > Sync warns when more than one Freed Desktop installation is registered with the library because parallel RSS or authenticated provider polling can duplicate request traffic. PWA readers do not trigger the warning.
+- [x] Desktop Settings > Sync warns when more than one Freed Desktop installation is registered with the library because parallel RSS or authenticated provider polling can duplicate request traffic. PWA clients do not trigger the warning.
 - [x] Failing RSS feeds can be reviewed and unsubscribed from the health panel, with optional article/history deletion
 - [x] Sidebar source actions and source settings surface degraded or paused provider health outside the debug panel
 - [x] Debug panel Health tab charts provider reliability plus daily and hourly pull volume across RSS, X, Facebook, Instagram, LinkedIn, Google Drive, and Dropbox, with an in-card duration dropdown for each provider

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -1,33 +1,62 @@
-# Phase 6: PWA Reader
+# Phase 6: PWA
 
-> **Status:** ✅ Complete (first-run legal gate shipped, public-safe bug reporting shipped, homescreen install flow shipped, offline article and image caching shipped, local reader cache modes shipped, mobile toolbar and reader polish shipped, complete bounded IndexedDB Library surfaces shipped, persistent bounded-memory search shipped, signed user intent outbox shipped, immutable Google Drive checkpoint sync shipped, manual Google Drive sync diagnostics shipped, and the PWA Automerge runtime retired)
+> **Status:** 🚧 In Progress (the product shell and signed-intent foundations exist; SQLite WebAssembly, OPFS persistence, bounded query parity, and IndexedDB Library deletion remain open)
+
+> **Architecture:** The PWA runs official SQLite WebAssembly over OPFS in
+> one worker. It uses the same schema catalog, named SQL, result DTOs, mutation
+> intent codecs, normalized checkpoint records, and conformance vectors as the
+> native core. IndexedDB is not a Library database or fallback. A narrow
+> IndexedDB keystore may remain only for nonextractable browser keys when
+> WebKit offers no suitable alternative.
+
 > **Dependencies:** Phase 4 (Sync Layer), Phase 5 (Desktop App)
+
+## Current SQLite PWA work
+
+- [ ] Prove the iOS 17 durability floor through
+      physical iPhone storage, suspension, recovery, quota, and playback tests.
+- [ ] Run official SQLite WebAssembly in one SharedWorker with a dedicated
+      worker recovery route, one connection generation, and one Library lock.
+- [ ] Persist the Library, query indexes, search, intent outbox, result receipts,
+      and sparse optimistic overlay in OPFS-backed SQLite.
+- [ ] Import normalized typed checkpoints into a verified staging database and
+      activate only after exact registry, frontier, state, and content-root
+      proof.
+- [ ] Serve every product surface through bounded named SQLite queries without
+      holding or scanning a corpus in React.
+- [ ] Support metadata only, streaming, partial cache, full cache, pinned
+      offline, and excluded content modes per device and rendition.
+- [ ] Delete IndexedDB Library generations, rows, overlays, checkpoint cursors,
+      search postings, and compatibility code after verified cutover.
 
 ---
 
 ## Overview
 
-Mobile companion to Freed Desktop for on-the-go reading. Timeline-focused, minimal chrome, content-first design. This is the primary mobile distribution surface, and it now enforces a first-run legal gate before sync or update side effects begin.
+The PWA is Freed's complete mobile client. It queries a local SQLite Library,
+supports durable edits through signed intents, manages selective offline
+content, and enforces a first-run legal gate before synchronization or update
+side effects begin.
 
 **Key architectural decisions:**
 
 - **Shared codebase** — Same React app embedded in Desktop WebView and deployed to [app.freed.wtf](https://app.freed.wtf), with the dev channel on `dev-app.freed.wtf`
-- **Thin client** — Displays pre-computed rankings from Desktop/OpenClaw, minimal local computation
+- **Local SQLite client:** Executes bounded named queries locally and displays canonical rankings computed by the Primary
 - **Light saves:** Saves URL stubs immediately; full detail extraction requires Freed Desktop
-- **Offline-first:** Service worker precaches the app shell and caches saved reader HTML and images for offline reading. Library records remain in IndexedDB.
+- **Offline-first:** Service worker precaches the app shell and bounded static assets. Library records, search, intents, results, and content indexes live in SQLite WebAssembly over OPFS. Large content lives in separate OPFS vault files.
 - **Versioned first-run consent** — PWA startup is blocked until the current legal bundle is accepted locally in the browser
 - **URL-driven navigation** — Active view, feed scope, and open reader state serialize into the URL so browser back and forward behave naturally
 - **Desktop handoff in source settings:** PWA Settings exposes Feeds, X / Twitter, Facebook, Instagram, LinkedIn, and Google Contacts as sync status dashboards with clear Freed Desktop management handoff states
 - **Mobile settings scope:** PWA Settings hides AI controls and source connection controls that only Freed Desktop can run
-- **Cloud sync diagnostics:** PWA Settings shows local item count, Drive stage, last download, last import, last intent upload, remote bytes, the last cloud error, why synchronization is waiting, recent Drive activity, and a manual `Sync now` action. The PWA imports immutable Desktop checkpoints into IndexedDB and publishes signed user intents without downloading or synchronizing a live SQLite file.
+- **Cloud sync diagnostics:** PWA Settings shows local item count, Drive stage, last download, last import, last intent upload, remote bytes, the last cloud error, why synchronization is waiting, recent Drive activity, and a manual `Sync now` action. The PWA imports immutable normalized checkpoints into local SQLite and publishes signed user intents without downloading or synchronizing a live SQLite file.
 - **Blank-state testing escape hatch** — PWA empty states now include a secondary sample-data section below the main handoff prompt for quick local testing
 - **Archived saved-item repair control** — Archived views now surface a one-click `Unarchive Saved Content` action when legacy or imported items end up both saved and archived
-- **Safe optimistic user mutations:** Read, saved, archived, and liked changes update the selected IndexedDB row immediately and enter the signed epoch-scoped intent outbox. They remain Pending until Freed Desktop publishes canonical acceptance, and provider-visible success requires a separate real provider result receipt. Device display controls and Friends graph pins remain local.
-- **People mutations:** Person and Account add, bounded batch add, synchronized profile and relationship updates, connection-person promotion, bounded reach-out history, and atomic removal enter the signed epoch-scoped intent outbox and update the selected IndexedDB Library shell immediately. Device-local graph coordinates stay outside canonical payloads, Account removal cannot prune a Person during legacy Friend replacement, and reach-out history retains its 20-entry cap without waking Automerge.
-- **FeedItem capture mutations:** New and updated FeedItems enter the signed epoch-scoped intent outbox in ordered transactions of at most 128 unique items. IndexedDB and local search update after each durable batch, repeated identities retain input order across transaction boundaries, and device-local ranking fields never enter canonical payloads.
-- **Library maintenance mutations:** Sample seeding, fingerprinted sample clearing, and bulk feed removal use the same signed Library Core operations as normal writes. Sample clearing scans the complete IndexedDB corpus and unlinks real accounts before removing sample people.
-- **SQLite-only PWA:** IndexedDB Library Core is the only PWA product store. Production builds reject any Automerge asset or retired registry payload, the service worker has no legacy `/sync` route, the rollback flag cannot reactivate the retired worker, and legacy Automerge cloud-file merging fails closed.
-- **Complete bounded reads:** Feed filters, all Saved orders, facets, Friends activity and timelines, Map, and Story Wall read the selected IndexedDB checkpoint beyond the initial 512-card UI window. Query pages are capped at 128 compact rows and source movement fails closed.
+- **Safe optimistic user mutations:** Read, saved, archived, and liked changes commit to a sparse local SQLite overlay and the signed epoch-scoped intent outbox atomically. They remain Pending until the Primary publishes canonical acceptance, and provider-visible success requires a separate real provider result receipt. Device display controls and Friends graph pins remain local.
+- **People mutations:** Person and Account creation, bounded batch creation, synchronized profile and relationship updates, connection-person promotion, bounded reach-out history, and atomic removal use registered signed intent mutations and update the sparse local SQLite overlay immediately. Device-local graph coordinates stay outside canonical payloads.
+- **FeedItem capture mutations:** New and updated FeedItems enter the signed epoch-scoped intent outbox in ordered bounded transactions. Local SQLite and search update after each durable batch, repeated identities retain input order across transaction boundaries, and device-local ranking fields never enter canonical payloads.
+- **Library maintenance mutations:** Sample seeding, fingerprinted sample clearing, and bulk feed removal use the same signed Library Core operations as normal writes. SQLite executes registered bounded maintenance mutations without a JavaScript corpus scan.
+- **SQLite-only PWA:** SQLite WebAssembly over OPFS is the only PWA Library row store. Production builds reject Automerge assets, retired registry payloads, IndexedDB Library databases, legacy `/sync` routes, and rollback flags that could reactivate a retired runtime.
+- **Complete bounded reads:** Feed filters, all Saved orders, facets, Friends activity and timelines, Map, and Story Wall use registered SQLite queries beyond the visible interface window. Query pages are capped, source movement fails closed, and React retains only the visible and adjacent windows.
 - **Mobile chrome polish:** The PWA mobile toolbar uses balanced menu and format controls, every top-level view keeps Theme and Zoom at the top of the far-right menu with tappable 10% zoom steps, the mobile drawer starts with search, Settings stacks compact sections, and the reader keeps fixed menus plus sane article spacing
 
 ---

--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -1,6 +1,6 @@
 # Phase 8: Friends + Social Graph
 
-> **Status:** In Progress, the canonical identity model uses `Person` plus attached `Account` records, the Friends workspace defaults to `All content`, and the shipping Friends route has been cut over to the next-generation GPU-resident Friends Galaxy. Raw WebGPU is preferred, WebGL2 is the retained compatibility backend, every semantic identity remains resident during movement, and the locked camera supports native iPhone touch and Mac trackpad navigation with inertia. Freed Desktop Friends activity, suggestions, overview, selected-person timelines, FriendEditor profile candidates, and the non-Saved Friends-only feed now read bounded source-fenced SQLite aggregates or pages instead of retaining the full item corpus. The PWA now reads its Friends-only feed, compact graph activity, selected-person timelines, location details, and Map candidates from bounded source-fenced IndexedDB pages. The broader Friends phase still includes unfinished native contacts, overlap, and Mozi work.
+> **Status:** In Progress. The canonical identity model uses `Person` plus attached `Account` records, and the shipping Friends route uses the GPU-resident Friends Galaxy. Freed Desktop uses bounded SQLite aggregates and pages. The current PWA transition store proved equivalent bounded reads in IndexedDB. Phase 6 replaces that store with SQLite WebAssembly over OPFS and the same named query contracts. Native contacts, overlap, and Mozi work remain unfinished.
 > **Dependencies:** Phase 7 (Facebook + Instagram capture provide most social content)
 
 ---
@@ -23,11 +23,11 @@ This phase also becomes the home for future-aware social planning. Historical po
 ┌──────────────────────────────────────────────────────────────────┐
 │                  8A: Person + Account Identity Layer              │
 │                                                                   │
-│  Person record (Automerge doc)                                    │
+│  Person row plus normalized child rows                            │
 │  ├── relationshipStatus: "connection" | "friend"                  │
 │  └── metadata for the confirmed same-human identity               │
 │                                                                   │
-│  Account record (Automerge doc)                                   │
+│  Account row plus normalized child rows                           │
 │  ├── kind: "social" | "contact"                                   │
 │  ├── provider + externalId                                        │
 │  └── optional personId when the operator confirms identity        │
@@ -609,7 +609,7 @@ The product Friends view now fixes decorative dust to the 100,000-star Raw WebGP
 | 8.163 | Reproject and collision-admit the bounded label roster on every changed camera frame while coalescing worker candidate refreshes and avoiding per-frame text rerasterization                                                                                     | High       | Done        |
 | 8.164 | Restore the standard workspace sidebar inset on Friends while retaining the full-frame pointer-free Galaxy background beneath it                                                                                                                                 | Medium     | Done        |
 | 8.165 | Extend the shared map and Friends Galaxy palette registry with AubOS Starship and Dark Star                                                                                                                                                                      | Medium     | Done        |
-| 8.166 | Move the Freed Desktop non-Saved Friends-only feed onto versioned `feed_browse_page_v2` SQLite pages when no search is active, while preserving Person-first membership, ordinary browse ordering, ranking invalidation, bounded projection and renderer residency, selected-card continuity, exact Automerge fallback, and the PWA reader | High       | Done        |
+| 8.166 | Move the Freed Desktop non-Saved Friends-only feed onto versioned `feed_browse_page_v2` SQLite pages when no search is active, while preserving Person-first membership, ordinary browse ordering, ranking invalidation, bounded projection and renderer residency, selected-card continuity, exact Automerge fallback, and the PWA client | High       | Done        |
 | 8.167 | Match the Friends detail rail's vertical card insets to the primary navigation rail, keep both resize rails full-height and centered in equal gutters, clamp wheel and pinch zoom at the exact per-canvas Fit All transform, and move graph diagnostics into the Friends sidebar menu | Medium     | Done        |
 | 8.168 | Add a persisted preview control that compares 100,000 worker-buffered decorative stars, 100,000 Raw WebGPU vertex-generated stars with no per-star source or instance buffer, and no decorative stars while reporting the last worker-to-renderer build time | Medium     | Done        |
 | 8.169 | Keep graph-invalidating fields narrow, coalesce sustained source hydration through one resident latest-wins worker, and replace Raw WebGPU scenes without recreating the canvas, device, or compiled pipelines | High       | Done        |

--- a/docs/STORAGE-ARCHITECTURE-ROADMAP.md
+++ b/docs/STORAGE-ARCHITECTURE-ROADMAP.md
@@ -1,581 +1,298 @@
-# Storage Architecture Roadmap
+# SQLite Library Core Delivery Roadmap
 
-Status: **Approved direction. The SQLite cutover is active; live acceptance remains gated.**
+This document is the current engineering checkpoint ledger for Freed's SQLite
+Library Core. It records what exists, what is being built next, and what proof
+closes each stage. It does not redefine the architecture.
 
-The normative architecture lives in
-[LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md). This roadmap records why
-the work exists, what evidence is real, and the safest delivery order.
+The architecture lives in
+[ARCHITECTURE.md](ARCHITECTURE.md) and
+[LIBRARY-CORE-ARCHITECTURE.md](LIBRARY-CORE-ARCHITECTURE.md). Exact durable
+behavior lives in [LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md).
 
-## Current implementation boundary
+## Current checkpoint
 
-The current cutover candidate retires the active compatibility runtime instead
-of preserving a bridge. Desktop and PWA production entry points no longer load
-an Automerge worker, package, WASM asset, mutable cloud document, LAN relay, or
-legacy snapshot. Freed Desktop reads and writes native SQLite directly, keeps
-large media outside the row store, publishes immutable Library Core objects,
-and retains 24 closed SQLite backups on their originating device. Drive never
-receives SQLite, WAL, SHM, or rollback-journal files. The PWA uses IndexedDB
-through bounded logical pages, intents, results, and search state. Exact-head
-validation, the dev release, installation, and runtime evidence remain before
-this candidate becomes the verified shipped boundary. Further corpus fault injection, media
-transport, retired-writer review, restore coverage, source cleanup, cursor
-optimization, and bundle splitting are recorded in issues #1446 through #1453
-instead of delaying the first manually testable SQLite build.
+Last updated: 2026-08-20
 
-The shared Google Drive adapter obtains mutable control, intent head, and
-result head revisions from the bounded strong Drive v2 JSON `etag` field. It
-samples that value around one Drive v3 media read and sends the exact token only
-through a Drive v2 media `PUT` with `If-Match`. A stale token returns `412` and
-triggers exact current readback. Immutable discovery, creation, media reads,
-multipart upload, and resumable upload remain on Drive v3. Freed Desktop and
-the PWA consume the same adapter without a new request or cadence change. The
-native route admits only the exact v2 file paths, methods, query fields,
-headers, strong token, and bounded body. An authenticated disposable
-appDataFolder probe confirmed a strong v2 JSON ETag, one successful update,
-stale same-token `412`, v3 byte readback, and cleanup. Installed Primary and PWA
-acceptance remains gated.
+| Workstream | State | Current evidence | Next closing proof |
+| --- | --- | --- | --- |
+| Architecture and documentation | Complete | SQLite-everywhere architecture, detailed contract, phase changes, and deletion target are documented in PR #1603 | Keep these documents synchronized with every implementation checkpoint |
+| Executable contract source | Not started | Existing TypeScript and Rust registries provide source material | One IDL generates Rust and TypeScript types, codecs, registries, and drift checks |
+| Native core extraction | Foundation exists | `packages/library-core-native` contains SQLite authority, journal, actor, lease, and checkpoint foundations | Freed Desktop and headless entry points call the same final native core, with no Library semantics in Tauri |
+| Final normalized schema | Foundation exists | Existing native schemas and transition migrations cover much of the durable model | Final tables, indexes, locality rules, content descriptors, and schema manifest pass catalog verification |
+| Mutation registry | Partial foundation | Existing native and shared operation contracts cover several product writes | Every durable product write is registered, typed, atomic, capability-scoped, and consumed by a real entry point |
+| Query registry | Partial foundation | Several Freed Desktop surfaces already have bounded SQLite readers | Every Freed Desktop and PWA surface uses generated named SQL with stable keyset cursors and fixed budgets |
+| Normalized synchronization | Transport foundation exists | PR #1602 merged immutable byte-bounded page packing; authenticated control, receipts, and Drive object transport also exist | Stable normalized registry, typed native export, SQLite import, operation segments, intents, results, and content descriptors pass cross-runtime conformance |
+| PWA SQLite | Not started | Browser checkpoint, query, and intent behavior provides semantic source material | Official SQLite WebAssembly over OPFS passes iPhone durability, recovery, query, mutation, and synchronization tests |
+| Selective content plane | Design complete | Descriptor, chunk, range, hydration, and cache policies are specified | Desktop and PWA prove metadata-only, stream, partial-cache, full-cache, pinned-offline, and excluded modes |
+| Direct migration and cutover | Not started | Source census and migration contracts exist | One external-memory migration writes the final schema and activates one SQLite-only storage epoch |
+| Runtime deletion | Not started | Deletion registry is documented | Automerge, shells, shadow stores, IndexedDB Library rows, dual paths, and fallback flags are absent from runtime bundles and callers |
+| Acceptance and release handoff | Not started | Test and evidence requirements are documented | Exact-head native, browser, iPhone, installed Desktop, performance, crash, and response-loss evidence is complete |
 
-Freed Desktop now has a direct local SQLite cutover candidate at schema v12.
-It imports the retained legacy Automerge library once, verifies the complete
-item count and database integrity, and then uses SQLite for ordinary startup,
-queries, mutations, search, export, diagnostics, sample management, and daily
-backup and restore. Normal Desktop execution does not start the Automerge
-worker, the legacy LAN relay, or the Automerge cloud loops, and no ordinary UI
-surface may request a full renderer item corpus. The old Automerge bytes remain
-only as a pre-import rollback source. Immutable Library Core checkpoint sync,
-the PWA IndexedDB reader and intent client, and the editable follower are now
-implemented candidates. Installed production acceptance still determines when
-the cutover and follower can be declared complete.
+## Destination
 
-### Native SQLite authority establishment
+Freed uses SQLite everywhere:
 
-A fresh SQLite Library signs
-`freed_library_core_native_sqlite_genesis_v1`. The certificate commits one
-opaque Library ID, the authority key, `library_core_v1`, schema v12,
-`op_segments_v1`, `freed_logical_checkpoint_v1`, and an exact captured SQLite
-source manifest. Fresh establishment never fabricates an Automerge document or
-head.
+- Freed Desktop and the headless Primary use one extracted Rust core and
+  bundled SQLite.
+- The PWA uses official SQLite WebAssembly in a worker and stores the Library
+  in OPFS.
+- Every product view uses a bounded typed SQLite query.
+- Every durable edit uses a registered mutation.
+- React stores only visible windows and ephemeral interface state.
+- Google Drive carries typed normalized protocol objects and optional content
+  blobs, never database files.
+- One active Primary admits canonical writes. Followers submit signed intents
+  and apply signed canonical results.
+- Each client chooses which large content to stream, cache, pin, or exclude.
 
-An installation that already holds the retired legacy certificate keeps those
-canonical signed bytes as historical evidence. It may install exactly one
-`freed_library_core_native_sqlite_protocol_transition_v1` correction. The
-correction references the prior certificate digest and keeps the Library ID,
-epoch, authority key lineage, actor rows, cloud writer admission, follower
-anchor, Drive namespace, intents, results, and checkpoints unchanged. Exact
-replay returns the stored correction after response loss or restart. A changed
-correction, unrelated SQLite source lineage, missing persisted authority,
-multiple active local Libraries, or unavailable authority key fails closed.
-An already signed native genesis or historical correction that committed
-schema v11 remains valid after the journal migrates to schema v12. Its exact
-canonical certificate is preserved. Only schema v11 and v12 native
-certificates verify, and the active protocol receipt reports the migrated v12
-journal.
+## Delivery sequence
 
-Authority bootstrap reads the accepted journal state and any persisted cloud
-identity before deriving a fresh Library ID. The first local Desktop actor may
-be enrolled before a cloud control tuple exists, but that bootstrap exception
-grants no operation admission and cannot enroll a second actor. Canonical
-operations, ordinary enrollment, and provider outbox work require a present
-matching writer-admission row. No authority path reads Automerge bytes or
-synchronizes SQLite, WAL, or SHM files.
+Each stage lands final-model code. No stage introduces a compatibility shell,
+dual write, alternate row store, or temporary product architecture.
 
-Schema v12 binds each admitted actor to one explicit native operation
-capability. Existing v1 Desktop and PWA actors receive a separately frozen
-14-operation `legacy_editor` policy for their exact epoch. The policy cannot
-grow when the canonical registry gains another operation. New scraper and
-agent actors require an authority-signed v2 certificate that binds the Library,
-epoch, actor identity and key, class, sorted operation set, explicit scope,
-issuance identity, and retirement identity. Scrapers receive capture only by
-default. Missing scope denies authority. Library-wide scope must be named
-explicitly. Bounded provider or source scope is recorded but denies all
-operations until a future envelope version carries a canonical scope binding.
-The native journal checks this capability before admitting remote operations.
-It reverifies each v2 canonical enrollment and requires exact equality between
-the signed immutable fields and the capability cache. The immediate commit
-transaction reloads and rechecks the capability before writing.
-This slice prebinds retirement identity and enforces an already verified
-retired state. The authority-signed production retirement transition remains
-future work, along with verified retirement propagation in checkpoint actor
-rows. The TypeScript constructor and verifier are test-only executable
-conformance machinery, with no production issuance caller. The PWA remains a
-v1-only enrollment importer. Headless activation must implement or promote a
-consumed production API and wire both consumers before any v2 actor is
-published into production sync.
+### 1. Executable contract and generation
 
-Gate A is a dormant census. A1 adds the package-internal closed legacy
-bootstrap record, journal, control, receipt, bounded current and historical
-reserved-root scan, and state classifier. Together they make the current
-synchronized schema, shared store surface, Desktop and PWA worker messages,
-planned operation and query vocabulary, device-local authorities, and
-bootstrap transaction boundary reviewable by the compiler. They do not
-activate Library Core, change a writer, migrate data, or claim that unresolved
-codecs, field algebra, query projections, retention limits, authenticated
-adopter pairing, or the executable bootstrap transaction are complete.
+Build one source of truth for:
 
-Every planned successor remains `planned_blocked`. The combined census reports
-`activationAllowed: false` until the executable contracts and one durable
-legacy bootstrap transaction exist. Registry presence is not an activation
-receipt.
+- logical fields and locality
+- normalized tables and indexes
+- mutation names, inputs, capabilities, algebra, and effects
+- query names, inputs, outputs, ordering, indexes, and budgets
+- checkpoint record kinds and typed primary keys
+- operation, intent, result, manifest, and control objects
+- content descriptors, chunk records, and range indexes
+- physical schema and protocol compatibility
+- source migration mappings and final deletion obligations
 
-The pure bootstrap classifier remains package-internal during step 1a. Step 1b
-adds the first production caller and may then expose the contract through the
-shared Library Core entry point. Step 1a does not ship an unused public API.
-The storage prerequisite for step 1b uses IndexedDB schema version 2. It
-preserves version 1 bytes at save revision zero, fences every save and clear
-with the loaded generation and revision, and advances in-memory committed
-Automerge heads only after that storage compare-and-swap succeeds. The
-primitive alone does not change the active worker. A failed Automerge decode
-retains the exact loaded bytes and revision for recovery. It does not re-read
-storage before a clear, and it never treats allocation exhaustion or an
-unknown load failure as proof of corruption.
+Generate Rust and TypeScript types, codecs, validators, registry constants, SQL
+bindings, and conformance vectors. CI fails on generated drift, unregistered
+durable state, or registered exports without real callers.
 
-The first dormant step 2 slice now provides the native SQLite projection
-kernel. Rust and the shared TypeScript adapter are checked against one
-versioned canonical SQL file. Native projection batches atomically upsert and
-delete rows while advancing one projection revision, and bounded keyset cursors
-fail closed if that revision changes between pages. The registered 128-row
-maximum and 2 MiB serialized response ceiling are enforced at the adapter.
-Feed rows select only compact card fields inside SQLite, cap media and tag
-collections independently, and never return full content, preserved reader
-bodies, or the unmodelled-field escape object. The package-internal
-`feed_page_v1` protocol now closes the exact request, response, compact
-projection, source identity, nested bounds, and opaque source-bound keyset
-cursor for that existing default nonhidden, nonarchived page. Its parsers
-snapshot retained values and enforce both the row and serialized-byte ceilings.
-The dark base tier pins its busy timeout, 32 MiB page cache, file-backed
-temporary work, and disabled mmap. The module is compiled into Freed Desktop
-but has no production caller and opens no user database. Dormant Desktop and
-PWA runtimes now implement the narrow default page, and the PWA can
-authenticate and materialize its row generation without activating a reader.
-The current renderer and future bounded adapters also share one canonical
-normalized product-filter predicate. Both current workers also share one exact
-recommendation-order contract that preserves priority, published-time, and
-source-enumeration tie semantics. The PWA can now materialize a separate
-query-specific browse generation whose authenticated identity binds the
-normalized filter, one ranking clock, and the order version. It streams at most
-128 projected rows at a time and lets IndexedDB enforce the exact priority,
-published-time, and source-sequence order. A closed dormant request and cursor
-now read that physical order with the same filter, clock, and order-version
-binding. Desktop now has the parallel crash-resumable SQLite generation store:
-it stores the exact source document, sorted-head digest and count, storage
-revisions, and query identity, admits only 128-row and 2 MiB pages with exact
-replay receipts, finalizes only an exact physical row count, and performs the
-full keyset order through its checked index with a private 4 MiB page cache.
-Freed Desktop now exposes that store through a dormant session-bound writer
-transport. Begin, append, finalize, and cancel return exact durable progress,
-so a lost response can resume from the stored next batch without guessing.
-Only one generation can write at a time, and factory reset first drops that
-connection before deleting the derived files. A dormant Desktop worker
-materializer now authenticates the exact Automerge frontier and storage
-revision, binds the normalized filter and ranking clock, validates every
-closed feed-card DTO, and streams replayable pages of at most 128 rows to that
-writer. Its main-thread adapter recovers exact append and finalization response
-loss without retaining a corpus-sized row or ID array. The
-selected-generation registry, native browse reader, renderer-cache eviction,
-and product caller proof remain explicit blockers. This is progress inside
-Gate B and step 4, not a claim that either gate is complete.
+Exit proof:
 
-The Desktop derived-shadow path now also has a dormant bounded projection
-probe. It pins one exact durable Automerge frontier and storage revision, emits
-deterministic batches capped at 1,000 rows and 4 MiB, retains only a
-250,000-entry, 16 MiB entity-ID index plus one replayable batch, and releases
-the decoded Automerge document between requests. It still calls
-`Automerge.load`, so it is a temporary compatibility path for building and
-testing the derived SQL reader while Automerge remains authoritative. It cannot
-satisfy the external-memory Gate C migration contract or authorize cutover. No
-production caller consumes the responses yet. Immutable external entity
-materialization and the default opaque feed cursor are now closed. The exact
-recommendation order is defined, but product filter and ordering execution,
-cancellation across the main-to-native boundary, renderer-cache eviction, and
-product read assignment remain blocked.
+- native and browser vectors are byte-identical
+- schema and SQL catalogs match the generated manifest
+- every registered query and mutation has a consumer
+- the deletion registry identifies every retired runtime path
 
-The bounded migration path now verifies the immutable Automerge source through
-fixed-memory external runs and atomically stages its actor, head, change,
-dependency, operation, element-key, successor, and payload graph in private
-SQLite. Automerge document chunks omit delete rows by design, so the stage
-reconstructs each missing successor as one target-bound delete identity instead
-of requiring a fictional operation row. It rejects an explicit delete row,
-one delete ID attached to unequal targets, a non-Lamport successor, or an
-explicit successor attached to another target. The schema enforces every
-remaining graph reference, and its receipts bind one exact source identity. A
-final bounded seal verifies contiguous per-actor change sequences and operation
-counters across stored operations and reconstructed deletes, then streams one
-canonical digest over all staged metadata, relationships, and payload bytes.
-The next immutable receipt selects every visible non-increment operation whose
-successors are all explicit increments. Increment rows do not become separate
-values or hide the counter they adjust. Explicit non-increment updates and
-omitted deletes remove their predecessors. Every concurrent visible operation
-remains instead of inventing one winner. This closes migration ingestion and
-the current-operation frontier. Counter arithmetic, object and sequence
-reconstruction, registered entity materialization, full-corpus parity,
-authenticated authority admission, and activation remain blocked.
+Estimated machine time: 2 to 4 focused conversations, approximately 1 to 2
+hours.
 
-The dormant migration chain now continues through complete FeedItem topology,
-bounded JSON reconstruction, and lossless native row projection. It keeps
-temporary object values in scratch SQLite and holds only one bounded document
-and row in native memory. The row stage shares the native shadow-store shape,
-admits only faithful strings, booleans, and JavaScript-safe integers into typed
-columns, and preserves every other value through explicit absence, raw,
-nested-rest, and blob-tier escapes. Its receipt binds the complete projected
-row sequence to the exact reconstructed-document receipt. Rust and TypeScript
-use the same recursive UTF-8 object-key order for projected JSON, and replay
-reprojects every document before accepting stored rows. A bounded population
-bridge now pins one verified scratch snapshot and copies those rows into the
-existing crash-resumable generation in deterministic receipt-bound pages. It
-resumes from the destination's durable row count after response loss and never
-retains the projected corpus in Rust memory. The package-internal default feed
-protocol can validate a bounded page from an immutable generation, but no
-product reader calls it. Full-corpus parity, production storage admission,
-active query adapters, and activation remain blocked.
+### 2. Final native database foundation
 
-Physical shadow schema version 4 now closes the native staging transaction
-inside one database and adds the archived-eligible Friends timeline index.
-A fresh staging file records the exact source identity, sequential batch
-receipts, projected row count, revision, and completion state. Rows and
-receipts roll back together, an interrupted process resumes at the exact next
-batch, and bounded reads reject the database until the declared and actual row
-counts both close. Version 3 generations remain immutable and cause a fresh
-schema-keyed generation instead of an in-place rewrite.
+Complete `packages/library-core-native` as the only native Library engine.
+Move schema opening, migrations, authority, mutation execution, query
+execution, checkpoint staging, content-vault access, backup, recovery, and
+process exclusion behind runtime-neutral Rust APIs.
 
-The dormant native publisher now seals a complete staging database into one
-immutable generation file. It checkpoints and removes WAL mode, verifies
-SQLite and the exact rebuild state, syncs the bytes, performs a same-directory
-durable no-replace publication, and verifies the destination read-only. Unix
-uses an exclusive hard-link publication point, so a racing destination cannot
-be overwritten. Selecting that file for a reader remains separate. The
-production storage-root handle, generation transition, stale-reader lifetime,
-rollback pointer, and cleanup policy are still blocked.
+Freed Desktop becomes a Tauri host adapter. The headless Primary becomes a
+second host of the same core. Neither host forks Library behavior.
 
-Freed Desktop now has one production-located startup bridge through that
-external decoder and publisher. Before the worker loads Automerge, it pins the
-exact IndexedDB generation and save revision, transfers fixed 1 MiB chunks into
-a crash-resumable native spool, reconstructs the source through disk-backed
-SQLite stages, and selects or replays one verified immutable derived
-generation. The durable spool identity survives renderer replacement, and
-failure releases live handles while preserving retry evidence and falling back
-to Automerge. After both sides confirm, the bridge deletes that revision's
-spool and scratch graph and retains only the selected and exact rollback
-projection generations.
+Exit proof:
 
-Gate D now serves the bidirectional all-content feed, item detail, exact
-Library facets,
-bounded Map and Story Wall candidates, Saved overview analytics, the four-mode
-Saved feed, the Friends-only feed, Friends
-activity, selected-person timelines, and Friend editor author candidates, export,
-background content discovery, provider
-completion accounting, RSS duplicate lookup, Google Contacts discovery, and
-account discovery from authenticated selected SQLite generations. Provider
-settings scan exact source-fenced 64-row SQLite pages for Facebook group
-repair, Facebook and Instagram media backup, and YouTube saved-video
-synchronization without retaining the `FeedItem` corpus. Media candidates are
-compact-staged locally and provider work begins only after the final source
-fence closes. SearchJump reads exact Library tags, archive totals, and complex scope
-counts from one bounded source-fenced scan, simple scope counts from compact
-aggregates, and one selected item detail. On the healthy default native path,
-palette focus and search do not lease the renderer corpus. Native failure or
-rollback uses the compatibility fallback. Its existing Automerge bulk mutation
-takes a short-lived compatibility lease only after the user runs it; native
-frozen-predicate bulk execution remains the cleanup for that action path. Header and
-sidebar counts share one source-versioned native aggregate. The default Desktop
-shell retains no item objects. Incremental Automerge patches carry one prior
-item occurrence so exact counts stay current without rebuilding the corpus.
-The Saved feed reads all four user-facing sort modes through source-fenced
-128-row SQLite pages, retains at most the current and adjacent page, and
-traverses the complete result without returning to compatibility at the old
-512-row limit. Its versioned native order uses one pinned recommendation clock
-and binary global-ID ties without retaining a corpus-sized source-order index.
-The Freed Desktop compatibility fallback uses that same clock and order. The
-PWA keeps its existing Saved ordering. Registry cleanup holds its write
-transaction while choosing retired generations and steadily retains current
-plus exact rollback. If cleanup fails after selection commits, the selection
-remains authoritative, the extra retired files remain non-authoritative, and a
-later selection retries cleanup.
-ReaderView may pin exactly one selected compact card after its feed page is
-evicted, and keeps the existing local-content and hydration path.
-The non-Saved Friends-only feed, when no search is active, uses the versioned
-`feed_browse_page_v2` request with `identityMode: "friends"` and Friends
-predicate schema version 1. It preserves
-the current Person-first Account resolution and legacy Friend-source fallback,
-then pages the filtered immutable generation through the ordinary browse order
-and bounds. Its materializer retains source positions for no more than the
-current 64-row native scan page. Ranking-weight or identity movement replaces
-the exact source-bound generation. React retains two pages plus one selected
-compact card so eviction cannot dismiss ReaderView. Version 1 and its
-all-content callers remain unchanged. A stale source, predicate mismatch,
-unavailable reader, or explicit rollback returns to the exact Automerge
-compatibility feed. The PWA remains unchanged.
-Friends search, Friends plus Saved, and other unfinished consumers share one
-reference-counted compatibility projection only while mounted, then evict it.
-Source mismatch or reader failure returns to Automerge.
-The ordinary all-content feed now traverses the complete result in both
-directions through the bidirectional `feed_browse_page_v3` request. It carries
-an explicit `next` or `previous` direction and returns both exclusive edge
-cursors bound to the exact generation and the exact first and last rows of the
-page. Backward reads mirror the forward keyset predicate through the same
-unique index, so both directions share one canonical order. React keeps two
-whole pages plus at most one pinned selected card, restores an evicted leading
-page when the user scrolls back, and holds the visible list anchored across the
-shift. The old 512-card compatibility escape hatch is retired: deep scrolling no
-longer reacquires the full renderer projection. Version 1 and version 2 wire
-shapes and their PWA, Friends, and Saved callers are unchanged. The device-local
-`freed.libraryCore.feedBrowseReaderV1.disabled=1` switch disables the feed
-reader, `freed.libraryCore.savedAnalyticsReaderV1.disabled=1` disables the
-Saved aggregate, `freed.libraryCore.savedFeedReaderV1.disabled=1` disables the
-Saved feed reader, `freed.libraryCore.friendsReaderV1.disabled=1` disables the
-Friends workspace readers,
-`freed.libraryCore.friendsFeedReaderV1.disabled=1` disables the Friends-only
-feed reader,
-`freed.libraryCore.feedBrowseBidirectionalReaderV1.disabled=1` returns the
-ordinary all-content feed to the Automerge compatibility projection,
-`freed.libraryCore.providerSettingsReaderV1.disabled=1`
-restores provider settings to the compatibility projection,
-`freed.libraryCore.friendEditorReaderV1.disabled=1` restores the Friend editor
-compatibility lease, `freed.libraryCore.searchJumpReaderV1.disabled=1`
-restores SearchJump compatibility, and
-`freed.libraryCore.rendererItemEvictionV1.disabled=1`
-restores the full renderer projection at startup. This does not satisfy Gate C or complete
-Gate D. IndexedDB v3 now stores the legacy Automerge source as exact 1 MiB
-chunks. External migration admits only the exact revision and byte length, then
-reads one revision-fenced chunk per transaction. Existing v1 and v2 stores
-perform one atomic versionchange split, after which migration no longer creates
-a source-sized structured clone. Before native decode, the finalized source is
-bound to the Desktop installation and signed with a device-held Ed25519 key.
-The exact immutable local receipt is read back and verified, while macOS vault
-access disables user interaction and fails closed instead of prompting. This
-legacy source-admission receipt is domain-separated from the future elected
-migration-candidate claim and grants no writer or cloud authority. The worker
-still owns the decoded Automerge document. Windows uses its native credential
-vault. Linux remains on the Automerge rollback path until it has a proven
-noninteractive platform vault. The next active milestone is
-conversion of the remaining compatibility surfaces and worker-corpus eviction,
-followed by complete elected migration authority admission.
+- a headless fixture and Freed Desktop open the same database format
+- two processes cannot write one data root
+- unknown schema, registry, or protocol versions fail before write authority
+- Tauri contains no Library schema, SQL, or mutation semantics
 
-### Process lifetime data-root exclusion
+Estimated machine time: 3 to 5 focused conversations, approximately 2 to 3
+hours.
 
-Every native Library Core runtime now takes one operating-system-backed
-exclusive lease on its canonical data root before SQLite can open. Freed
-Desktop holds the lease in process-managed state until exit. A future headless
-service must use the same primitive for the same root. A contender fails
-closed with both process IDs when the holder PID is readable, plus the exact
-data root, lock path, executable, package, version, and refusal time. Each
-failure overwrites one bounded `process-last-refusal.json` file, so diagnostics
-remain available when a release Windows app has no console without accumulating
-one file per launch. Clean exit releases the kernel lock and truncates its
-diagnostic PID. A killed process can leave stale PID text, but the kernel
-releases the actual lock and the next process replaces that text after it
-acquires the handle. The persistent `process.lock` file is local control state,
-not cloud authority or a database transport object.
+### 3. Complete mutations and normalized materialization
 
-## What the evidence establishes
+Route every retained product write through the generated mutation registry.
+This includes item state, highlights, notes, feeds, subscriptions, people,
+accounts, relationships, tags, graph state, ranking policy, capture policy,
+preferences, saved-link capture, provider capture, imports, maintenance,
+tombstones, and content metadata.
 
-On the owner's 15,846-item production document, the current Automerge and
-WebKit design amplifies a small serialized corpus into hundreds of MiB of
-resident memory. Larger synthetic documents scale roughly linearly. Full
-document hydration, full-array derivations, binary copies, search indexes, and
-provider WebViews then compete inside one memory-constrained application.
+Each mutation commits canonical rows, journal occurrence, materialized effects,
+actor tip, tombstone or cascade effects, receipt, replication outbox, and
+invalidation topics in one SQLite transaction.
 
-The evidence supports these conclusions:
+Exit proof:
 
-- A paged row store can answer bounded library queries without materializing
-  the corpus in the renderer.
-- `WebAssembly.Memory` does not shrink, so terminating an idle legacy worker is
-  more reliable than hoping its peak allocation returns to the operating
-  system.
-- Desktop search is built from truncated text today.
-- The PWA's 2,500-item hydration cap limits the final message, not the
-  full-corpus work performed before it.
-- Facebook and Instagram captures have been blocked by memory pressure. Lower
-  library memory can allow existing scheduled attempts to complete.
+- every product write maps to one registered mutation
+- retry is idempotent
+- capability and writer-epoch checks fail closed
+- legal large fields become content descriptors and bounded chunks
+- no generic JSON patch, shell mutation, or JavaScript cascade remains
 
-The evidence does not yet establish a universal 200 MiB renderer floor,
-15 millisecond cold start, multi-million-item ceiling, or a precise amount of
-memory attributable to Automerge alone. Those are hypotheses until the
-process-safe attribution harness and matched fixtures measure them.
+Estimated machine time: 5 to 8 focused conversations, approximately 3 to 5
+hours.
 
-## Corrections to the earlier roadmap
+### 4. Complete bounded queries
 
-The previous version contained five unsafe premises:
+Route feed, Saved, search, item detail, Friends, map, Story Wall, analytics,
+facets, counts, settings, exports, diagnostics, and selected content through
+named SQL. Use stable keyset cursors and explicit byte and row budgets.
 
-1. **Cloud convergence already exists.** Desktop and PWA cloud paths merge
-   Automerge documents. The ETag compare-and-swap prevents one manifest or blob
-   replacement from blindly overwriting another. It is not the semantic merge.
-2. **Automerge cannot be deleted before replacement sync exists.** Doing so
-   would turn two writable clients into divergent databases.
-3. **A SQL writer flip is not independently reversible.** Rollback is safe only
-   from a compatibility state proven at the same frontier.
-4. **A filtered UI projection is not migration input.** Hidden records,
-   truncated text, absent values, relationships, and source-head identity must
-   come from an immutable raw source.
-5. **A Web Worker is still a WebKit process.** The corpus leaves renderer
-   memory only when the worker no longer retains it.
+Add a compact invalidation stream keyed by registered topics. Views refresh
+only the pages or aggregates affected by a committed mutation.
 
-The implementation order below is built around those corrections.
+Exit proof:
 
-## Engine decision
+- every view queries SQLite directly through its platform adapter
+- no query returns or scans the corpus in JavaScript
+- query plans use registered indexes at 25,000 and 100,000 items
+- renderer and worker memory stay bounded while traversing the full Library
 
-Desktop uses stock SQLite through Rust.
+Estimated machine time: 5 to 8 focused conversations, approximately 3 to 5
+hours.
 
-The PWA MVP uses IndexedDB through the same strict logical Library Core adapter
-and conformance suite as every future browser engine. It stores bounded record
-pages, tombstones, search postings, cursors, intents, and result receipts. It
-does not retain the full corpus in JavaScript memory. SQLite WASM with OPFS is a
-future measured adapter, not an MVP dependency. A later engine can rebuild from
-immutable cloud objects and activate only after verification. Product logic
-does not fork by storage engine.
+### 5. Normalized wire protocol
 
-Private-corpus Automerge decoding runs only on an elected installation that
-holds the current authenticated migration claim. It is resumable, uses the
-external-memory decoder, stays under the fixed 384, 512, or 768 MiB tier
-ceiling, and proves enough private staging capacity for source-sized runs.
-Other installations bootstrap by streaming and verifying the accepted logical
-checkpoint, blob roots, and operation segments. Every adapter proves public
-migration vectors and its own installation-qualified, fenced device-local
-source contribution. A low-memory browser does not decode the owner's full
-legacy corpus merely to prove that it can run Library Core.
+Implement `freed_normalized_checkpoint_v2` as a stream of closed typed records.
+Record identity is the stable registry key plus canonical typed primary key.
+Page order is never logical identity.
 
-Turso remains rejected for this role. The measured evaluation in
-[TURSO-EVALUATION.md](TURSO-EVALUATION.md) found unacceptable incremental FTS
-behavior, resident memory, and silent index-maintenance failure. Adoption
-depends on those probes changing, not on a version number.
+The transport profile uses:
 
-## Delivery order
+- at most 131,072 canonical bytes per logical record, frozen after the required
+  physical measurements
+- at most 128 records per page
+- at most 2,097,152 decoded canonical bytes per page
+- at most 1,048,576 source bytes per native export response
+- content descriptors and content-addressed chunks for larger legal values
 
-Each step is separately reviewable. "Dark" means code may ship but cannot own
-user data yet.
+Add append-only operation segments, signed follower intents, signed Primary
+results, authenticated manifests, content descriptors, and range indexes. Keep
+Google Drive endpoints, headers, retries, OAuth behavior, and cadence unchanged.
 
-| step | delivery | activation condition |
-| --- | --- | --- |
-| 0 | Process-safe memory attribution and matched tier fixtures | Exact build and process-generation evidence, no startup stall |
-| 1a | Close the Library Core registries and legacy epoch bootstrap contract | The dormant census is complete; every synchronized field then gains executable algebra, locality, deletion, storage, operation, and query contracts; the exact digest-addressed in-document bootstrap record, bounded complete current and historical reserved-root scan, source-descended prepared journal, local control, receipt, identity codecs, digest equations, creator and TOFU read-only adopter states, conflict rules, and value-only history-rebuild fence are closed and runtime-neutral |
-| 1b | Implement the dormant legacy epoch bootstrap transaction | IndexedDB v2 first preserves legacy bytes at revision zero and fences every save or clear with the exact loaded generation and save revision; repeatable Automerge persistence derives deltas from durable heads and publishes candidate bytes and heads only after compare-and-swap; one explicit local owner action prepares an exact journal; the adapter loads staged candidate bytes by digest, proves their bound heads and record occurrence, then one compare-and-swap commits the record-bearing Automerge document, creator control, receipt, retained journal, and next revision atomically; another installation pins only TOFU read-only control until authenticated authority-holder pairing exists; ordinary saves update the current control frontier atomically with their own operation provenance; exact retry does not re-prompt; startup absence requires empty current and historical reserved-root scans and never prepares authority; deleted roots and unequal records block without winner selection; any compatibility rebuild preserves recorded history or is fenced after bootstrap |
-| 2 | Dormant Rust SQLite core and shared operation fixtures | Crash-safe complete transaction receipts, signature and fork rejection, and identical cross-platform materialization |
-| 3 | Authenticated elected Automerge migration authority plus bounded device-local source contributions | Candidate registration is the first claim-bound mutation, and registration races state-correct candidate-absent abandonment and cleanup in one serialization domain; cloud claims use authenticated store time and expiry; local claims use null timestamps and never self-expire; every claim-bound source, candidate-registry, and cutover mutation uses a closed noncircular payload-bound grant; cloud source commits require the original runtime-owned process generation and live monotonic attempt handle; migration and rollback split corpus-sized prepared proofs from a maximum 65-fence, 2 MiB activation sidecar committed in one atomic authority bundle; rollback uses its own signed reservation and activation schema; full-field private-corpus diff, composite source identity, resumable receipts, changed-head rejection, and adapter fixture parity pass |
-| 4 | Bounded Desktop query API | Stable cursors, explicit limits, cancellation, count and search parity |
-| 5 | Desktop surfaces read verified SQL projection | No visible surface requires the full item array |
-| 6 | Short-lived legacy compatibility engine | Automerge worker terminates after bounded work; provider WebViews do not overlap it |
-| 7 | Dormant PWA Library Core adapter | Browser durability matrix, operation fixture parity, and bounded accepted-checkpoint bootstrap without private-corpus Automerge decode |
-| 8 | Immutable operation-segment cloud sync | Two-device offline and CAS-conflict convergence through signed actors and one global authority pointer |
-| 9 | Coordinated storage-epoch cutover | Desktop and PWA switch writer and protocol through one signed transition certificate; legacy clients are fenced into their retired namespace |
-| 10 | Installed-build soak and rollback window | Tier memory, sync, provider extraction, recovery, export, and import gates pass |
-| 11 | Automerge retirement | No supported writer needs it and roll-forward recovery is proven |
+Exit proof:
 
-The first large memory win arrives at steps 5 and 6. SQL can serve bounded
-reads while the authoritative legacy worker becomes short-lived. The final
-architectural simplification arrives only after step 9.
+- a legal maximum-sized item round-trips losslessly through native and browser
+  SQLite as bounded records
+- every record validates before import
+- incomplete, duplicated, reordered, oversized, or mismatched data fails before
+  activation
+- no `00_library_shell`, `shellJson`, whole FeedItem JSON, or SQLite file enters
+  the transport
 
-Before step 5 completes, every full-corpus product and UI consumer must move
-behind the bounded core: classification, content fetch, provider-action
-derivation, product-facing cloud and LAN sync, search, Friends, map, counts,
-startup maintenance, duplicate analysis, snapshot, backup, and export. The
-registered short-lived legacy migration and replication bridges may remain
-through Gate D until Gate E replaces them. Moving only React while another
-WebKit product worker keeps scanning the corpus is not renderer eviction.
+Estimated machine time: 4 to 7 focused conversations, approximately 3 to 5
+hours.
 
-## Provider boundary
+### 6. PWA SQLite and editable follower behavior
 
-This program does not add provider requests, navigation, scrolling, clicking,
-cookies, headers, or a faster schedule.
+Run official SQLite WebAssembly in one worker and persist the Library in OPFS.
+Use the generated schema, SQL, result DTOs, mutations, codecs, and vectors.
 
-The first slice capable of turning a memory-rejected Facebook or Instagram
-attempt into real provider contact is provider-observable. The owner approved
-this exact effect for the existing Facebook and Instagram schedule in
-`codex-task:019f4ce3-2ee3-76b2-bc0c-eb7f4958a7de`: "You are fully authorized to
-continue this optimization in ways which will increase provider pull frequency
-by fixing cases where we were previously unable to pull." The provider can see
-successful contact where memory rejection previously produced none. The
-lowest-profile alternative is to keep rejecting those attempts and leave that
-data unsynced. The decision remains in scope only while cadence, retry policy,
-requests, navigation, cookies, headers, and extraction behavior remain
-unchanged. The first active slice must cite that exact decision and write and
-validate its healthy Gate 1 artifact before publication. It does not need
-another approval for the same behavior. Dormant storage, migration, and query
-work remains provider-free. Any later change to provider cadence, retry policy,
-request shape, WebView behavior, cookies, headers, or extraction code requires
-its own provider-risk decision before implementation.
+Store canonical replica rows, indexes, search, intent outbox, result receipts,
+and the sparse optimistic overlay in SQLite. A narrow IndexedDB keystore may
+remain only for nonextractable keys when WebKit provides no suitable
+alternative.
 
-Provider extraction follows a two-phase memory boundary during migration:
+Exit proof:
 
-1. capture results enter a durable local capture journal;
-2. the provider WebView closes;
-3. the library engine wakes and materializes the journal;
-4. the library engine returns to its settled budget or terminates.
+- iOS 17 physical-device tests cover persistence, suspension, worker loss,
+  quota pressure, recovery, and offline playback
+- every PWA view uses bounded SQLite queries
+- intent and result reconciliation survives restart and response loss
+- IndexedDB contains no Library rows, cursors, checkpoints, search state,
+  intents, results, or compatibility state
 
-No in-memory handoff may require both the full legacy corpus and the provider
-WebView to stay resident.
+Estimated machine time: 4 to 7 focused conversations, approximately 3 to 5
+hours.
 
-## Integrity work that cannot be skipped
+### 7. Selective content plane
 
-The storage cutover must also repair these existing boundaries:
+Separate logical metadata replication from large byte hydration. A descriptor
+identifies the content, rendition, length, digest, chunk or range structure,
+and available sources. Each client stores its own hydration and retention
+policy.
 
-- Markdown export is a sharing format, not a complete backup.
-- Import reports parsed items before all durable phases finish and is not one
-  resumable transaction.
-- Current snapshots write Automerge and contact state as separate files.
-- Current destructive deduplication is heuristic and order-sensitive.
-- Deletion lacks a durable row-level tombstone contract.
-- Several current field policies still describe PWA convergence as absent,
-  which is no longer factually correct.
+Exit proof:
 
-These are part of Library Core correctness. They are not reasons to preserve
-the current full-document architecture.
+- Freed Desktop can pre-download and verify multi-gigabyte video without
+  loading it into application memory
+- PWA can stream selected ranges, cache a subset, pin a complete rendition, or
+  exclude the asset
+- metadata checkpoints remain complete when no content bytes are local
+- garbage collection preserves every canonical, pinned, checkpointed, backed
+  up, or actively transferred object
 
-## Test and evidence routing
+Estimated machine time: included across stages 3, 5, and 6.
 
-The following blocking-proof groups are illustrative. The closed universal
-gate registry and proof requirements in
-[LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md) are binding:
+### 8. Direct migration, cutover, and deletion
 
-- transaction crash recovery;
-- actor signature, retirement, fork detection, and deterministic repair;
-- complete transaction-member delivery without partial materialization;
-- future-clock quarantine and certified repair;
-- migration claim races, response loss, interruption, and source change;
-- exact payload-bound operation grants, grant-bound live source attempts,
-  candidate registration versus absent-state abandonment, reservation and
-  activation races, dead-claimant abandonment, state-correct absent cleanup,
-  persistent registered-candidate cleanup, and deleted-payload closure;
-- prepared migration and rollback proofs, signed rollback fences, exact
-  prepared-proof binding, 65-fence and 2 MiB finalization boundaries, one
-  atomic sidecar bundle, deadline release, and no corpus or genesis-closure
-  work while fences are active;
-- global epoch and same-epoch manifest races, compound authority-state
-  compare-and-swap, prepared-transition recovery, and legacy fencing;
-- cutover, rollback, authority recovery, and concurrent-restore receipts;
-- recovery supersession for a consumed active or abandoned migration lifecycle;
-- duplicate and response-loss replay;
-- reusable native materializer ownership and a thin Freed Desktop crate
-  adapter, pinned by
-  [`native-materializer-binding.test.ts`](../packages/shared/src/library-core/native-materializer-binding.test.ts);
-- two-device offline convergence through authenticated branch-qualified
-  manifests;
-- schema and database-plus-blob snapshot atomicity, including missing and
-  corrupt replicated blobs;
-- bidirectional Desktop and PWA encrypted backup and restore, including
-  paged-inventory bootstrap, recursive media-exclusion lineage, and busy
-  same-transition descendant registration;
-- complete reader lookup plans and authenticated hit, missing, or error probe
-  outcomes without Cache enumeration or network fallback;
-- import idempotency;
-- bounded query, full semantics beyond the legacy 2,500-item cap, and activated
-  4 GiB startup admission.
+Read the source Library through a bounded external-memory migration process and
+write directly into the final SQLite schema. Record an explicit result for
+every source field and content object. Activate one SQLite-only storage epoch
+after parity, authority, checkpoint, backup, and follower import proof.
 
-The private corpus, 100,000-item performance, large randomized convergence
-matrix, browser compatibility sweep, and six-hour memory slope remain
-mandatory evidence in dedicated or nightly lanes. They do not belong in every
-ordinary feature or release workflow.
+Rollback is allowed only before a later canonical write and only to the same
+frontier. After a later write, recovery rolls forward from immutable logical
+objects and backups.
+
+Delete:
+
+- Automerge runtime, worker, persistence, merge, and cloud paths
+- `shellJson`, `shell_json`, `DesktopLibraryShell`, and equivalent shells
+- monolithic `DocState` and whole FeedItem checkpoint records
+- shadow stores, shadow readers, compatibility leases, and dual-engine flags
+- IndexedDB Library generations, rows, indexes, overlays, and cursors
+- ordinal checkpoint identity
+- whole-corpus subscriptions and renderer state
+- generic patch and toggle mutation routes
+- database, WAL, SHM, and rollback-journal cloud transport
+- rollback flags that revive retired engines
+- dead migrations, repair routes, exports, tests, and vocabulary with no final
+  product requirement
+
+Exit proof:
+
+- production bundles contain no retired runtime engine or payload
+- source parity and exclusion closure cover every retained field and byte
+- the Primary publishes a normalized checkpoint for the new storage epoch
+- Freed Desktop and a physical iPhone import and query the exact checkpoint
+- deletion scans, caller scans, release inspection, and migration receipts pass
+
+Estimated machine time: 6 to 10 focused conversations, approximately 4 to 7
+hours.
+
+### 9. Acceptance and release handoff
+
+Run native and browser conformance, fault injection, performance fixtures,
+physical iPhone storage and media tests, installed Freed Desktop verification,
+and exact-head integration validation. Reconcile every affected PHASE document
+and `roadmap-status.json` with the measured result.
+
+Exit proof:
+
+- exact commit and tree are recorded
+- all required local and CI checks pass
+- installed build identity matches the candidate
+- the acceptance receipt names schema, protocol, registry, migration,
+  checkpoint, content, browser, and performance evidence
+- remaining work is either zero or recorded as a deduplicated `debt` issue
+
+Estimated machine time: 4 to 7 focused conversations, approximately 3 to 5
+hours. Physical-device access, soak windows, CI queues, release, installation,
+and activation are external elapsed time.
+
+## Total estimate
+
+The initial estimate from executable contract through release-ready candidate
+is 33 to 56 focused implementation conversations and approximately 22 to 37
+hours of machine execution. The estimate is updated from measured stage
+receipts after each checkpoint.
+
+## Operational boundaries
+
+The implementation program does not imply authority for provider traffic,
+provider-observable behavior changes, Google Drive behavior changes, release,
+installation, deployment, live-data migration, writer-epoch cutover, or
+destructive cleanup. Those operations retain their separate controls and
+evidence requirements.
+
+Product implementation updates affected PHASE documents and
+`roadmap-status.json` in the same commit as each checkpoint. The public website
+roadmap remains in its separate `www` lane.
 
 ## Completion
 
-The roadmap is complete only when:
-
-- Desktop and PWA use one replicated operation contract;
-- every visible library read is bounded;
-- one atomic epoch owns writes;
-- delete, offline conflict, replay, response loss, migration, rollback, import,
-  snapshot, and recovery have deterministic proof;
-- the installed application meets the tier budgets in the Library Core
-  contract;
-- Facebook and Instagram can run their existing schedule without library
-  memory starvation;
-- Automerge and its full-document containment machinery are removed from every
-  supported writer.
+The program is complete only when every supported client queries SQLite,
+every durable write uses a registered mutation, synchronization uses only
+normalized typed protocol objects, selective content behavior works on real
+devices, the SQLite-only epoch is active, and every retired runtime path in the
+deletion list is absent.

--- a/docs/TURSO-EVALUATION.md
+++ b/docs/TURSO-EVALUATION.md
@@ -6,6 +6,16 @@ Decided 2026-07-24, re-verified 2026-07-25 against Turso 0.7.1. This document ex
 
 Reproduction scripts and raw results are in [`docs/turso-evaluation/`](turso-evaluation/).
 
+## Architecture consequence
+
+This decision now governs the complete Library Core. Freed Desktop and the
+headless Primary consume a bundled stock SQLite build through the same
+extracted Rust core. The PWA consumes official SQLite WebAssembly over OPFS.
+Both runtimes use one checked-in SQL catalog, generated typed bindings, and one
+cross-runtime conformance suite. IndexedDB is not a Library row engine or
+fallback. SQLite database files remain local and never become synchronization
+or backup transport.
+
 ---
 
 ## Read this first if you are here to relitigate

--- a/docs/YOUTUBE-INTEGRATION.md
+++ b/docs/YOUTUBE-INTEGRATION.md
@@ -217,6 +217,40 @@ context.
 The feasible design moves resolution and packaging to Freed Desktop, then moves
 the resulting package to the PWA. The PWA does not resolve YouTube streams.
 
+### Shared selective-content contract
+
+Offline media uses the Library Core content plane defined in
+[LIBRARY-CORE-ARCHITECTURE.md](LIBRARY-CORE-ARCHITECTURE.md). YouTube-specific
+resolution produces a rendition. It does not invent a second synchronization
+system.
+
+The normalized Library checkpoint contains only typed content descriptors. It
+never contains media bytes or a whole package serialized as one logical
+record. One rendition may be hundreds of megabytes or multiple gigabytes while
+each checkpoint record remains within the initial 131,072-byte canonical
+ceiling.
+
+Each rendition is one content-addressed logical blob with a paged authenticated
+range index. Clients can verify selected ranges without downloading the whole
+blob. Range leaf size is a measured content-plane parameter. It is independent
+from checkpoint record size. The implementation must benchmark 1 MiB, 4 MiB,
+8 MiB, and 16 MiB leaves before freezing the media profile.
+
+Hydration policy is device-local and supports these states:
+
+- Metadata only
+- Stream on demand
+- Partial verified cache
+- Fully cached
+- Pinned offline
+- Excluded
+
+A Freed Desktop installation may pre-download and pin a long-form video. An
+iPhone may cache audio only, selected video ranges, or a complete rendition.
+Another client may stream through the approved Google Drive transport or
+exclude the rendition entirely. These choices never alter canonical Library
+metadata, checkpoint identity, or another device's policy.
+
 ### Audio-First Package
 
 Audio is the first supported rendition because it best serves focused study,
@@ -273,9 +307,11 @@ a provider change does not masquerade as storage corruption.
 
 ### Transfer Order
 
-Media bytes never belong in Automerge, the normal document relay, application
-logs, bug reports, or rotating document snapshots. Only a small package record
-and, if useful, a device-keyed availability summary may enter synced metadata.
+Media bytes never belong in checkpoint rows, application logs, bug reports, or
+SQLite file transport. Only typed content descriptors, authenticated range
+roots, and canonical rendition metadata enter normalized synchronization.
+Hydration, cache range maps, eviction state, playback position, and local
+availability stay device-local.
 
 Transfer should follow this order:
 
@@ -412,11 +448,12 @@ Before starting, the PWA should:
 6. Resume from the last verified chunk after interruption.
 7. Mark the rendition offline only after every chunk and final checksum pass.
 
-The app shell, artwork, and small metadata can stay in the Cache API and
-IndexedDB. Large media should use the Origin Private File System, with IndexedDB
-holding the searchable package index and download state. OPFS is available in
-modern iOS Safari, is scoped to the Freed origin, and is still governed by
-browser quota and eviction policy.
+The app shell and bounded static assets can stay in the Cache API. Library
+metadata, the searchable content index, intent state, range map, and download
+state live in SQLite WebAssembly over OPFS. Large media lives in the same
+origin's content vault as separate OPFS files. IndexedDB is not a Library or
+media-index store. A narrow IndexedDB keystore may remain only for
+nonextractable WebCrypto keys when WebKit offers no suitable alternative.
 
 Cloud objects remain encrypted in transit and at rest. After download, the PWA
 should authenticate and decrypt into the final OPFS media file. Locked-screen
@@ -443,8 +480,8 @@ Freed should maintain a user-visible storage budget and apply these rules:
 - Evict least-recently-played unpinned packages next.
 - Keep metadata after media eviction so the item remains saved and can be
   downloaded again.
-- Reconcile IndexedDB against OPFS on startup, resume, and before claiming that
-  an item is offline.
+- Reconcile SQLite content descriptors and range state against the OPFS vault
+  on startup, resume, and before claiming that an item is offline.
 - Surface the reason for every automatic eviction and the bytes recovered.
 
 `Available offline` means that the selected rendition exists on this device and

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -22,7 +22,7 @@
       "status": "current",
       "source": "docs/PHASE-5-DESKTOP.md"
     },
-    { "id": 6, "status": "complete", "source": "docs/PHASE-6-PWA.md" },
+    { "id": 6, "status": "current", "source": "docs/PHASE-6-PWA.md" },
     {
       "id": 7,
       "status": "current",

--- a/scripts/validate-roadmap-status.test.mjs
+++ b/scripts/validate-roadmap-status.test.mjs
@@ -18,7 +18,7 @@ test("roadmap status manifest matches every phase document", () => {
   );
   assert.equal(
     manifest.phases.find((phase) => phase.id === 6)?.status,
-    "complete",
+    "current",
   );
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- State the architecture directly: Freed uses SQLite everywhere across Freed Desktop, the headless Primary, and the PWA.
- Define bounded typed queries and mutations, normalized logical-object synchronization, signed follower intents, selective content hydration, direct SQLite-only cutover, and explicit runtime deletion targets.
- Separate durable architecture from current engineering status. The storage roadmap and PHASE documents now carry dated implementation checkpoints.

## Testing
- `node --test scripts/validate-roadmap-status.test.mjs`
- `node scripts/validate-roadmap-status.mjs`
- `node scripts/validate-main-backflow.mjs --dev-ref=origin/dev --main-ref=origin/main`
- `npm run validate:feature` using Node 24.14.1