### PR TITLE
fix: forward Go compiler to Linux actor build

### DIFF
--- a/scripts/automation-actors.mjs
+++ b/scripts/automation-actors.mjs
@@ -871,6 +871,11 @@ function buildHostArtifacts(dependencies, directory) {
     "automation-actor-provisioner",
   );
   const hostBuildPath = inspectRegularFile(dependencies.hostBuildPath);
+  const buildEnvironment =
+    dependencies.platform === "linux" &&
+    typeof dependencies.env.FREED_GO_EXECUTABLE === "string"
+      ? { FREED_GO_EXECUTABLE: dependencies.env.FREED_GO_EXECUTABLE }
+      : {};
   runChecked(
     dependencies,
     "/bin/bash",
@@ -881,7 +886,11 @@ function buildHostArtifacts(dependencies, directory) {
       "--provisioner-output",
       provisionerOutput,
     ],
-    { cwd: dependencies.repoRoot, purpose: "Automation actor host build" },
+    {
+      cwd: dependencies.repoRoot,
+      purpose: "Automation actor host build",
+      additionalEnv: buildEnvironment,
+    },
   );
   return {
     hostOutput: inspectRegularFile(hostOutput, { executable: true }),

--- a/scripts/automation-actors.test.mjs
+++ b/scripts/automation-actors.test.mjs
@@ -907,6 +907,30 @@ test("provision all installs one content-addressed runtime and all public bindin
   );
 });
 
+test("Linux provisioning forwards only the reviewed Go compiler to the host build", (t) => {
+  const value = fixture(t);
+  value.dependencies.platform = "linux";
+  value.dependencies.env.FREED_GO_EXECUTABLE = "/usr/bin/go";
+
+  executeCommand(
+    {
+      action: "provision",
+      actor: "freed-runtime-observer",
+      stateRoot: value.stateRoot,
+    },
+    value.dependencies,
+  );
+
+  const build = value.calls.find(
+    ({ executable, args }) =>
+      executable === "/bin/bash" && args[0] === value.hostBuildPath,
+  );
+  assert.equal(build.options.env.FREED_GO_EXECUTABLE, "/usr/bin/go");
+  assert.equal(build.options.env.FREED_OWNER_LEASE_TOKEN, undefined);
+  assert.equal(build.options.env.DEVELOPER_DIR, undefined);
+  assert.equal(build.options.env.TMPDIR, undefined);
+});
+
 test("Linux provisioning completes the full trusted actor lifecycle with root-owned material", (t) => {
   const value = fixture(t);
   value.dependencies.platform = "linux";


### PR DESCRIPTION
(AI Generated).

## Summary
- Pass the reviewed FREED_GO_EXECUTABLE through the Linux native-host build boundary.
- Keep the remaining caller environment scrubbed.

## Testing
- node --test scripts/automation-actors.test.mjs scripts/automation-actor-linux.test.mjs
- npm run validate:feature