### PR TITLE
fix: run Library Core on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -467,7 +467,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825a76410c181273ba90b1 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -456,6 +456,51 @@ jobs:
           path: packages/pwa/test-results/
           retention-days: 7
 
+  windows-native:
+    name: Windows native compile
+    needs: tooling-smoke-plan
+    if: needs.tooling-smoke-plan.outputs.native == 'true'
+    runs-on: windows-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825a76410c181273ba90b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          components: clippy
+          targets: x86_64-pc-windows-msvc
+
+      - name: Cache Rust build artifacts
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: packages/desktop/src-tauri -> target
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build shared packages and Desktop frontend
+        shell: bash
+        run: |
+          (cd packages/shared && npm run build)
+          (cd packages/sync && npm run build)
+          (cd packages/capture-rss && npm run build)
+          (cd packages/desktop && npm run build)
+
+      - name: Check the Windows Desktop native target
+        working-directory: packages/desktop/src-tauri
+        run: cargo check --target x86_64-pc-windows-msvc --all-features
+
   dev:
     name: Dev integration
     if: github.event_name == 'push'

--- a/docs/LIBRARY-CORE-CONTRACT.md
+++ b/docs/LIBRARY-CORE-CONTRACT.md
@@ -73,9 +73,14 @@ version change never silently enables a fallback engine.
 Freed Desktop and the headless Primary are hosts of this crate. Tauri does not
 own Library SQL, schemas, query semantics, or mutation semantics.
 
-On Freed Desktop, the normalized database is opened from a private
-descriptor-bound `library-sqlite` directory under its own process lease. The
-native query command accepts a flat registered `queryId` request, removes that
+On macOS and Linux, Freed Desktop opens the normalized database from a private
+descriptor-bound `library-sqlite` directory. On Windows, Freed Desktop holds
+one operating-system-backed process lease over the canonical application data
+root, resolves the database beneath that root, rejects a symbolic final
+component, disables SQLite URI interpretation, and uses a private SQLite
+cache. Both adapters enforce the same one-way selector, schema, query,
+mutation, checkpoint, and storage-epoch contract. The native query command
+accepts a flat registered `queryId` request, removes that
 discriminator, deserializes the remaining fields into the exact generated
 request type, and returns the exact response DTO. Unknown query IDs and extra
 fields fail closed. Raw SQL never crosses the native boundary.

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -752,6 +752,7 @@ export async function captureDomFeed(
 | 5.188 | Construct normalized FeedItem capture payloads through the shared pure capture projector used by the PWA. Desktop cannot submit Primary-owned analysis, device-authored highlights, or capture tags through a root upsert, and no host-specific projection can drift from the contract | Medium     | ✓ Complete |
 | 5.189 | Close the Desktop acceptance boundary around authoritative SQLite rows. Likes, read receipts, archive scopes, RSS health search, Person and Account promotion, candidate ranking, graph linkage, map timelines, and social filtering now validate native query and mutation projections instead of inspecting a renderer corpus. The dual-column reader pins only its visible bounded window while SQLite refreshes beneath it, and device-local RSS health can join that bounded Feed window without loading the subscription catalog | High       | ✓ Complete |
 | 5.190 | Remove compatibility-shaped fields from current Person, Account, Friend, RSS, AI, display, Facebook, Story Wall, and app-state contracts. Installation-local settings use their dedicated stores, synchronized preference mutations reject unsupported fields, graph and RSS runtime state use explicit local models, and opaque historical values remain readable only by fenced one-time import functions | High       | ✓ Complete |
+| 5.191 | Make the activated SQLite storage epoch operational on Windows. Freed Desktop holds one process lease over the canonical app data root, opens the normalized database with the same stock SQLite schema and bounded query contract as macOS and Linux, verifies the one-way authority selector before product access, supports fresh genesis and the fenced historical cutover, and stores local snapshots as typed checkpoint records. Native authority changes compile the real Windows target before release | High       | ✓ Complete |
 
 ---
 
@@ -769,6 +770,7 @@ export async function captureDomFeed(
 - [x] Auto-updater checks GitHub Releases on launch and in the background, then installs updates in-app
 - [x] Desktop Settings > Updates embeds a compact scrolling preview of the latest five changelog cards with a full changelog link
 - [x] CI/CD release pipeline builds for macOS (ARM + Intel), Windows, Linux on tag push
+- [x] Native Library Core changes compile on Windows during pull request and dev integration validation, before release packaging
 - [x] Dev release tags run the faster dev validation lane and build only the internal macOS Apple Silicon target, while production tags keep full validation and all supported platform builds
 - [x] App icons generated for all platforms
 - [x] macOS DMG builds

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -12940,8 +12940,9 @@ pub fn run() {
                 .app_data_dir()
                 .expect("Failed to resolve app data directory");
             std::fs::create_dir_all(&data_dir).ok();
-            #[cfg(unix)]
-            if library_core_desktop_runtime::complete_normalized_desktop_cutover_if_ready()
+            if library_core_desktop_runtime::complete_normalized_desktop_cutover_if_ready(
+                &app_handle,
+            )
                 .map_err(std::io::Error::other)?
             {
                 info!("[library-core] selected normalized SQLite authority");

--- a/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
@@ -27,6 +27,8 @@ const CONTENT_VAULT_DIRECTORY: &str = "library-content-vault";
 const NORMALIZED_LIBRARY_DIRECTORY: &str = "library-sqlite";
 #[cfg(not(unix))]
 const AUTHORITY_SELECTION_FILE: &str = "library-authority-selection-v1.json";
+#[cfg(not(unix))]
+const NORMALIZED_DATABASE_FILE: &str = "library-core.sqlite";
 
 #[derive(Debug, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -193,23 +195,177 @@ fn open_normalized_database(app: &tauri::AppHandle) -> Result<Connection, String
             .connect_selected_normalized()
             .map_err(|error| error.to_string());
     }
-    let _ = app;
-    Err("normalized SQLite authority selection is unavailable on this host".into())
+    #[cfg(unix)]
+    {
+        let _ = app;
+        Err("normalized SQLite Desktop binding is unavailable".into())
+    }
+    #[cfg(not(unix))]
+    {
+        let root = app_root(app)?;
+        let selection_path = root.join(AUTHORITY_SELECTION_FILE);
+        let selection: DesktopLibraryAuthoritySelectionV1 =
+            serde_json::from_slice(&fs::read(&selection_path).map_err(|error| {
+                format!("normalized SQLite authority is not selected: {error}")
+            })?)
+            .map_err(|_| "normalized SQLite authority selection is invalid".to_owned())?;
+        if selection.format != "freed_desktop_sqlite_authority_selection_v1"
+            || !valid_normalized_digest(&selection.library_id)
+        {
+            return Err("normalized SQLite authority selection identity is invalid".into());
+        }
+        let connection = open_unselected_normalized_database(app, false)?;
+        let matches: i64 = connection
+            .query_row(
+                "SELECT count(*)
+                 FROM library_active_authority AS active
+                 JOIN library_authority_epochs AS epoch ON epoch.epoch_id = active.epoch_id
+                 JOIN library_meta AS meta ON meta.singleton_id = 1
+                 JOIN library_materialization_generation AS generation ON generation.singleton_id = 1
+                 WHERE active.active_key = 'active'
+                   AND active.library_id = ?1
+                   AND meta.library_id = active.library_id
+                   AND meta.authority_epoch = active.epoch_id
+                   AND epoch.library_id = active.library_id
+                   AND epoch.materialized_state_digest = generation.generation_id;",
+                [&selection.library_id],
+                |row| row.get(0),
+            )
+            .map_err(|error| error.to_string())?;
+        if matches != 1 {
+            return Err("normalized SQLite authority selection does not match SQLite".into());
+        }
+        Ok(connection)
+    }
 }
 
-#[cfg(unix)]
-pub(super) fn complete_normalized_desktop_cutover_if_ready() -> Result<bool, String> {
-    let binding = freed_library_core::desktop_binding().map_err(|error| error.to_string())?;
-    if binding
-        .normalized_authority_is_selected_v1()
-        .map_err(|error| error.to_string())?
+#[cfg(not(unix))]
+#[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct DesktopLibraryAuthoritySelectionV1 {
+    format: String,
+    library_id: String,
+}
+
+#[cfg(not(unix))]
+fn valid_normalized_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}
+
+#[cfg(not(unix))]
+fn open_unselected_normalized_database(
+    app: &tauri::AppHandle,
+    create: bool,
+) -> Result<Connection, String> {
+    freed_library_core::open_normalized_sqlite_database_v1(
+        &app_root(app)?
+            .join(NORMALIZED_LIBRARY_DIRECTORY)
+            .join(NORMALIZED_DATABASE_FILE),
+        create,
+    )
+    .map_err(|error| error.to_string())
+}
+
+#[cfg(not(unix))]
+fn publish_windows_authority_selection(
+    app: &tauri::AppHandle,
+    prepared: &freed_library_core::NormalizedDesktopAuthorityPreparedV1,
+) -> Result<(), String> {
+    if !valid_normalized_digest(&prepared.library_id) {
+        return Err("normalized SQLite authority identity is invalid".into());
+    }
+    let path = app_root(app)?.join(AUTHORITY_SELECTION_FILE);
+    if path.exists() {
+        return open_normalized_database(app).map(|_| ());
+    }
+    let pending = path.with_extension("pending");
+    let bytes = serde_json::to_vec(&DesktopLibraryAuthoritySelectionV1 {
+        format: "freed_desktop_sqlite_authority_selection_v1".into(),
+        library_id: prepared.library_id.clone(),
+    })
+    .map_err(|error| error.to_string())?;
+    fs::write(&pending, bytes).map_err(|error| error.to_string())?;
+    fs::rename(&pending, &path).map_err(|error| error.to_string())?;
+    open_normalized_database(app).map(|_| ())
+}
+
+pub(super) fn complete_normalized_desktop_cutover_if_ready(
+    app: &tauri::AppHandle,
+) -> Result<bool, String> {
+    #[cfg(not(unix))]
     {
+        return complete_windows_normalized_cutover(app);
+    }
+    #[cfg(unix)]
+    {
+        let _ = app;
+        let binding = freed_library_core::desktop_binding().map_err(|error| error.to_string())?;
+        if binding
+            .normalized_authority_is_selected_v1()
+            .map_err(|error| error.to_string())?
+        {
+            return Ok(false);
+        }
+        if !binding.historical_source_is_present_v1() {
+            return Ok(false);
+        }
+        let mut source = binding.connect().map_err(|error| error.to_string())?;
+        let source_state: Option<(i64, i64, i64, Option<i64>)> = source
+            .query_row(
+                "SELECT active, expectedItemCount, importedItemCount, activatedAtMs
+             FROM library_core_desktop_state WHERE singletonId = 1;",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
+            )
+            .optional()
+            .map_err(|error| error.to_string())?;
+        let Some((active, expected_items, imported_items, activated_at)) = source_state else {
+            return Ok(false);
+        };
+        if active == 0 && activated_at.is_none() {
+            return Ok(false);
+        }
+        if active != 1 || activated_at.is_none() || expected_items != imported_items {
+            return Err("historical Library is not a complete migration source".to_owned());
+        }
+        let mut target = binding
+            .connect_normalized()
+            .map_err(|error| error.to_string())?;
+        let installation_witness = crate::get_desktop_installation_witness()?;
+        let accepted_at = i64::try_from(crate::unix_millis_now())
+            .map_err(|_| "Desktop cutover time is invalid".to_owned())?;
+        let prepared = freed_library_core::prepare_normalized_desktop_cutover_v1(
+            &mut source,
+            &mut target,
+            &installation_witness,
+            &PlatformActorKeyStore,
+            &PlatformAuthorityKeyStore,
+            accepted_at,
+        )
+        .map_err(|error| error.to_string())?;
+        binding
+            .publish_normalized_authority_selection_v1(&prepared)
+            .map_err(|error| error.to_string())?;
+        Ok(true)
+    }
+}
+
+#[cfg(not(unix))]
+fn complete_windows_normalized_cutover(app: &tauri::AppHandle) -> Result<bool, String> {
+    if app_root(app)?.join(AUTHORITY_SELECTION_FILE).exists() {
+        open_normalized_database(app)?;
         return Ok(false);
     }
-    if !binding.historical_source_is_present_v1() {
+    let Some(mut source) = freed_library_core::open_historical_migration_source_v1(
+        &app_root(app)?.join("library-core"),
+    )
+    .map_err(|error| error.to_string())?
+    else {
         return Ok(false);
-    }
-    let mut source = binding.connect().map_err(|error| error.to_string())?;
+    };
     let source_state: Option<(i64, i64, i64, Option<i64>)> = source
         .query_row(
             "SELECT active, expectedItemCount, importedItemCount, activatedAtMs
@@ -226,11 +382,9 @@ pub(super) fn complete_normalized_desktop_cutover_if_ready() -> Result<bool, Str
         return Ok(false);
     }
     if active != 1 || activated_at.is_none() || expected_items != imported_items {
-        return Err("historical Library is not a complete migration source".to_owned());
+        return Err("historical Library is not a complete migration source".into());
     }
-    let mut target = binding
-        .connect_normalized()
-        .map_err(|error| error.to_string())?;
+    let mut target = open_unselected_normalized_database(app, true)?;
     let installation_witness = crate::get_desktop_installation_witness()?;
     let accepted_at = i64::try_from(crate::unix_millis_now())
         .map_err(|_| "Desktop cutover time is invalid".to_owned())?;
@@ -243,93 +397,127 @@ pub(super) fn complete_normalized_desktop_cutover_if_ready() -> Result<bool, Str
         accepted_at,
     )
     .map_err(|error| error.to_string())?;
-    binding
-        .publish_normalized_authority_selection_v1(&prepared)
-        .map_err(|error| error.to_string())?;
+    drop(target);
+    publish_windows_authority_selection(app, &prepared)?;
     Ok(true)
 }
 
-#[cfg(unix)]
 #[tauri::command]
 pub(super) fn ensure_fresh_normalized_desktop_library(
+    app: tauri::AppHandle,
     historical_data_absent: bool,
 ) -> Result<bool, String> {
-    let binding = freed_library_core::desktop_binding().map_err(|error| error.to_string())?;
-    if binding
-        .normalized_authority_is_selected_v1()
-        .map_err(|error| error.to_string())?
+    #[cfg(not(unix))]
     {
-        return Ok(true);
-    }
-    if !historical_data_absent {
-        return Ok(false);
-    }
-    if binding.historical_source_is_present_v1() {
-        let source = binding.connect().map_err(|error| error.to_string())?;
-        let source_state: Option<i64> = source
-            .query_row(
-                "SELECT singletonId FROM library_core_desktop_state WHERE singletonId = 1;",
-                [],
-                |row| row.get(0),
-            )
-            .optional()
-            .map_err(|error| error.to_string())?;
-        if source_state.is_some() {
+        if app_root(&app)?.join(AUTHORITY_SELECTION_FILE).exists() {
+            open_normalized_database(&app)?;
+            return Ok(true);
+        }
+        if !historical_data_absent {
             return Ok(false);
         }
-        let mut tables = source
-            .prepare(
-                "SELECT name FROM sqlite_schema
-                 WHERE type = 'table' AND name LIKE 'library_core_%'
-                 ORDER BY name;",
-            )
-            .map_err(|error| error.to_string())?;
-        let table_names = tables
-            .query_map([], |row| row.get::<_, String>(0))
+        let historical = app_root(&app)?
+            .join("library-core")
+            .join(NORMALIZED_DATABASE_FILE);
+        if historical.exists() {
+            return Ok(false);
+        }
+        let mut target = open_unselected_normalized_database(&app, true)?;
+        let installation_witness = crate::get_desktop_installation_witness()?;
+        let accepted_at = i64::try_from(crate::unix_millis_now())
+            .map_err(|_| "Desktop fresh Library time is invalid".to_owned())?;
+        let prepared = freed_library_core::prepare_fresh_normalized_desktop_library_v1(
+            &mut target,
+            &installation_witness,
+            &PlatformActorKeyStore,
+            &PlatformAuthorityKeyStore,
+            accepted_at,
+        )
+        .map_err(|error| error.to_string())?;
+        drop(target);
+        publish_windows_authority_selection(&app, &prepared)?;
+        return Ok(true);
+    }
+    #[cfg(unix)]
+    {
+        let _ = app;
+        let binding = freed_library_core::desktop_binding().map_err(|error| error.to_string())?;
+        if binding
+            .normalized_authority_is_selected_v1()
             .map_err(|error| error.to_string())?
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|error| error.to_string())?;
-        drop(tables);
-        for table_name in table_names {
-            if table_name == "library_core_meta" {
-                continue;
-            }
-            if !table_name
-                .bytes()
-                .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
-            {
-                return Err("historical Library table identity is invalid".into());
-            }
-            let occupied: i64 = source
+        {
+            return Ok(true);
+        }
+        if !historical_data_absent {
+            return Ok(false);
+        }
+        if binding.historical_source_is_present_v1() {
+            let source = binding.connect().map_err(|error| error.to_string())?;
+            let source_state: Option<i64> = source
                 .query_row(
-                    &format!("SELECT EXISTS(SELECT 1 FROM \"{table_name}\" LIMIT 1);"),
+                    "SELECT singletonId FROM library_core_desktop_state WHERE singletonId = 1;",
                     [],
                     |row| row.get(0),
                 )
+                .optional()
                 .map_err(|error| error.to_string())?;
-            if occupied != 0 {
+            if source_state.is_some() {
                 return Ok(false);
             }
+            let mut tables = source
+                .prepare(
+                    "SELECT name FROM sqlite_schema
+                 WHERE type = 'table' AND name LIKE 'library_core_%'
+                 ORDER BY name;",
+                )
+                .map_err(|error| error.to_string())?;
+            let table_names = tables
+                .query_map([], |row| row.get::<_, String>(0))
+                .map_err(|error| error.to_string())?
+                .collect::<Result<Vec<_>, _>>()
+                .map_err(|error| error.to_string())?;
+            drop(tables);
+            for table_name in table_names {
+                if table_name == "library_core_meta" {
+                    continue;
+                }
+                if !table_name
+                    .bytes()
+                    .all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+                {
+                    return Err("historical Library table identity is invalid".into());
+                }
+                let occupied: i64 = source
+                    .query_row(
+                        &format!("SELECT EXISTS(SELECT 1 FROM \"{table_name}\" LIMIT 1);"),
+                        [],
+                        |row| row.get(0),
+                    )
+                    .map_err(|error| error.to_string())?;
+                if occupied != 0 {
+                    return Ok(false);
+                }
+            }
         }
+        let mut target = binding
+            .connect_normalized()
+            .map_err(|error| error.to_string())?;
+        let installation_witness = crate::get_desktop_installation_witness()?;
+        let accepted_at = i64::try_from(crate::unix_millis_now())
+            .map_err(|_| "Desktop fresh Library time is invalid".to_owned())?;
+        let prepared = freed_library_core::prepare_fresh_normalized_desktop_library_v1(
+            &mut target,
+            &installation_witness,
+            &PlatformActorKeyStore,
+            &PlatformAuthorityKeyStore,
+            accepted_at,
+        )
+        .map_err(|error| error.to_string())?;
+        binding
+            .publish_normalized_authority_selection_v1(&prepared)
+            .map_err(|error| error.to_string())?;
+        Ok(true)
     }
-    let mut target = binding
-        .connect_normalized()
-        .map_err(|error| error.to_string())?;
-    let installation_witness = crate::get_desktop_installation_witness()?;
-    let accepted_at = i64::try_from(crate::unix_millis_now())
-        .map_err(|_| "Desktop fresh Library time is invalid".to_owned())?;
-    let prepared = freed_library_core::prepare_fresh_normalized_desktop_library_v1(
-        &mut target,
-        &installation_witness,
-        &PlatformActorKeyStore,
-        &PlatformAuthorityKeyStore,
-        accepted_at,
-    )
-    .map_err(|error| error.to_string())?;
-    binding
-        .publish_normalized_authority_selection_v1(&prepared)
-        .map_err(|error| error.to_string())?;
-    Ok(true)
 }
 
 #[tauri::command]

--- a/packages/desktop/src-tauri/src/library_core_platform_key.rs
+++ b/packages/desktop/src-tauri/src/library_core_platform_key.rs
@@ -23,8 +23,7 @@ use std::sync::{LazyLock, Mutex};
 #[cfg(not(feature = "isolated-preview-data-root"))]
 pub(crate) const KEYRING_SERVICE: &str = "wtf.freed.library-core";
 #[cfg(feature = "isolated-preview-data-root")]
-pub(crate) const KEYRING_SERVICE: &str =
-    "wtf.freed.library-core.sqlite-native-preview";
+pub(crate) const KEYRING_SERVICE: &str = "wtf.freed.library-core.sqlite-native-preview";
 const MAXIMUM_SUBJECT_BYTES: usize = 128;
 
 /// One named private key: which vault account holds it, and how its envelope

--- a/packages/desktop/src-tauri/src/library_core_process_lease.rs
+++ b/packages/desktop/src-tauri/src/library_core_process_lease.rs
@@ -57,11 +57,17 @@ impl LibraryCoreProcessLease {
         }
         #[cfg(not(unix))]
         {
-            freed_library_core::LibraryCoreProcessLease::acquire(
-                requested_data_root,
-                DESKTOP_IDENTITY,
-            )
-            .map(|lease| Self { _lease: lease })
+            let app_root = requested_data_root.parent().ok_or_else(|| {
+                freed_library_core::LibraryCoreProcessLeaseError::Storage {
+                    operation: "bind",
+                    path: requested_data_root.to_path_buf(),
+                    source: std::io::Error::other(
+                        "Freed Desktop Library Core data root has no app root",
+                    ),
+                }
+            })?;
+            freed_library_core::LibraryCoreProcessLease::acquire(app_root, DESKTOP_IDENTITY)
+                .map(|lease| Self { _lease: lease })
         }
     }
 

--- a/packages/library-core-native/src/historical_migration_source.rs
+++ b/packages/library-core-native/src/historical_migration_source.rs
@@ -216,6 +216,33 @@ impl HistoricalMigrationSource {
     }
 }
 
+/// Opens the retired Desktop SQLite source through a bounded read-only path.
+///
+/// This exists for the Windows storage-epoch cutover, where Unix directory
+/// descriptors are unavailable. Absence is distinct from an invalid source.
+pub fn open_historical_migration_source_v1(
+    library_directory: &Path,
+) -> LibraryCoreStorageResult<Option<Connection>> {
+    let database = database_path(library_directory);
+    let metadata = match std::fs::symlink_metadata(&database) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error.into()),
+    };
+    if metadata.file_type().is_symlink() || !metadata.is_file() {
+        return Err(LibraryCoreStorageError(
+            "historical Desktop migration source is not an ordinary file".into(),
+        ));
+    }
+    let parent = std::fs::canonicalize(library_directory)?;
+    let source = HistoricalMigrationSource {
+        root: parent,
+        #[cfg(unix)]
+        bound: None,
+    };
+    source.connect().map(Some)
+}
+
 #[cfg(unix)]
 fn bound_database_is_present(directory: RawFd) -> LibraryCoreStorageResult<bool> {
     let leaf = CString::new(LIBRARY_FILE).map_err(|_| {

--- a/packages/library-core-native/src/historical_migration_source.rs
+++ b/packages/library-core-native/src/historical_migration_source.rs
@@ -1,6 +1,7 @@
 use rusqlite::{Connection, OpenFlags};
 #[cfg(unix)]
 use std::ffi::CString;
+#[cfg(unix)]
 use std::fs::File;
 #[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};

--- a/packages/library-core-native/src/lib.rs
+++ b/packages/library-core-native/src/lib.rs
@@ -46,7 +46,6 @@ mod normalized_operation_verifier;
 mod normalized_protocol_limits;
 mod normalized_query;
 mod normalized_replication;
-#[cfg(unix)]
 mod normalized_snapshot;
 mod normalized_sqlite;
 mod normalized_transaction_validator;
@@ -74,7 +73,9 @@ pub use device_graph_layout::{
     mutate_device_graph_layout_v1, DeviceGraphLayoutError, DeviceGraphLayoutMutationResultV1,
     DeviceGraphLayoutMutationV1,
 };
-pub use historical_migration_source::LibraryCoreStorageError;
+pub use historical_migration_source::{
+    open_historical_migration_source_v1, LibraryCoreStorageError,
+};
 pub use library_core_actor_enrollment::{
     countersign_actor_enrollment_request_bytes, load_or_create_normalized_actor_id_v2,
     prepare_normalized_follower_actor_enrollment_request_v2, sign_library_core_operation_digest,
@@ -174,7 +175,6 @@ pub use normalized_replication::{
     NormalizedOperationExportPageV2, NormalizedOperationExportRecordV2,
     NormalizedOperationExportRequestV2, NormalizedOperationRecordKindV2,
 };
-#[cfg(unix)]
 pub use normalized_snapshot::{
     clear_normalized_local_snapshots_v1, create_normalized_local_snapshot_v1,
     list_normalized_local_snapshots_v1, restore_normalized_local_snapshot_v1,
@@ -184,9 +184,10 @@ pub use normalized_sqlite::{
     append_normalized_checkpoint_stage_page_v2, begin_normalized_checkpoint_stage_v2,
     describe_normalized_checkpoint_export_v2, export_normalized_checkpoint_page_v2,
     export_pinned_normalized_checkpoint_page_v2, install_normalized_schema_v1,
-    BeginNormalizedCheckpointStageV2, NormalizedCheckpointCursorV2,
-    NormalizedCheckpointExportDescriptorV2, NormalizedCheckpointExportPageV2,
-    NormalizedCheckpointExportRequestV2, NormalizedCheckpointStageStatusV2, NormalizedSqliteError,
+    open_normalized_sqlite_database_v1, BeginNormalizedCheckpointStageV2,
+    NormalizedCheckpointCursorV2, NormalizedCheckpointExportDescriptorV2,
+    NormalizedCheckpointExportPageV2, NormalizedCheckpointExportRequestV2,
+    NormalizedCheckpointStageStatusV2, NormalizedSqliteError,
     PinnedNormalizedCheckpointExportRequestV2,
 };
 pub use normalized_writer_certificate::{

--- a/packages/library-core-native/src/library_core_process_lease.rs
+++ b/packages/library-core-native/src/library_core_process_lease.rs
@@ -7,7 +7,9 @@
 //! file exists only to make a refusal attributable.
 
 use serde::Serialize;
-use std::io::{Read, Seek, SeekFrom, Write};
+#[cfg(unix)]
+use std::io::{Read, Seek, SeekFrom};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 

--- a/packages/library-core-native/src/normalized_snapshot.rs
+++ b/packages/library-core-native/src/normalized_snapshot.rs
@@ -490,7 +490,7 @@ fn acquire_snapshot_operation(
     }
     #[cfg(windows)]
     {
-        let mut lock = fslock::LockFile::open(snapshot_root.path.join(SNAPSHOT_LOCK_FILE))
+        let mut lock = fslock::LockFile::open(&snapshot_root.path.join(SNAPSHOT_LOCK_FILE))
             .map_err(|error| snapshot_error(error.to_string()))?;
         if !lock
             .try_lock()
@@ -1172,6 +1172,7 @@ pub(crate) fn restore_normalized_local_snapshot_bound_v1(
     )
 }
 
+#[cfg(unix)]
 pub(crate) fn clear_normalized_local_snapshots_bound_v1(
     snapshot_directory: RawFd,
 ) -> Result<(), NormalizedSqliteError> {

--- a/packages/library-core-native/src/normalized_snapshot.rs
+++ b/packages/library-core-native/src/normalized_snapshot.rs
@@ -29,12 +29,17 @@ use rusqlite::{params, Connection, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use sha2::{Digest, Sha256};
+#[cfg(unix)]
 use std::ffi::{CStr, CString};
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufRead, BufReader, BufWriter, Read, Write};
+#[cfg(unix)]
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+#[cfg(unix)]
 use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
 
 const SNAPSHOT_FORMAT: &str = "freed_normalized_local_snapshot_v1";
 const SNAPSHOT_FILE_SUFFIX: &str = ".freed-snapshot";
@@ -98,9 +103,13 @@ struct SnapshotArchive {
 }
 
 struct SnapshotOperationGuard {
+    #[cfg(unix)]
     lock: File,
+    #[cfg(windows)]
+    _lock: fslock::LockFile,
 }
 
+#[cfg(unix)]
 impl Drop for SnapshotOperationGuard {
     fn drop(&mut self) {
         unsafe {
@@ -110,7 +119,10 @@ impl Drop for SnapshotOperationGuard {
 }
 
 struct SnapshotDirectory {
+    #[cfg(unix)]
     directory: File,
+    #[cfg(windows)]
+    path: PathBuf,
 }
 
 fn snapshot_error(message: impl Into<String>) -> NormalizedSqliteError {
@@ -118,6 +130,7 @@ fn snapshot_error(message: impl Into<String>) -> NormalizedSqliteError {
 }
 
 impl SnapshotDirectory {
+    #[cfg(unix)]
     fn from_descriptor(descriptor: RawFd) -> Result<Self, NormalizedSqliteError> {
         if descriptor < 0 {
             return Err(snapshot_error(
@@ -145,14 +158,23 @@ impl SnapshotDirectory {
 
     fn open_or_create(path: &Path) -> Result<Self, NormalizedSqliteError> {
         ensure_snapshot_directory(path)?;
-        let directory = OpenOptions::new()
-            .read(true)
-            .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW)
-            .open(path)
-            .map_err(|error| snapshot_error(error.to_string()))?;
-        Self::from_descriptor(directory.as_raw_fd())
+        #[cfg(unix)]
+        {
+            let directory = OpenOptions::new()
+                .read(true)
+                .custom_flags(libc::O_DIRECTORY | libc::O_CLOEXEC | libc::O_NOFOLLOW)
+                .open(path)
+                .map_err(|error| snapshot_error(error.to_string()))?;
+            Self::from_descriptor(directory.as_raw_fd())
+        }
+        #[cfg(windows)]
+        {
+            let path = fs::canonicalize(path).map_err(|error| snapshot_error(error.to_string()))?;
+            Ok(Self { path })
+        }
     }
 
+    #[cfg(unix)]
     fn leaf(name: &str) -> Result<CString, NormalizedSqliteError> {
         if name.is_empty()
             || name.len() > 255
@@ -164,38 +186,73 @@ impl SnapshotDirectory {
         CString::new(name).map_err(|_| snapshot_error("normalized snapshot file name is invalid"))
     }
 
+    #[cfg(windows)]
+    fn leaf(name: &str) -> Result<&str, NormalizedSqliteError> {
+        if name.is_empty()
+            || name.len() > 255
+            || matches!(name, "." | "..")
+            || name
+                .as_bytes()
+                .iter()
+                .any(|byte| matches!(byte, b'/' | b'\\'))
+        {
+            return Err(snapshot_error("normalized snapshot file name is invalid"));
+        }
+        Ok(name)
+    }
+
     fn open_private_file_optional(
         &self,
         name: &str,
     ) -> Result<Option<File>, NormalizedSqliteError> {
         let name = Self::leaf(name)?;
-        let descriptor = unsafe {
-            libc::openat(
-                self.directory.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-            )
-        };
-        if descriptor < 0 {
-            let error = std::io::Error::last_os_error();
-            if error.kind() == std::io::ErrorKind::NotFound {
-                return Ok(None);
-            }
-            return Err(snapshot_error(error.to_string()));
-        }
-        let file = unsafe { File::from_raw_fd(descriptor) };
-        let metadata = file
-            .metadata()
-            .map_err(|error| snapshot_error(error.to_string()))?;
-        if !metadata.is_file()
-            || metadata.file_type().is_symlink()
-            || metadata.mode() & 0o777 != 0o600
-            || metadata.nlink() != 1
-            || metadata.uid() != unsafe { libc::geteuid() }
+        #[cfg(unix)]
         {
-            return Err(snapshot_error("normalized snapshot file is not private"));
+            let descriptor = unsafe {
+                libc::openat(
+                    self.directory.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_RDONLY | libc::O_CLOEXEC | libc::O_NOFOLLOW,
+                )
+            };
+            if descriptor < 0 {
+                let error = std::io::Error::last_os_error();
+                if error.kind() == std::io::ErrorKind::NotFound {
+                    return Ok(None);
+                }
+                return Err(snapshot_error(error.to_string()));
+            }
+            let file = unsafe { File::from_raw_fd(descriptor) };
+            let metadata = file
+                .metadata()
+                .map_err(|error| snapshot_error(error.to_string()))?;
+            if !metadata.is_file()
+                || metadata.file_type().is_symlink()
+                || metadata.mode() & 0o777 != 0o600
+                || metadata.nlink() != 1
+                || metadata.uid() != unsafe { libc::geteuid() }
+            {
+                return Err(snapshot_error("normalized snapshot file is not private"));
+            }
+            Ok(Some(file))
         }
-        Ok(Some(file))
+        #[cfg(windows)]
+        {
+            let path = self.path.join(name);
+            let metadata = match fs::symlink_metadata(&path) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+                Err(error) => return Err(snapshot_error(error.to_string())),
+            };
+            if metadata.file_type().is_symlink() || !metadata.is_file() {
+                return Err(snapshot_error("normalized snapshot file is not private"));
+            }
+            OpenOptions::new()
+                .read(true)
+                .open(path)
+                .map(Some)
+                .map_err(|error| snapshot_error(error.to_string()))
+        }
     }
 
     fn open_private_file(&self, name: &str) -> Result<File, NormalizedSqliteError> {
@@ -205,20 +262,36 @@ impl SnapshotDirectory {
 
     fn create_private_file(&self, name: &str) -> Result<File, NormalizedSqliteError> {
         let name = Self::leaf(name)?;
-        let descriptor = unsafe {
-            libc::openat(
-                self.directory.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_WRONLY | libc::O_CREAT | libc::O_EXCL | libc::O_CLOEXEC | libc::O_NOFOLLOW,
-                0o600,
-            )
-        };
-        if descriptor < 0 {
-            return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+        #[cfg(unix)]
+        {
+            let descriptor = unsafe {
+                libc::openat(
+                    self.directory.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_WRONLY
+                        | libc::O_CREAT
+                        | libc::O_EXCL
+                        | libc::O_CLOEXEC
+                        | libc::O_NOFOLLOW,
+                    0o600,
+                )
+            };
+            if descriptor < 0 {
+                return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+            }
+            Ok(unsafe { File::from_raw_fd(descriptor) })
         }
-        Ok(unsafe { File::from_raw_fd(descriptor) })
+        #[cfg(windows)]
+        {
+            OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(self.path.join(name))
+                .map_err(|error| snapshot_error(error.to_string()))
+        }
     }
 
+    #[cfg(unix)]
     fn open_lock_file(&self) -> Result<File, NormalizedSqliteError> {
         let name = Self::leaf(SNAPSHOT_LOCK_FILE)?;
         let descriptor = unsafe {
@@ -248,79 +321,117 @@ impl SnapshotDirectory {
 
     fn remove_file(&self, name: &str) -> Result<bool, NormalizedSqliteError> {
         let name = Self::leaf(name)?;
-        if unsafe { libc::unlinkat(self.directory.as_raw_fd(), name.as_ptr(), 0) } == 0 {
-            return Ok(true);
+        #[cfg(unix)]
+        {
+            if unsafe { libc::unlinkat(self.directory.as_raw_fd(), name.as_ptr(), 0) } == 0 {
+                return Ok(true);
+            }
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::NotFound {
+                return Ok(false);
+            }
+            Err(snapshot_error(error.to_string()))
         }
-        let error = std::io::Error::last_os_error();
-        if error.kind() == std::io::ErrorKind::NotFound {
-            return Ok(false);
+        #[cfg(windows)]
+        {
+            match fs::remove_file(self.path.join(name)) {
+                Ok(()) => Ok(true),
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+                Err(error) => Err(snapshot_error(error.to_string())),
+            }
         }
-        Err(snapshot_error(error.to_string()))
     }
 
     fn rename(&self, from: &str, to: &str) -> Result<(), NormalizedSqliteError> {
         let from = Self::leaf(from)?;
         let to = Self::leaf(to)?;
-        if unsafe {
-            libc::renameat(
-                self.directory.as_raw_fd(),
-                from.as_ptr(),
-                self.directory.as_raw_fd(),
-                to.as_ptr(),
-            )
-        } < 0
+        #[cfg(unix)]
         {
-            return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+            if unsafe {
+                libc::renameat(
+                    self.directory.as_raw_fd(),
+                    from.as_ptr(),
+                    self.directory.as_raw_fd(),
+                    to.as_ptr(),
+                )
+            } < 0
+            {
+                return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+            }
+            Ok(())
         }
-        Ok(())
+        #[cfg(windows)]
+        {
+            fs::rename(self.path.join(from), self.path.join(to))
+                .map_err(|error| snapshot_error(error.to_string()))
+        }
     }
 
     fn names(&self) -> Result<Vec<String>, NormalizedSqliteError> {
-        let duplicated =
-            unsafe { libc::fcntl(self.directory.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
-        if duplicated < 0 {
-            return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
-        }
-        if unsafe { libc::lseek(duplicated, 0, libc::SEEK_SET) } < 0 {
+        #[cfg(unix)]
+        {
+            let duplicated =
+                unsafe { libc::fcntl(self.directory.as_raw_fd(), libc::F_DUPFD_CLOEXEC, 0) };
+            if duplicated < 0 {
+                return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+            }
+            if unsafe { libc::lseek(duplicated, 0, libc::SEEK_SET) } < 0 {
+                unsafe {
+                    libc::close(duplicated);
+                }
+                return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+            }
+            let directory = unsafe { libc::fdopendir(duplicated) };
+            if directory.is_null() {
+                unsafe {
+                    libc::close(duplicated);
+                }
+                return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+            }
+            let mut names = Vec::new();
+            loop {
+                let entry = unsafe { libc::readdir(directory) };
+                if entry.is_null() {
+                    break;
+                }
+                let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
+                let Ok(name) = name.to_str() else {
+                    continue;
+                };
+                if !matches!(name, "." | "..") {
+                    names.push(name.to_owned());
+                }
+            }
             unsafe {
-                libc::close(duplicated);
+                libc::closedir(directory);
             }
-            return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+            Ok(names)
         }
-        let directory = unsafe { libc::fdopendir(duplicated) };
-        if directory.is_null() {
-            unsafe {
-                libc::close(duplicated);
-            }
-            return Err(snapshot_error(std::io::Error::last_os_error().to_string()));
+        #[cfg(windows)]
+        {
+            Ok(fs::read_dir(&self.path)
+                .map_err(|error| snapshot_error(error.to_string()))?
+                .filter_map(|entry| entry.ok())
+                .filter_map(|entry| entry.file_name().into_string().ok())
+                .collect::<Vec<_>>())
         }
-        let mut names = Vec::new();
-        loop {
-            let entry = unsafe { libc::readdir(directory) };
-            if entry.is_null() {
-                break;
-            }
-            let name = unsafe { CStr::from_ptr((*entry).d_name.as_ptr()) };
-            let Ok(name) = name.to_str() else {
-                continue;
-            };
-            if !matches!(name, "." | "..") {
-                names.push(name.to_owned());
-            }
-        }
-        unsafe {
-            libc::closedir(directory);
-        }
-        Ok(names)
     }
 
     fn sync(&self) -> Result<(), NormalizedSqliteError> {
-        self.directory
-            .sync_all()
-            .map_err(|error| snapshot_error(error.to_string()))
+        #[cfg(unix)]
+        {
+            self.directory
+                .sync_all()
+                .map_err(|error| snapshot_error(error.to_string()))
+        }
+        #[cfg(windows)]
+        {
+            Ok(())
+        }
     }
 }
 
+#[cfg(unix)]
 fn path_for_bound_directory(descriptor: RawFd) -> Result<SnapshotDirectory, NormalizedSqliteError> {
     SnapshotDirectory::from_descriptor(descriptor)
 }
@@ -346,13 +457,15 @@ fn ensure_snapshot_directory(path: &Path) -> Result<(), NormalizedSqliteError> {
         }
         Err(error) => return Err(snapshot_error(error.to_string())),
     }
+    #[cfg(unix)]
     fs::set_permissions(path, fs::Permissions::from_mode(0o700))
         .map_err(|error| snapshot_error(error.to_string()))?;
     let metadata = fs::symlink_metadata(path).map_err(|error| snapshot_error(error.to_string()))?;
-    if !metadata.is_dir()
-        || metadata.file_type().is_symlink()
-        || metadata.permissions().mode() & 0o7777 != 0o700
-    {
+    if !metadata.is_dir() || metadata.file_type().is_symlink() {
+        return Err(snapshot_error("normalized snapshot root is not private"));
+    }
+    #[cfg(unix)]
+    if metadata.permissions().mode() & 0o7777 != 0o700 {
         return Err(snapshot_error("normalized snapshot root is not private"));
     }
     Ok(())
@@ -361,17 +474,34 @@ fn ensure_snapshot_directory(path: &Path) -> Result<(), NormalizedSqliteError> {
 fn acquire_snapshot_operation(
     snapshot_root: &SnapshotDirectory,
 ) -> Result<SnapshotOperationGuard, NormalizedSqliteError> {
-    let lock = snapshot_root.open_lock_file()?;
-    if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } < 0 {
-        let error = std::io::Error::last_os_error();
-        if error.kind() == std::io::ErrorKind::WouldBlock {
+    #[cfg(unix)]
+    {
+        let lock = snapshot_root.open_lock_file()?;
+        if unsafe { libc::flock(lock.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } < 0 {
+            let error = std::io::Error::last_os_error();
+            if error.kind() == std::io::ErrorKind::WouldBlock {
+                return Err(snapshot_error(
+                    "another normalized snapshot operation is already active",
+                ));
+            }
+            return Err(snapshot_error(error.to_string()));
+        }
+        Ok(SnapshotOperationGuard { lock })
+    }
+    #[cfg(windows)]
+    {
+        let mut lock = fslock::LockFile::open(snapshot_root.path.join(SNAPSHOT_LOCK_FILE))
+            .map_err(|error| snapshot_error(error.to_string()))?;
+        if !lock
+            .try_lock()
+            .map_err(|error| snapshot_error(error.to_string()))?
+        {
             return Err(snapshot_error(
                 "another normalized snapshot operation is already active",
             ));
         }
-        return Err(snapshot_error(error.to_string()));
+        Ok(SnapshotOperationGuard { _lock: lock })
     }
-    Ok(SnapshotOperationGuard { lock })
 }
 
 fn canonical_record(
@@ -997,6 +1127,7 @@ fn clear_normalized_local_snapshots_in_v1(
     snapshot_root.sync()
 }
 
+#[cfg(unix)]
 pub(crate) fn create_normalized_local_snapshot_bound_v1(
     connection: &mut Connection,
     snapshot_directory: RawFd,
@@ -1007,6 +1138,7 @@ pub(crate) fn create_normalized_local_snapshot_bound_v1(
     create_normalized_local_snapshot_in_v1(connection, &directory, created_at_ms, reason)
 }
 
+#[cfg(unix)]
 pub(crate) fn list_normalized_local_snapshots_bound_v1(
     snapshot_directory: RawFd,
 ) -> Result<Vec<NormalizedLocalSnapshotSummaryV1>, NormalizedSqliteError> {
@@ -1016,6 +1148,7 @@ pub(crate) fn list_normalized_local_snapshots_bound_v1(
 }
 
 #[allow(clippy::too_many_arguments)]
+#[cfg(unix)]
 pub(crate) fn restore_normalized_local_snapshot_bound_v1(
     connection: &mut Connection,
     snapshot_directory: RawFd,
@@ -1046,7 +1179,7 @@ pub(crate) fn clear_normalized_local_snapshots_bound_v1(
     clear_normalized_local_snapshots_in_v1(&directory)
 }
 
-#[cfg(test)]
+#[cfg(all(test, unix))]
 mod tests {
     use super::*;
     use crate::{install_normalized_schema_v1, prepare_fresh_normalized_desktop_library_v1};

--- a/packages/library-core-native/src/normalized_sqlite.rs
+++ b/packages/library-core-native/src/normalized_sqlite.rs
@@ -15,6 +15,7 @@ use rusqlite::{params, Connection, OpenFlags, OptionalExtension};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use sha2::{Digest, Sha256};
+use std::path::Path;
 
 const STAGED_RECORD_DIGEST_PREFIX: &[u8] =
     b"freed.library-core.v2/digest-bytes/staged-checkpoint-record\0";
@@ -42,6 +43,46 @@ pub(crate) fn configure_normalized_sqlite_connection(
     install_normalized_schema_v1(connection)?;
     connection.pragma_update(None, "journal_mode", "WAL")?;
     Ok(())
+}
+
+/// Opens the normalized Library database through the platform path boundary.
+///
+/// The caller must already hold the process-wide Library lease. This adapter
+/// rejects a symbolic final component, disables SQLite URI interpretation,
+/// uses a private cache, and applies the same schema and connection contract
+/// on every supported Desktop platform.
+pub fn open_normalized_sqlite_database_v1(
+    database_path: &Path,
+    create: bool,
+) -> Result<Connection, NormalizedSqliteError> {
+    let parent = database_path
+        .parent()
+        .ok_or(NormalizedSqliteError::InvalidRequest(
+            "normalized SQLite database has no parent directory",
+        ))?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| NormalizedSqliteError::Transport(error.to_string()))?;
+    let parent = std::fs::canonicalize(parent)
+        .map_err(|error| NormalizedSqliteError::Transport(error.to_string()))?;
+    let leaf = database_path
+        .file_name()
+        .ok_or(NormalizedSqliteError::InvalidRequest(
+            "normalized SQLite database file name is invalid",
+        ))?;
+    let resolved = parent.join(leaf);
+    match std::fs::symlink_metadata(&resolved) {
+        Ok(metadata) if metadata.file_type().is_symlink() || !metadata.is_file() => {
+            return Err(NormalizedSqliteError::InvalidRequest(
+                "normalized SQLite database is not an ordinary file",
+            ));
+        }
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound && create => {}
+        Err(error) => return Err(NormalizedSqliteError::Transport(error.to_string())),
+    }
+    let connection = Connection::open_with_flags(&resolved, normalized_sqlite_open_flags(create))?;
+    configure_normalized_sqlite_connection(&connection)?;
+    Ok(connection)
 }
 
 #[derive(Debug)]
@@ -742,6 +783,30 @@ mod tests {
         let connection = Connection::open_in_memory().expect("open");
         install_normalized_schema_v1(&connection).expect("schema");
         connection
+    }
+
+    #[test]
+    fn platform_path_opener_creates_and_reopens_the_normalized_schema() {
+        let root = tempfile::TempDir::new().expect("create database root");
+        let path = root
+            .path()
+            .join("library-sqlite")
+            .join("library-core.sqlite");
+        let created = open_normalized_sqlite_database_v1(&path, true).expect("create database");
+        assert_eq!(
+            created
+                .query_row("PRAGMA application_id;", [], |row| row.get::<_, i64>(0))
+                .expect("application identity"),
+            i64::from(SQLITE_APPLICATION_ID)
+        );
+        drop(created);
+        let reopened = open_normalized_sqlite_database_v1(&path, false).expect("reopen database");
+        assert_eq!(
+            reopened
+                .query_row("PRAGMA user_version;", [], |row| row.get::<_, i64>(0))
+                .expect("schema version"),
+            i64::from(SQLITE_SCHEMA_VERSION)
+        );
     }
 
     fn install_test_authority(connection: &Connection, accepted_counter: i64) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Run the activated SQLite Library Core on Windows with the same authority selector, bounded database contract, fresh genesis, fenced migration cutover, typed local snapshots, and a permanent Windows native compile gate.

## Testing
- npm run validate:feature
- cargo check --manifest-path packages/desktop/src-tauri/Cargo.toml --all-features
- GitHub Windows native compile

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `f06b9623d038328323a7abb83ab0a3fe0a074018`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `01a02119-c605-7fe3-95ee-5a04de9519ca`
- Provider review decision: `diff_authorized`
- Provider review artifact: `7571165a105870062cf49fbd85faa3f7bd449f22135dd4feb6de43caaf1b81cd`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The classified native startup file passes the existing application handle into the Windows-only SQLite storage-epoch cutover. Provider requests, navigation, cookies, headers, extraction, retries, cadence, media loading, login, and background activity are unchanged.
- Fingerprinting risk: None from this diff. It creates no provider contact and changes no provider-visible request or timing pattern.
- Lowest profile alternative: Keep provider traffic disabled while validating the Windows SQLite startup and release compile path offline.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`