### PR TITLE
fix: recognize release identity backflow

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -49,7 +49,7 @@ const HISTORICAL_MAIN_PROMOTION_SUBJECTS = new Set([
   "chore: promote updater asset url fix to main (#313)",
 ]);
 export const REVERSE_INTEGRATION_COMMIT_SUBJECT_PATTERN =
-  /^(?:chore|fix): (?:merge main (?:back )?into dev(?: .*)?|reverse integrate (?:main|v\d+\.\d+\.\d+)(?: into dev| after v\d+\.\d+\.\d+| production release)?|backflow v\d+\.\d+\.\d+ main into dev|sync main(?: release artifacts)?(?: back)? into dev(?: .*)?)(?: \(#\d+\))?$/;
+  /^(?:chore|fix): (?:merge main (?:back )?into dev(?: .*)?|reverse integrate (?:main|v\d+\.\d+\.\d+)(?: into dev| after v\d+\.\d+\.\d+| production release| release identity)?|backflow v\d+\.\d+\.\d+ main into dev|sync main(?: release artifacts)?(?: back)? into dev(?: .*)?)(?: \(#\d+\))?$/;
 
 function runGit(args, { cwd } = {}) {
   return execFileSync("git", args, {

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -910,7 +910,10 @@ test("validate-main-backflow rejects a main rollback to an older dev blob", (t) 
   assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
 });
 
-test("validate-main-backflow accepts a reverse-integrated main hotfix after dev advances", (t) => {
+for (const reverseIntegrationSubject of [
+  "chore: merge main back into dev after v26.7.700 (#929)",
+  "chore: reverse integrate v26.7.700 release identity (#929)",
+]) test(`validate-main-backflow accepts ${reverseIntegrationSubject}`, (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));
 
@@ -933,7 +936,7 @@ test("validate-main-backflow accepts a reverse-integrated main hotfix after dev 
 
   git(cwd, ["checkout", "dev"]);
   git(cwd, ["checkout", "main", "--", "packages/pwa/src/app.ts"]);
-  commitAll(cwd, "chore: merge main back into dev after v26.7.700 (#929)");
+  commitAll(cwd, reverseIntegrationSubject);
   writeRepoFile(
     cwd,
     "packages/pwa/src/app.ts",


### PR DESCRIPTION
(AI Generated).

## Summary
- Recognize the repository's existing release-identity reverse-integration commit form so the backflow validator accepts exact production blobs already preserved in dev history.

## Testing
- node --test scripts/release-promotion.test.mjs (41 passed); npm run validate:feature; node scripts/validate-main-backflow.mjs --dev-ref=origin/dev --main-ref=origin/main