### PR TITLE
fix: recover legacy Library cutover

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1166,6 +1166,8 @@ enum StartupFailureStage {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
 struct StartupFailureDetail {
     stage: StartupFailureStage,
+    #[serde(default)]
+    detail_stage: String,
     code: String,
     message: String,
     occurred_at_ms: u64,
@@ -2721,7 +2723,10 @@ fn mark_startup_failed(data_dir: &Path) {
     save_startup_recovery_state(data_dir, &state);
 }
 
-fn mark_startup_library_core_failure(data_dir: &Path, message: &str) {
+fn mark_startup_library_core_failure(
+    data_dir: &Path,
+    error: &library_core_desktop_runtime::NormalizedDesktopCutoverError,
+) {
     let occurred_at_ms = now_unix_ms();
     let mut state = load_startup_recovery_state(data_dir);
     state.pending_boot_started_at_ms = None;
@@ -2729,26 +2734,32 @@ fn mark_startup_library_core_failure(data_dir: &Path, message: &str) {
     state.last_failed_boot_at_ms = Some(occurred_at_ms);
     state.last_failure = Some(StartupFailureDetail {
         stage: StartupFailureStage::NormalizedSqliteCutover,
-        code: "library_core_cutover_refused".to_owned(),
-        message: bounded_startup_failure_message(message),
+        detail_stage: error.stage().as_str().to_owned(),
+        code: error.stage().failure_code().to_owned(),
+        message: bounded_startup_failure_message(error.message()),
         occurred_at_ms,
     });
     save_startup_recovery_state(data_dir, &state);
 }
 
-fn record_startup_library_core_failure(app: &tauri::AppHandle, data_dir: &Path, message: &str) {
-    mark_startup_library_core_failure(data_dir, message);
+fn record_startup_library_core_failure(
+    app: &tauri::AppHandle,
+    data_dir: &Path,
+    failure: &library_core_desktop_runtime::NormalizedDesktopCutoverError,
+) {
+    mark_startup_library_core_failure(data_dir, failure);
     error!(
-        "[library-core] normalized SQLite startup cutover refused: {}",
-        message
+        "[library-core] normalized SQLite startup cutover refused stage={}: {}",
+        failure.stage().as_str(),
+        failure.message()
     );
     append_runtime_health(
         app,
         serde_json::json!({
             "event": "library_core_startup_failure",
-            "stage": "normalized_sqlite_cutover",
-            "code": "library_core_cutover_refused",
-            "error": bounded_startup_failure_message(message),
+            "stage": failure.stage().as_str(),
+            "code": failure.stage().failure_code(),
+            "error": bounded_startup_failure_message(failure.message()),
         }),
     );
 }
@@ -15843,15 +15854,23 @@ mod tests {
     fn library_core_cutover_refusal_is_preserved_without_reopening_library_state() {
         let temp = tempfile::tempdir().unwrap();
         let oversized_message = format!("{}é", "x".repeat(STARTUP_FAILURE_MESSAGE_MAX_BYTES));
+        let error = library_core_desktop_runtime::NormalizedDesktopCutoverError::new(
+            library_core_desktop_runtime::NormalizedDesktopCutoverStage::CandidatePrepare,
+            oversized_message,
+        );
 
-        mark_startup_library_core_failure(temp.path(), &oversized_message);
+        mark_startup_library_core_failure(temp.path(), &error);
 
         let state = load_startup_recovery_state(temp.path());
         assert!(startup_requires_recovery(&state));
         assert_eq!(state.consecutive_failed_boots, 1);
         let failure = state.last_failure.expect("typed failure must be retained");
         assert_eq!(failure.stage, StartupFailureStage::NormalizedSqliteCutover);
-        assert_eq!(failure.code, "library_core_cutover_refused");
+        assert_eq!(failure.detail_stage, "candidate_prepare");
+        assert_eq!(
+            failure.code,
+            "library_core_cutover_candidate_prepare_refused"
+        );
         assert_eq!(failure.message.len(), STARTUP_FAILURE_MESSAGE_MAX_BYTES);
         assert!(failure.message.is_char_boundary(failure.message.len()));
     }
@@ -15868,6 +15887,7 @@ mod tests {
                 last_successful_boot_at_ms: Some(100),
                 last_failure: Some(StartupFailureDetail {
                     stage: StartupFailureStage::NormalizedSqliteCutover,
+                    detail_stage: "historical_source_state".to_owned(),
                     code: "library_core_cutover_refused".to_owned(),
                     message: "historical Library source refused".to_owned(),
                     occurred_at_ms: 123,
@@ -15903,6 +15923,7 @@ mod tests {
                 last_successful_boot_at_ms: Some(100),
                 last_failure: Some(StartupFailureDetail {
                     stage: StartupFailureStage::NormalizedSqliteCutover,
+                    detail_stage: "historical_source_state".to_owned(),
                     code: "library_core_cutover_refused".to_owned(),
                     message: "historical Library source refused".to_owned(),
                     occurred_at_ms: 123,
@@ -15941,6 +15962,10 @@ mod tests {
         assert_eq!(
             json["startupRecovery"]["last_failure"]["stage"],
             "normalized_sqlite_cutover"
+        );
+        assert_eq!(
+            json["startupRecovery"]["last_failure"]["detail_stage"],
+            "historical_source_state"
         );
         assert!(json["runtimeHealth"].as_str().unwrap().contains("new"));
         assert!(json["runtimeDiagnostics"]
@@ -17097,6 +17122,7 @@ mod tests {
                 last_successful_boot_at_ms: None,
                 last_failure: Some(StartupFailureDetail {
                     stage: StartupFailureStage::NormalizedSqliteCutover,
+                    detail_stage: "historical_source_state".to_owned(),
                     code: "library_core_cutover_refused".to_owned(),
                     message: "source refused".to_owned(),
                     occurred_at_ms: 789,

--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -1155,12 +1155,30 @@ async fn restore_scraper_feed(
     Ok(())
 }
 
+const STARTUP_FAILURE_MESSAGE_MAX_BYTES: usize = 4 * 1024;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum StartupFailureStage {
+    NormalizedSqliteCutover,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+struct StartupFailureDetail {
+    stage: StartupFailureStage,
+    code: String,
+    message: String,
+    occurred_at_ms: u64,
+}
+
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+#[serde(default)]
 struct StartupRecoveryState {
     consecutive_failed_boots: u32,
     pending_boot_started_at_ms: Option<u64>,
     last_failed_boot_at_ms: Option<u64>,
     last_successful_boot_at_ms: Option<u64>,
+    last_failure: Option<StartupFailureDetail>,
 }
 
 #[derive(Default)]
@@ -1263,6 +1281,18 @@ fn save_startup_recovery_state(data_dir: &Path, state: &StartupRecoveryState) {
             error
         );
     }
+}
+
+fn bounded_startup_failure_message(message: &str) -> String {
+    if message.len() <= STARTUP_FAILURE_MESSAGE_MAX_BYTES {
+        return message.to_owned();
+    }
+
+    let mut end = STARTUP_FAILURE_MESSAGE_MAX_BYTES;
+    while end > 0 && !message.is_char_boundary(end) {
+        end -= 1;
+    }
+    message[..end].to_owned()
 }
 
 fn runtime_health_path(data_dir: &Path) -> PathBuf {
@@ -2691,6 +2721,38 @@ fn mark_startup_failed(data_dir: &Path) {
     save_startup_recovery_state(data_dir, &state);
 }
 
+fn mark_startup_library_core_failure(data_dir: &Path, message: &str) {
+    let occurred_at_ms = now_unix_ms();
+    let mut state = load_startup_recovery_state(data_dir);
+    state.pending_boot_started_at_ms = None;
+    state.consecutive_failed_boots = state.consecutive_failed_boots.saturating_add(1);
+    state.last_failed_boot_at_ms = Some(occurred_at_ms);
+    state.last_failure = Some(StartupFailureDetail {
+        stage: StartupFailureStage::NormalizedSqliteCutover,
+        code: "library_core_cutover_refused".to_owned(),
+        message: bounded_startup_failure_message(message),
+        occurred_at_ms,
+    });
+    save_startup_recovery_state(data_dir, &state);
+}
+
+fn record_startup_library_core_failure(app: &tauri::AppHandle, data_dir: &Path, message: &str) {
+    mark_startup_library_core_failure(data_dir, message);
+    error!(
+        "[library-core] normalized SQLite startup cutover refused: {}",
+        message
+    );
+    append_runtime_health(
+        app,
+        serde_json::json!({
+            "event": "library_core_startup_failure",
+            "stage": "normalized_sqlite_cutover",
+            "code": "library_core_cutover_refused",
+            "error": bounded_startup_failure_message(message),
+        }),
+    );
+}
+
 fn mark_startup_pending(data_dir: &Path) {
     let mut state = load_startup_recovery_state(data_dir);
     state.pending_boot_started_at_ms = Some(now_unix_ms());
@@ -2706,13 +2768,17 @@ fn prepare_startup_recovery_retry(data_dir: &Path) {
 
 fn mark_startup_success(data_dir: &Path) {
     let mut state = load_startup_recovery_state(data_dir);
-    if state.pending_boot_started_at_ms.is_none() && state.consecutive_failed_boots == 0 {
+    if state.pending_boot_started_at_ms.is_none()
+        && state.consecutive_failed_boots == 0
+        && state.last_failure.is_none()
+    {
         return;
     }
 
     state.pending_boot_started_at_ms = None;
     state.consecutive_failed_boots = 0;
     state.last_successful_boot_at_ms = Some(now_unix_ms());
+    state.last_failure = None;
     save_startup_recovery_state(data_dir, &state);
     info!("[recovery] renderer reached healthy startup state");
 }
@@ -7760,6 +7826,18 @@ fn retry_startup_after_crash(app: tauri::AppHandle) -> Result<(), String> {
         .map_err(|error| error.to_string())?;
     std::fs::create_dir_all(&data_dir).ok();
     prepare_startup_recovery_retry(&data_dir);
+
+    match library_core_desktop_runtime::complete_normalized_desktop_cutover_if_ready(&app) {
+        Ok(true) => info!("[library-core] selected normalized SQLite authority during retry"),
+        Ok(false) => {}
+        Err(error) => {
+            record_startup_library_core_failure(&app, &data_dir, &error);
+            return Err(
+                "Freed could not safely open this Library. Download diagnostics and keep the existing Library files unchanged."
+                    .to_owned(),
+            );
+        }
+    }
 
     if let Some(window) = app.get_webview_window(MAIN_WINDOW_LABEL) {
         scrub_webview_before_destroy(&window);
@@ -12940,23 +13018,20 @@ pub fn run() {
                 .app_data_dir()
                 .expect("Failed to resolve app data directory");
             std::fs::create_dir_all(&data_dir).ok();
-            if library_core_desktop_runtime::complete_normalized_desktop_cutover_if_ready(
+            let mut startup_recovery_state = reconcile_startup_recovery_state(&data_dir);
+            match library_core_desktop_runtime::complete_normalized_desktop_cutover_if_ready(
                 &app_handle,
-            )
-                .map_err(std::io::Error::other)?
-            {
-                info!("[library-core] selected normalized SQLite authority");
+            ) {
+                Ok(true) => info!("[library-core] selected normalized SQLite authority"),
+                Ok(false) => {}
+                Err(error) => {
+                    record_startup_library_core_failure(&app_handle, &data_dir, &error);
+                    startup_recovery_state = load_startup_recovery_state(&data_dir);
+                }
             }
-            let dev_sync_result_data_dir = data_dir.clone();
-            app.listen("dev-sync-trigger-native-result", move |event| {
-                handle_dev_sync_trigger_result_event(&dev_sync_result_data_dir, event.payload());
-            });
-            start_dev_sync_trigger_watcher(app_handle.clone(), data_dir.clone());
-
             #[cfg(target_os = "macos")]
             clear_saved_window_state(&app_handle);
 
-            let startup_recovery_state = reconcile_startup_recovery_state(&data_dir);
             if startup_requires_recovery(&startup_recovery_state) {
                 warn!(
                     "[recovery] opening native recovery window after {} failed early startup attempt(s)",
@@ -12965,6 +13040,14 @@ pub fn run() {
                 let _ = open_or_focus_recovery_window(&app_handle)?;
             } else {
                 let _ = start_main_window_quietly(&app_handle)?;
+                let dev_sync_result_data_dir = data_dir.clone();
+                app.listen("dev-sync-trigger-native-result", move |event| {
+                    handle_dev_sync_trigger_result_event(
+                        &dev_sync_result_data_dir,
+                        event.payload(),
+                    );
+                });
+                start_dev_sync_trigger_watcher(app_handle.clone(), data_dir.clone());
             }
 
             // Build system tray
@@ -15757,6 +15840,23 @@ mod tests {
     }
 
     #[test]
+    fn library_core_cutover_refusal_is_preserved_without_reopening_library_state() {
+        let temp = tempfile::tempdir().unwrap();
+        let oversized_message = format!("{}é", "x".repeat(STARTUP_FAILURE_MESSAGE_MAX_BYTES));
+
+        mark_startup_library_core_failure(temp.path(), &oversized_message);
+
+        let state = load_startup_recovery_state(temp.path());
+        assert!(startup_requires_recovery(&state));
+        assert_eq!(state.consecutive_failed_boots, 1);
+        let failure = state.last_failure.expect("typed failure must be retained");
+        assert_eq!(failure.stage, StartupFailureStage::NormalizedSqliteCutover);
+        assert_eq!(failure.code, "library_core_cutover_refused");
+        assert_eq!(failure.message.len(), STARTUP_FAILURE_MESSAGE_MAX_BYTES);
+        assert!(failure.message.is_char_boundary(failure.message.len()));
+    }
+
+    #[test]
     fn startup_recovery_retry_rearms_pending_boot_without_preserving_failure_count() {
         let temp = tempfile::tempdir().unwrap();
         save_startup_recovery_state(
@@ -15766,6 +15866,12 @@ mod tests {
                 pending_boot_started_at_ms: None,
                 last_failed_boot_at_ms: Some(123),
                 last_successful_boot_at_ms: Some(100),
+                last_failure: Some(StartupFailureDetail {
+                    stage: StartupFailureStage::NormalizedSqliteCutover,
+                    code: "library_core_cutover_refused".to_owned(),
+                    message: "historical Library source refused".to_owned(),
+                    occurred_at_ms: 123,
+                }),
             },
         );
 
@@ -15775,6 +15881,13 @@ mod tests {
         assert_eq!(state.consecutive_failed_boots, 0);
         assert!(state.pending_boot_started_at_ms.is_some());
         assert_eq!(state.last_failed_boot_at_ms, Some(123));
+        assert_eq!(
+            state
+                .last_failure
+                .as_ref()
+                .map(|failure| failure.code.as_str()),
+            Some("library_core_cutover_refused")
+        );
     }
 
     #[test]
@@ -15788,6 +15901,12 @@ mod tests {
                 pending_boot_started_at_ms: None,
                 last_failed_boot_at_ms: Some(123),
                 last_successful_boot_at_ms: Some(100),
+                last_failure: Some(StartupFailureDetail {
+                    stage: StartupFailureStage::NormalizedSqliteCutover,
+                    code: "library_core_cutover_refused".to_owned(),
+                    message: "historical Library source refused".to_owned(),
+                    occurred_at_ms: 123,
+                }),
             },
         );
         std::fs::write(runtime_health_path(data_dir.path()), "old\nnew\n").unwrap();
@@ -15815,6 +15934,14 @@ mod tests {
         assert_eq!(json["version"], "26.6.901");
         assert_eq!(json["platform"], "macos");
         assert_eq!(json["startupRecovery"]["consecutive_failed_boots"], 1);
+        assert_eq!(
+            json["startupRecovery"]["last_failure"]["code"],
+            "library_core_cutover_refused"
+        );
+        assert_eq!(
+            json["startupRecovery"]["last_failure"]["stage"],
+            "normalized_sqlite_cutover"
+        );
         assert!(json["runtimeHealth"].as_str().unwrap().contains("new"));
         assert!(json["runtimeDiagnostics"]
             .as_str()
@@ -16946,6 +17073,7 @@ mod tests {
                 pending_boot_started_at_ms: Some(123),
                 last_failed_boot_at_ms: None,
                 last_successful_boot_at_ms: None,
+                last_failure: None,
             },
         );
 
@@ -16967,6 +17095,12 @@ mod tests {
                 pending_boot_started_at_ms: Some(456),
                 last_failed_boot_at_ms: Some(789),
                 last_successful_boot_at_ms: None,
+                last_failure: Some(StartupFailureDetail {
+                    stage: StartupFailureStage::NormalizedSqliteCutover,
+                    code: "library_core_cutover_refused".to_owned(),
+                    message: "source refused".to_owned(),
+                    occurred_at_ms: 789,
+                }),
             },
         );
 
@@ -16976,6 +17110,7 @@ mod tests {
         assert_eq!(state.consecutive_failed_boots, 0);
         assert!(state.pending_boot_started_at_ms.is_none());
         assert!(state.last_successful_boot_at_ms.is_some());
+        assert!(state.last_failure.is_none());
     }
 
     #[test]

--- a/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
@@ -19,6 +19,77 @@ use super::library_core_actor_key_store::{
 use super::library_core_authority_key_store::{
     load_established_authority_key_pair, PlatformAuthorityKeyStore,
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum NormalizedDesktopCutoverStage {
+    DesktopBinding,
+    AuthoritySelection,
+    HistoricalSourceOpen,
+    HistoricalSourceState,
+    NormalizedTargetOpen,
+    InstallationWitness,
+    CandidatePrepare,
+    SelectorPublish,
+}
+
+impl NormalizedDesktopCutoverStage {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::DesktopBinding => "desktop_binding",
+            Self::AuthoritySelection => "authority_selection",
+            Self::HistoricalSourceOpen => "historical_source_open",
+            Self::HistoricalSourceState => "historical_source_state",
+            Self::NormalizedTargetOpen => "normalized_target_open",
+            Self::InstallationWitness => "installation_witness",
+            Self::CandidatePrepare => "candidate_prepare",
+            Self::SelectorPublish => "selector_publish",
+        }
+    }
+
+    pub(super) const fn failure_code(self) -> &'static str {
+        match self {
+            Self::DesktopBinding => "library_core_cutover_desktop_binding_refused",
+            Self::AuthoritySelection => "library_core_cutover_authority_selection_refused",
+            Self::HistoricalSourceOpen => "library_core_cutover_historical_source_open_refused",
+            Self::HistoricalSourceState => "library_core_cutover_historical_source_state_refused",
+            Self::NormalizedTargetOpen => "library_core_cutover_normalized_target_open_refused",
+            Self::InstallationWitness => "library_core_cutover_installation_witness_refused",
+            Self::CandidatePrepare => "library_core_cutover_candidate_prepare_refused",
+            Self::SelectorPublish => "library_core_cutover_selector_publish_refused",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct NormalizedDesktopCutoverError {
+    stage: NormalizedDesktopCutoverStage,
+    message: String,
+}
+
+impl NormalizedDesktopCutoverError {
+    pub(super) fn new(stage: NormalizedDesktopCutoverStage, message: impl ToString) -> Self {
+        Self {
+            stage,
+            message: message.to_string(),
+        }
+    }
+
+    pub(super) const fn stage(&self) -> NormalizedDesktopCutoverStage {
+        self.stage
+    }
+
+    pub(super) fn message(&self) -> &str {
+        &self.message
+    }
+}
+
+impl std::fmt::Display for NormalizedDesktopCutoverError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{}: {}", self.stage.as_str(), self.message)
+    }
+}
+
+impl std::error::Error for NormalizedDesktopCutoverError {}
 #[cfg(not(unix))]
 const SNAPSHOT_DIRECTORY: &str = "library-snapshots";
 #[cfg(not(unix))]
@@ -294,7 +365,7 @@ fn publish_windows_authority_selection(
 
 pub(super) fn complete_normalized_desktop_cutover_if_ready(
     app: &tauri::AppHandle,
-) -> Result<bool, String> {
+) -> Result<bool, NormalizedDesktopCutoverError> {
     #[cfg(not(unix))]
     {
         return complete_windows_normalized_cutover(app);
@@ -302,17 +373,29 @@ pub(super) fn complete_normalized_desktop_cutover_if_ready(
     #[cfg(unix)]
     {
         let _ = app;
-        let binding = freed_library_core::desktop_binding().map_err(|error| error.to_string())?;
+        let binding = freed_library_core::desktop_binding().map_err(|error| {
+            NormalizedDesktopCutoverError::new(NormalizedDesktopCutoverStage::DesktopBinding, error)
+        })?;
         if binding
             .normalized_authority_is_selected_v1()
-            .map_err(|error| error.to_string())?
+            .map_err(|error| {
+                NormalizedDesktopCutoverError::new(
+                    NormalizedDesktopCutoverStage::AuthoritySelection,
+                    error,
+                )
+            })?
         {
             return Ok(false);
         }
         if !binding.historical_source_is_present_v1() {
             return Ok(false);
         }
-        let mut source = binding.connect().map_err(|error| error.to_string())?;
+        let mut source = binding.connect().map_err(|error| {
+            NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::HistoricalSourceOpen,
+                error,
+            )
+        })?;
         let source_state: Option<(i64, i64, i64, Option<i64>)> = source
             .query_row(
                 "SELECT active, expectedItemCount, importedItemCount, activatedAtMs
@@ -321,7 +404,12 @@ pub(super) fn complete_normalized_desktop_cutover_if_ready(
                 |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
             )
             .optional()
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| {
+                NormalizedDesktopCutoverError::new(
+                    NormalizedDesktopCutoverStage::HistoricalSourceState,
+                    error,
+                )
+            })?;
         let Some((active, expected_items, imported_items, activated_at)) = source_state else {
             return Ok(false);
         };
@@ -329,14 +417,29 @@ pub(super) fn complete_normalized_desktop_cutover_if_ready(
             return Ok(false);
         }
         if active != 1 || activated_at.is_none() || expected_items != imported_items {
-            return Err("historical Library is not a complete migration source".to_owned());
+            return Err(NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::HistoricalSourceState,
+                "historical Library is not a complete migration source",
+            ));
         }
-        let mut target = binding
-            .connect_normalized()
-            .map_err(|error| error.to_string())?;
-        let installation_witness = crate::get_desktop_installation_witness()?;
-        let accepted_at = i64::try_from(crate::unix_millis_now())
-            .map_err(|_| "Desktop cutover time is invalid".to_owned())?;
+        let mut target = binding.connect_normalized().map_err(|error| {
+            NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::NormalizedTargetOpen,
+                error,
+            )
+        })?;
+        let installation_witness = crate::get_desktop_installation_witness().map_err(|error| {
+            NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::InstallationWitness,
+                error,
+            )
+        })?;
+        let accepted_at = i64::try_from(crate::unix_millis_now()).map_err(|_| {
+            NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::CandidatePrepare,
+                "Desktop cutover time is invalid",
+            )
+        })?;
         let prepared = freed_library_core::prepare_normalized_desktop_cutover_v1(
             &mut source,
             &mut target,
@@ -345,24 +448,48 @@ pub(super) fn complete_normalized_desktop_cutover_if_ready(
             &PlatformAuthorityKeyStore,
             accepted_at,
         )
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::CandidatePrepare,
+                error,
+            )
+        })?;
         binding
             .publish_normalized_authority_selection_v1(&prepared)
-            .map_err(|error| error.to_string())?;
+            .map_err(|error| {
+                NormalizedDesktopCutoverError::new(
+                    NormalizedDesktopCutoverStage::SelectorPublish,
+                    error,
+                )
+            })?;
         Ok(true)
     }
 }
 
 #[cfg(not(unix))]
-fn complete_windows_normalized_cutover(app: &tauri::AppHandle) -> Result<bool, String> {
-    if app_root(app)?.join(AUTHORITY_SELECTION_FILE).exists() {
-        open_normalized_database(app)?;
+fn complete_windows_normalized_cutover(
+    app: &tauri::AppHandle,
+) -> Result<bool, NormalizedDesktopCutoverError> {
+    let root = app_root(app).map_err(|error| {
+        NormalizedDesktopCutoverError::new(NormalizedDesktopCutoverStage::DesktopBinding, error)
+    })?;
+    if root.join(AUTHORITY_SELECTION_FILE).exists() {
+        open_normalized_database(app).map_err(|error| {
+            NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::AuthoritySelection,
+                error,
+            )
+        })?;
         return Ok(false);
     }
-    let Some(mut source) = freed_library_core::open_historical_migration_source_v1(
-        &app_root(app)?.join("library-core"),
-    )
-    .map_err(|error| error.to_string())?
+    let Some(mut source) =
+        freed_library_core::open_historical_migration_source_v1(&root.join("library-core"))
+            .map_err(|error| {
+                NormalizedDesktopCutoverError::new(
+                    NormalizedDesktopCutoverStage::HistoricalSourceOpen,
+                    error,
+                )
+            })?
     else {
         return Ok(false);
     };
@@ -374,7 +501,12 @@ fn complete_windows_normalized_cutover(app: &tauri::AppHandle) -> Result<bool, S
             |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?)),
         )
         .optional()
-        .map_err(|error| error.to_string())?;
+        .map_err(|error| {
+            NormalizedDesktopCutoverError::new(
+                NormalizedDesktopCutoverStage::HistoricalSourceState,
+                error,
+            )
+        })?;
     let Some((active, expected_items, imported_items, activated_at)) = source_state else {
         return Ok(false);
     };
@@ -382,12 +514,29 @@ fn complete_windows_normalized_cutover(app: &tauri::AppHandle) -> Result<bool, S
         return Ok(false);
     }
     if active != 1 || activated_at.is_none() || expected_items != imported_items {
-        return Err("historical Library is not a complete migration source".into());
+        return Err(NormalizedDesktopCutoverError::new(
+            NormalizedDesktopCutoverStage::HistoricalSourceState,
+            "historical Library is not a complete migration source",
+        ));
     }
-    let mut target = open_unselected_normalized_database(app, true)?;
-    let installation_witness = crate::get_desktop_installation_witness()?;
-    let accepted_at = i64::try_from(crate::unix_millis_now())
-        .map_err(|_| "Desktop cutover time is invalid".to_owned())?;
+    let mut target = open_unselected_normalized_database(app, true).map_err(|error| {
+        NormalizedDesktopCutoverError::new(
+            NormalizedDesktopCutoverStage::NormalizedTargetOpen,
+            error,
+        )
+    })?;
+    let installation_witness = crate::get_desktop_installation_witness().map_err(|error| {
+        NormalizedDesktopCutoverError::new(
+            NormalizedDesktopCutoverStage::InstallationWitness,
+            error,
+        )
+    })?;
+    let accepted_at = i64::try_from(crate::unix_millis_now()).map_err(|_| {
+        NormalizedDesktopCutoverError::new(
+            NormalizedDesktopCutoverStage::CandidatePrepare,
+            "Desktop cutover time is invalid",
+        )
+    })?;
     let prepared = freed_library_core::prepare_normalized_desktop_cutover_v1(
         &mut source,
         &mut target,
@@ -396,9 +545,13 @@ fn complete_windows_normalized_cutover(app: &tauri::AppHandle) -> Result<bool, S
         &PlatformAuthorityKeyStore,
         accepted_at,
     )
-    .map_err(|error| error.to_string())?;
+    .map_err(|error| {
+        NormalizedDesktopCutoverError::new(NormalizedDesktopCutoverStage::CandidatePrepare, error)
+    })?;
     drop(target);
-    publish_windows_authority_selection(app, &prepared)?;
+    publish_windows_authority_selection(app, &prepared).map_err(|error| {
+        NormalizedDesktopCutoverError::new(NormalizedDesktopCutoverStage::SelectorPublish, error)
+    })?;
     Ok(true)
 }
 

--- a/packages/library-core-native/src/normalized_migration.rs
+++ b/packages/library-core-native/src/normalized_migration.rs
@@ -2340,12 +2340,22 @@ pub(crate) fn migrate_legacy_feed_item_v1(
     let content_bytes = take_large_text(object_mut(&mut item, "content")?, "text")?;
     let preserved_bytes = match item.get_mut("preservedContent") {
         None | Some(Value::Null) => None,
-        Some(value) => take_large_text(
-            value
+        Some(value) => {
+            let preserved = value
                 .as_object_mut()
-                .ok_or_else(|| invalid("legacy preserved content is invalid"))?,
-            "text",
-        )?,
+                .ok_or_else(|| invalid("legacy preserved content is invalid"))?;
+            if preserved
+                .get("publishedAt")
+                .and_then(Value::as_object)
+                .is_some_and(|value| {
+                    value.len() == 1
+                        && value.get("__nonFinite").and_then(Value::as_str) == Some("NaN")
+                })
+            {
+                preserved.insert("publishedAt".to_owned(), Value::Null);
+            }
+            take_large_text(preserved, "text")?
+        }
     };
     let content_digest = content_bytes
         .as_deref()
@@ -2456,51 +2466,79 @@ pub(crate) fn migrate_legacy_feed_item_v1(
         let signals = signals
             .as_object()
             .ok_or_else(|| invalid("legacy FeedItem signals are invalid"))?;
-        let version = signals
-            .get("version")
-            .and_then(Value::as_i64)
-            .filter(|value| *value >= 0)
-            .ok_or_else(|| invalid("legacy FeedItem signal version is invalid"))?;
-        let method = signals
-            .get("method")
-            .and_then(Value::as_str)
-            .ok_or_else(|| invalid("legacy FeedItem signal method is invalid"))?;
-        let inferred_at = signals
-            .get("inferredAt")
-            .and_then(Value::as_i64)
-            .filter(|value| *value >= 0)
-            .ok_or_else(|| invalid("legacy FeedItem signal time is invalid"))?;
-        transaction.execute(
-            "INSERT INTO library_feed_item_signals (global_id, version, method, inferred_at)
-             VALUES (?1, ?2, ?3, ?4);",
-            params![global_id, version, method, inferred_at],
-        )?;
-        let scores = signals
-            .get("scores")
-            .and_then(Value::as_object)
-            .ok_or_else(|| invalid("legacy FeedItem signal scores are invalid"))?;
-        if scores.len() > MAXIMUM_SIGNALS {
-            return Err(invalid("legacy FeedItem signal scores exceed their bound"));
-        }
-        let tags = bounded_array(
-            signals.get("tags"),
-            MAXIMUM_SIGNALS,
-            "legacy FeedItem signal tags exceed their bound",
-        )?;
-        for (signal, score) in scores {
-            if signal.is_empty() || signal.len() > 512 {
-                return Err(invalid("legacy FeedItem signal identity is invalid"));
+        if !signals.contains_key("version") {
+            if signals.len() != 1 || !signals.contains_key("tags") {
+                return Err(invalid("legacy FeedItem signal metadata is incomplete"));
             }
-            let score = score
-                .as_f64()
-                .filter(|value| value.is_finite())
-                .ok_or_else(|| invalid("legacy FeedItem signal score is invalid"))?;
-            let tagged = tags.iter().any(|tag| tag.as_str() == Some(signal.as_str()));
-            transaction.execute(
-                "INSERT INTO library_feed_item_signal_scores (global_id, signal, score, tagged)
-                 VALUES (?1, ?2, ?3, ?4);",
-                params![global_id, signal, score, tagged],
+            let tags = bounded_array(
+                signals.get("tags"),
+                MAXIMUM_SIGNALS,
+                "legacy FeedItem signal tags exceed their bound",
             )?;
+            for (ordinal, tag) in tags.iter().enumerate() {
+                let signal = tag
+                    .as_str()
+                    .filter(|value| !value.is_empty() && value.len() <= 512)
+                    .ok_or_else(|| invalid("legacy FeedItem signal identity is invalid"))?;
+                if tags[..ordinal]
+                    .iter()
+                    .any(|prior| prior.as_str() == Some(signal))
+                {
+                    return Err(invalid("legacy FeedItem signal identity is duplicated"));
+                }
+                transaction.execute(
+                    "INSERT INTO library_feed_item_signal_scores
+                     (global_id, signal, score, tagged) VALUES (?1, ?2, NULL, 1);",
+                    params![global_id, signal],
+                )?;
+            }
+        } else {
+            let version = signals
+                .get("version")
+                .and_then(Value::as_i64)
+                .filter(|value| *value >= 0)
+                .ok_or_else(|| invalid("legacy FeedItem signal version is invalid"))?;
+            let method = signals
+                .get("method")
+                .and_then(Value::as_str)
+                .ok_or_else(|| invalid("legacy FeedItem signal method is invalid"))?;
+            let inferred_at = signals
+                .get("inferredAt")
+                .and_then(Value::as_i64)
+                .filter(|value| *value >= 0)
+                .ok_or_else(|| invalid("legacy FeedItem signal time is invalid"))?;
+            transaction.execute(
+                "INSERT INTO library_feed_item_signals (global_id, version, method, inferred_at)
+             VALUES (?1, ?2, ?3, ?4);",
+                params![global_id, version, method, inferred_at],
+            )?;
+            let scores = signals
+                .get("scores")
+                .and_then(Value::as_object)
+                .ok_or_else(|| invalid("legacy FeedItem signal scores are invalid"))?;
+            if scores.len() > MAXIMUM_SIGNALS {
+                return Err(invalid("legacy FeedItem signal scores exceed their bound"));
+            }
+            let tags = bounded_array(
+                signals.get("tags"),
+                MAXIMUM_SIGNALS,
+                "legacy FeedItem signal tags exceed their bound",
+            )?;
+            for (signal, score) in scores {
+                if signal.is_empty() || signal.len() > 512 {
+                    return Err(invalid("legacy FeedItem signal identity is invalid"));
+                }
+                let score = score
+                    .as_f64()
+                    .filter(|value| value.is_finite())
+                    .ok_or_else(|| invalid("legacy FeedItem signal score is invalid"))?;
+                let tagged = tags.iter().any(|tag| tag.as_str() == Some(signal.as_str()));
+                transaction.execute(
+                    "INSERT INTO library_feed_item_signal_scores (global_id, signal, score, tagged)
+                     VALUES (?1, ?2, ?3, ?4);",
+                    params![global_id, signal, score, tagged],
+                )?;
+            }
         }
     }
 
@@ -2733,8 +2771,13 @@ mod tests {
             "publishedAt": 9,
             "author": {"id": "author", "handle": "ada", "displayName": "Ada"},
             "content": {"text": "Body", "mediaUrls": [], "mediaTypes": []},
+            "preservedContent": {
+                "text": "Preserved body",
+                "publishedAt": {"__nonFinite": "NaN"}
+            },
             "userState": {"hidden": false, "saved": false, "archived": false, "tags": tags},
-            "topics": []
+            "topics": [],
+            "contentSignals": {"tags": ["essay", "recommendation"]}
         });
         connection
             .execute(
@@ -2774,6 +2817,39 @@ mod tests {
             (1, 1, 1)
         );
         assert_eq!(receipt.reach_outs, 1);
+        assert_eq!(
+            target
+                .query_row(
+                    "SELECT preserved_published_at FROM library_feed_items
+                     WHERE global_id = 'rss:live';",
+                    [],
+                    |row| row.get::<_, Option<i64>>(0),
+                )
+                .unwrap(),
+            None
+        );
+        assert_eq!(
+            target
+                .query_row(
+                    "SELECT count(*) FROM library_feed_item_signals
+                     WHERE global_id = 'rss:live';",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        assert_eq!(
+            target
+                .query_row(
+                    "SELECT count(*) FROM library_feed_item_signal_scores
+                     WHERE global_id = 'rss:live' AND score IS NULL AND tagged = 1;",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            2
+        );
         assert_eq!(receipt.normalized_product_digest.len(), 64);
         assert!(receipt.normalized_record_count > 5);
         assert_eq!(
@@ -3517,5 +3593,113 @@ mod tests {
             .records
             .iter()
             .all(|record| !record.registry_key.contains("shell")));
+    }
+
+    #[test]
+    fn migrates_legacy_tag_only_signals_without_inventing_analysis_metadata() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        install_normalized_schema_v1(&connection).unwrap();
+        let item = json!({
+            "globalId": "rss:tag-only-signals",
+            "platform": "rss",
+            "contentType": "article",
+            "capturedAt": 10,
+            "publishedAt": 9,
+            "author": {"id": "author", "handle": "author", "displayName": "Author"},
+            "content": {"text": "Body", "mediaUrls": [], "mediaTypes": []},
+            "userState": {
+                "hidden": false,
+                "saved": false,
+                "archived": false,
+                "tags": [],
+                "highlights": []
+            },
+            "contentSignals": {"tags": ["essay", "recommendation"]}
+        });
+        let transaction = connection.transaction().unwrap();
+        migrate_legacy_feed_item_v1(&transaction, "rss:tag-only-signals", &item.to_string(), 11)
+            .unwrap();
+        transaction.commit().unwrap();
+
+        assert_eq!(
+            connection
+                .query_row(
+                    "SELECT count(*) FROM library_feed_item_signals
+                     WHERE global_id = 'rss:tag-only-signals';",
+                    [],
+                    |row| row.get::<_, i64>(0),
+                )
+                .unwrap(),
+            0
+        );
+        let mut statement = connection
+            .prepare(
+                "SELECT signal, score, tagged FROM library_feed_item_signal_scores
+                 WHERE global_id = 'rss:tag-only-signals' ORDER BY signal;",
+            )
+            .unwrap();
+        let rows = statement
+            .query_map([], |row| {
+                Ok((
+                    row.get::<_, String>(0)?,
+                    row.get::<_, Option<f64>>(1)?,
+                    row.get::<_, i64>(2)?,
+                ))
+            })
+            .unwrap()
+            .collect::<rusqlite::Result<Vec<_>>>()
+            .unwrap();
+        assert_eq!(
+            rows,
+            vec![
+                ("essay".to_owned(), None, 1),
+                ("recommendation".to_owned(), None, 1),
+            ]
+        );
+    }
+
+    #[test]
+    fn migrates_legacy_non_finite_preserved_publication_time_as_absent() {
+        let mut connection = Connection::open_in_memory().unwrap();
+        install_normalized_schema_v1(&connection).unwrap();
+        let item = json!({
+            "globalId": "x:legacy-preserved-time",
+            "platform": "x",
+            "contentType": "post",
+            "capturedAt": 10,
+            "publishedAt": 9,
+            "author": {"id": "author", "handle": "author", "displayName": "Author"},
+            "content": {"text": "Body", "mediaUrls": [], "mediaTypes": []},
+            "preservedContent": {
+                "text": "Preserved body",
+                "publishedAt": {"__nonFinite": "NaN"}
+            },
+            "userState": {
+                "hidden": false,
+                "saved": false,
+                "archived": false,
+                "tags": [],
+                "highlights": []
+            }
+        });
+        let transaction = connection.transaction().unwrap();
+        migrate_legacy_feed_item_v1(
+            &transaction,
+            "x:legacy-preserved-time",
+            &item.to_string(),
+            11,
+        )
+        .unwrap();
+        transaction.commit().unwrap();
+
+        let preserved_published_at = connection
+            .query_row(
+                "SELECT preserved_published_at FROM library_feed_items
+                 WHERE global_id = 'x:legacy-preserved-time';",
+                [],
+                |row| row.get::<_, Option<i64>>(0),
+            )
+            .unwrap();
+        assert_eq!(preserved_published_at, None);
     }
 }


### PR DESCRIPTION
(AI Generated).

## Summary

- Preserve normalized SQLite cutover failures as bounded typed startup diagnostics instead of letting a Tauri setup panic abort Freed Desktop.
- Identify the exact refused cutover stage and open local recovery without starting the development sync watcher.
- Migrate legitimate historical tag-only content signals without inventing analysis metadata.
- Treat the historical non-finite preserved publication sentinel as an absent optional timestamp.
- Reproduce both private data shapes with a synthetic fenced historical Library, authority frontier, installation witness, cutover, actor installation, and replay fixture.

## Root cause

The 2902 cutover migrator required full classifier metadata for every non-null `contentSignals` object. Older valid rows can contain only tags. A smaller set of preserved articles also stores an optional unknown publication time as the historical canonical non-finite sentinel. Candidate preparation refused those rows, and Tauri converted the setup error into a panic inside the macOS application delegate callback, producing SIGABRT.

## Validation

- Exact copied primary Library migrated to a new isolated normalized target with SQLite integrity `ok` and zero foreign-key violations.
- Historical source database, WAL, and SHM remained unchanged.
- Library Core native lint passed with warnings denied.
- Library Core native tests passed, 180 tests.
- Desktop native tests passed, 170 tests.
- Desktop unit tests passed, 785 tests.
- Scoped browser tests passed, 32 tests.
- Desktop production build passed using the pinned Node 24 toolchain.
- Changed-path feature validation passed.
- Main backflow validation passed.

## Boundaries

This changes no provider requests, WebView navigation, cookies, headers, retry behavior, paging, cadence, extraction, or provider timing. No live provider traffic was used. The primary Library has not been reopened or modified.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `f89865dd39d4367b310c427866262cde5edce402`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-core-launch-abort-20260829`
- Provider review decision: `diff_authorized`
- Provider review artifact: `a6e6c8d12623d16b0134d35ccb3fd881b0840bd4ccc8b688eeb40a115ee45b60`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. Successful startup keeps the existing provider flow. A refused Library cutover now opens local recovery while the development sync watcher remains stopped. The prior refused path aborted before provider work, so both paths make zero provider contacts.
- Fingerprinting risk: None introduced. The diff adds no request, WebView load, navigation, retry, cadence, cookie, header, scrolling, click, media, login, extraction, or provider timing change.
- Lowest profile alternative: Keep all provider traffic disabled and validate the Library migration and recovery path with offline synthetic fixtures and the preserved copied Library.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`