### PR TITLE
fix: align claim freshness with trusted launcher

### DIFF
--- a/docs/AUTOMATION-CONTROL-PLANE.md
+++ b/docs/AUTOMATION-CONTROL-PLANE.md
@@ -331,6 +331,14 @@ owner. While a claim is active, normal task transitions and authority updates
 are fenced. The coordinator must release the exact claim before lifecycle
 projection continues.
 
+Initial acquisition accepts a request for at most eight minutes. That bound
+covers the trusted launcher's reviewed 370-second lifecycle, its 380-second
+caller boundary, and the separately bounded claim command. The claim and
+request timestamps must still match exactly, custody must begin at epoch one,
+and a timestamp more than 30 seconds in the future remains invalid. The wider
+transit allowance grants no additional actor, task, provider, publication, or
+worker authority.
+
 Claim expiry policy remains conservative. AubTown may release an unlaunched
 `claimed` record only after its initial grace and an exact heartbeat compare.
 A stale `running` record remains authoritative custody until the worker returns

--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -3985,6 +3985,147 @@ test("task lifecycle events stay inside their exact lease authority window", () 
   }
 });
 
+test("factory claim freshness covers trusted launcher transit and stays bounded", () => {
+  const stateRoot = temporaryStateRoot();
+  const baseMs = Date.now();
+  const controller = actorLease(stateRoot, "freed-stability-controller", {
+    nowMs: baseMs,
+  });
+  const createPilotTask = (taskId, issueNumber, offset) => {
+    createTask({
+      stateRoot,
+      taskId,
+      ...controller,
+      observerAuthority: "pr-only",
+      providerAuthority: "forbidden",
+      details: {
+        behavioral: false,
+        estimatedMinutes: 30,
+        githubIssue: {
+          number: issueNumber,
+          url: `https://github.com/freed-project/freed/issues/${issueNumber}`,
+        },
+      },
+      nowMs: baseMs + offset,
+    });
+    transitionTask({
+      stateRoot,
+      taskId,
+      ...controller,
+      toState: "triaged",
+      nowMs: baseMs + offset + 1,
+    });
+    transitionTask({
+      stateRoot,
+      taskId,
+      ...controller,
+      toState: "approved_for_pr",
+      nowMs: baseMs + offset + 2,
+    });
+  };
+  createPilotTask("factory-freshness-accepted", 1636, 1);
+  createPilotTask("factory-freshness-stale", 1637, 4);
+  createPilotTask("factory-freshness-future", 1638, 7);
+
+  const coordinator = actorLease(stateRoot, "freed-nightly-runner", {
+    nowMs: baseMs + 20,
+  });
+  const requestFor = ({ taskId, issueNumber, operationId, requestedAt }) => {
+    const conflictDomains = [`logical:${taskId}`];
+    return {
+      schemaVersion: 1,
+      operationId,
+      taskId,
+      expectedTaskRevision: 3,
+      bindingDigest: "a".repeat(64),
+      claim: {
+        claimId: `${taskId}-claim`,
+        githubIssue: {
+          number: issueNumber,
+          url: `https://github.com/freed-project/freed/issues/${issueNumber}`,
+        },
+        custodyEpoch: 1,
+        hostId: "linux-one",
+        workerId: "worker-one",
+        branch: `fix/${taskId}`,
+        worktree: `/tmp/${taskId}`,
+        conflictDomains,
+        conflictDomainDigest: createHash("sha256")
+          .update(JSON.stringify(conflictDomains))
+          .digest("hex"),
+        claimedAt: requestedAt,
+        baseHead: "b".repeat(40),
+        accountId: "account-one",
+        driverId: "codex-app-server",
+        target: "shared",
+        workLane: "runtime-neutral",
+        publicationCeiling: "draft-pr",
+      },
+      requestedAt,
+    };
+  };
+
+  const acceptedAt = baseMs + 21;
+  const accepted = requestFor({
+    taskId: "factory-freshness-accepted",
+    issueNumber: 1636,
+    operationId: "905968c8-e7d4-4668-94e2-88bcd9b9204a",
+    requestedAt: new Date(acceptedAt).toISOString(),
+  });
+  assert.equal(
+    acquireFactoryExecutionClaim({
+      stateRoot,
+      ...coordinator,
+      request: accepted,
+      // 380 seconds for the trusted launcher plus 90 seconds for the bounded
+      // claim command remains inside the eight-minute freshness contract.
+      nowMs: acceptedAt + 470_000,
+    }).authorityClaimId,
+    "factory-freshness-accepted-claim",
+  );
+
+  const staleAt = baseMs + 22;
+  const stale = requestFor({
+    taskId: "factory-freshness-stale",
+    issueNumber: 1637,
+    operationId: "72640ee7-8f3e-4aae-9140-74e7902f1cc0",
+    requestedAt: new Date(staleAt).toISOString(),
+  });
+  assert.throws(
+    () =>
+      acquireFactoryExecutionClaim({
+        stateRoot,
+        ...coordinator,
+        request: stale,
+        nowMs: staleAt + 8 * 60_000 + 1,
+      }),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "claim_time_invalid",
+  );
+
+  const futureNowMs = baseMs + 23;
+  const future = requestFor({
+    taskId: "factory-freshness-future",
+    issueNumber: 1638,
+    operationId: "59aa1a13-b90c-4be5-b251-a2936193c814",
+    requestedAt: new Date(futureNowMs + 30_001).toISOString(),
+  });
+  assert.throws(
+    () =>
+      acquireFactoryExecutionClaim({
+        stateRoot,
+        ...coordinator,
+        request: future,
+        nowMs: futureNowMs,
+      }),
+    (error) =>
+      error instanceof AutomationControlError &&
+      error.code === "claim_time_invalid",
+  );
+  assert.equal(listFactoryExecutionClaims({ stateRoot }).claims.length, 1);
+});
+
 test("task-scoped factory claims survive retries, fence custody, and release exactly", () => {
   const stateRoot = temporaryStateRoot();
   const nowMs = Date.now();

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -76,6 +76,11 @@ export const CONTROL_EVENT_HISTORY_MAX_RECORDS = 100_000;
 const TASK_CONTROL_FILE_MAX_BYTES = 16 * 1024 * 1024;
 const FACTORY_CLAIM_ADMISSION_LIFETIME_MS = 5 * 60 * 1_000;
 const FACTORY_CLAIM_CLOCK_SKEW_MS = 30 * 1_000;
+// The trusted actor launcher owns a bounded 370-second lifecycle, and its
+// caller reserves another 10 seconds before the claim command starts. Keep
+// initial claim freshness bounded while allowing that reviewed authority path
+// to finish without making a healthy request stale in transit.
+const FACTORY_CLAIM_ACQUIRE_FRESHNESS_MS = 8 * 60 * 1_000;
 const FACTORY_CLAIM_ACTOR = "freed-nightly-runner";
 const FACTORY_CLAIM_ACTIONS = Object.freeze([
   "claim-acquire",
@@ -11264,7 +11269,7 @@ export function acquireFactoryExecutionClaim({
         nowMs,
       );
       if (
-        nowMs - requestedAtMs > 120 * 1_000 ||
+        nowMs - requestedAtMs > FACTORY_CLAIM_ACQUIRE_FRESHNESS_MS ||
         value.claim.claimedAt !== value.requestedAt ||
         value.claim.custodyEpoch !== 1
       ) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Extend initial factory claim freshness to the exact bounded trusted-launcher path while preserving clock skew, epoch, replay, and authority checks. Closes the blocker described in #1636.

## Testing
- Focused factory claim freshness test passed; npm run validate:feature passed.