### PR TITLE
fix: defer checkpoint refresh effect

### DIFF
--- a/packages/pwa/src/components/PwaSyncSettings.tsx
+++ b/packages/pwa/src/components/PwaSyncSettings.tsx
@@ -280,7 +280,7 @@ export function PwaSyncSettings() {
   }, [selectedCheckpoint]);
 
   useEffect(() => {
-    void refreshSelectedCheckpoint();
+    queueMicrotask(() => void refreshSelectedCheckpoint());
     const timer = window.setInterval(
       () => void refreshSelectedCheckpoint(),
       15_000,


### PR DESCRIPTION
(AI Generated).

## Summary
- 

## Testing
- Not run, no focused validation was recorded.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `82ac96fba8382dbdb1067a4b5da38dd8cfaae05b`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-checkpoint-effect-20260820`
- Provider review decision: `diff_authorized`
- Provider review artifact: `e12ef3c748c261f62d7e59d6f017d8ccb8303fabfdda54373ac7801bbfacae61`
- Providers: other
- Observable behavior: Provider-observable behavior is unchanged. The PWA schedules its existing local IndexedDB checkpoint-receipt refresh in a microtask instead of invoking it directly in a React effect. No provider request, navigation, timing, retry, cookie, header, extraction, login, media, or background contact changes.
- Fingerprinting risk: None from this diff. The changed operation reads local IndexedDB state and cannot alter provider contact or provider-visible bytes.
- Lowest profile alternative: Keep provider traffic disabled and verify the local checkpoint diagnostics with unit tests and the offline PWA build.

Files bound into this provider review:
- `packages/pwa/src/components/PwaSyncSettings.tsx`