### PR TITLE
fix: restore Command-Q quit on macOS

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -12887,17 +12887,23 @@ fn handle_primary_menu_action(app: &tauri::AppHandle, id: &str) -> bool {
     }
 }
 
+fn build_primary_show_item<R: tauri::Runtime, M: Manager<R>>(
+    manager: &M,
+) -> tauri::Result<MenuItem<R>> {
+    MenuItem::with_id(
+        manager,
+        PRIMARY_MENU_ITEM_SHOW,
+        "Show Freed",
+        true,
+        None::<&str>,
+    )
+}
+
 fn build_primary_action_items<R: tauri::Runtime, M: Manager<R>>(
     manager: &M,
 ) -> tauri::Result<(MenuItem<R>, MenuItem<R>)> {
     Ok((
-        MenuItem::with_id(
-            manager,
-            PRIMARY_MENU_ITEM_SHOW,
-            "Show Freed",
-            true,
-            None::<&str>,
-        )?,
+        build_primary_show_item(manager)?,
         MenuItem::with_id(
             manager,
             PRIMARY_MENU_ITEM_QUIT,
@@ -12928,7 +12934,9 @@ fn handle_macos_reopen(app: &tauri::AppHandle, has_visible_windows: bool) {
 
 #[cfg(target_os = "macos")]
 fn build_macos_app_menu<R: tauri::Runtime, M: Manager<R>>(manager: &M) -> tauri::Result<Menu<R>> {
-    let (show_item, quit_item) = build_primary_action_items(manager)?;
+    let show_item = build_primary_show_item(manager)?;
+    // The native Quit item owns the standard Command-Q accelerator on macOS.
+    let quit_item = PredefinedMenuItem::quit(manager, Some("Quit Freed"))?;
     let app_menu = Submenu::with_items(
         manager,
         manager.app_handle().package_info().name.clone(),


### PR DESCRIPTION
(AI Generated).

## Summary
- Use the native macOS Quit menu item so the system Command-Q accelerator terminates Freed Desktop.
- Keep the tray Quit action on the existing explicit exit path.

## Testing
- npm run validate:feature
- Isolated native Freed Preview exited after Command-Q was sent to its exact process.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `a40b8e1247f2da74b6df6c92534593697a8a8091`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `macos-command-q-20260829`
- Provider review decision: `diff_authorized`
- Provider review artifact: `8e5bd464914f51d1dfa2cd5a72867cb4c3435182bb9af8b4a7051ebbb1f62e08`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. The diff only replaces Freed Desktop's custom macOS Quit menu item with Tauri's native Quit item.
- Fingerprinting risk: None. The change does not alter provider requests, navigation, timing, retries, cookies, headers, scrolling, clicks, extraction, media, login, or background activity.
- Lowest profile alternative: Keep all provider traffic disabled while validating the local macOS application lifecycle.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`