### PR TITLE
chore: prepare v26.8.2903-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.2902",
+  "version": "26.8.2903",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.2902"
+version = "26.8.2903"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.2902"
+version = "26.8.2903"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.2902",
+  "version": "26.8.2903",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.2902",
+  "version": "26.8.2903",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.29.json
+++ b/release-notes/daily/dev/26.8.29.json
@@ -10,5 +10,5 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [],
-  "updatedAt": "2026-08-30T00:24:32.146Z"
+  "updatedAt": "2026-08-30T03:05:30.651Z"
 }

--- a/release-notes/releases/v26.8.2903-dev.json
+++ b/release-notes/releases/v26.8.2903-dev.json
@@ -3,7 +3,7 @@
   "version": "26.8.2903-dev",
   "channel": "dev",
   "dayKey": "26.8.29",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-08-30T03:05:30.645Z",
   "model": "heuristic",
@@ -97,20 +97,21 @@
     ]
   },
   "release": {
-    "deck": "Replace library authority with SQLite, support trusted automation launchers on Linux, and run every Library view from bounded SQLite queries",
+    "deck": "Freed Desktop now repairs real-world legacy Library data during SQLite cutover instead of aborting at launch",
     "features": [
-      "Replace library authority with SQLite",
-      "Support trusted automation launchers on Linux",
-      "Run every Library view from bounded SQLite queries"
+      "Run every Library view from bounded SQLite queries",
+      "Store and sync normalized Library records without the historical engines",
+      "Support trusted automation launchers on Linux"
     ],
     "fixes": [
-      "Recover legacy Library cutover",
-      "Admit supported Library predecessors",
+      "Migrate tag-only content analysis without inventing confidence scores",
+      "Treat preserved non-finite publication timestamps as missing data",
+      "Keep refused cutovers in typed recovery and stop Library sync until retry succeeds",
+      "Accept historical schemas 6 through 12 at cutover",
       "Run Library Core on Windows",
       "Align claim freshness with trusted launcher",
       "Forward Go compiler to Linux actor build",
-      "Add event history witness repair",
-      "Accept historical schemas 6 through 12 at cutover"
+      "Add event history witness repair"
     ],
     "followUps": [
       "Align Vite 8 build tooling",
@@ -122,11 +123,8 @@
       "Bump the cargo-updates group across 1 directory with 2 updates",
       "Bump js-yaml from 4.3.0 to 4.3.1",
       "Bump fast-uri from 3.1.4 to 3.1.5",
-      "Bump undici from 7.28.0 to 7.29.0",
-      "Store and sync normalized Library records without the historical engines",
-      "Freed now runs its Library on SQLite across Freed Desktop and PWA, with bounded queries, normalized sync records, and native Windows support",
-      "The SQLite release now upgrades real-world Libraries without reopening the retired engines"
+      "Bump undici from 7.28.0 to 7.29.0"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.2903-dev\n\nReplace library authority with SQLite, support trusted automation launchers on Linux, and run every Library view from bounded SQLite queries\n\n### Features\n\n- Replace library authority with SQLite\n- Support trusted automation launchers on Linux\n- Run every Library view from bounded SQLite queries\n\n### Fixes\n\n- Recover legacy Library cutover\n- Admit supported Library predecessors\n- Run Library Core on Windows\n- Align claim freshness with trusted launcher\n- Forward Go compiler to Linux actor build\n- Add event history witness repair\n- Accept historical schemas 6 through 12 at cutover\n\n### Follow-ups\n\n- Align Vite 8 build tooling\n- Bump serde_with from 3.16.1 to 3.22.0 in /packages/desktop/src-tauri\n- Bump vite from 7.3.6 to 8.2.1\n- Bump globals from 16.5.0 to 17.11.0\n- Bump react-router and react-router-dom\n- Bump postcss from 8.5.23 to 8.5.24\n- Bump the cargo-updates group across 1 directory with 2 updates\n- Bump js-yaml from 4.3.0 to 4.3.1\n- Bump fast-uri from 3.1.4 to 3.1.5\n- Bump undici from 7.28.0 to 7.29.0\n- Store and sync normalized Library records without the historical engines\n- Freed now runs its Library on SQLite across Freed Desktop and PWA, with bounded queries, normalized sync records, and native Windows support\n- The SQLite release now upgrades real-world Libraries without reopening the retired engines\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.2903-dev\n\nFreed Desktop now repairs real-world legacy Library data during SQLite cutover instead of aborting at launch.\n\n### Features\n\n- Run every Library view from bounded SQLite queries\n- Store and sync normalized Library records without the historical engines\n- Support trusted automation launchers on Linux\n\n### Fixes\n\n- Migrate tag-only content analysis without inventing confidence scores\n- Treat preserved non-finite publication timestamps as missing data\n- Keep refused cutovers in typed recovery and stop Library sync until retry succeeds\n- Accept historical schemas 6 through 12 at cutover\n- Run Library Core on Windows\n- Align claim freshness with trusted launcher\n- Forward Go compiler to Linux actor build\n- Add event history witness repair\n\n### Follow-ups\n\n- Align Vite 8 build tooling\n- Bump serde_with from 3.16.1 to 3.22.0 in /packages/desktop/src-tauri\n- Bump vite from 7.3.6 to 8.2.1\n- Bump globals from 16.5.0 to 17.11.0\n- Bump react-router and react-router-dom\n- Bump postcss from 8.5.23 to 8.5.24\n- Bump the cargo-updates group across 1 directory with 2 updates\n- Bump js-yaml from 4.3.0 to 4.3.1\n- Bump fast-uri from 3.1.4 to 3.1.5\n- Bump undici from 7.28.0 to 7.29.0\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.2903-dev.json
+++ b/release-notes/releases/v26.8.2903-dev.json
@@ -1,0 +1,132 @@
+{
+  "tag": "v26.8.2903-dev",
+  "version": "26.8.2903-dev",
+  "channel": "dev",
+  "dayKey": "26.8.29",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-30T03:05:30.645Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.2902-dev",
+    "previousPublishedDayTag": "v26.8.2002-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "f77d8f035f0944eacf20448811e1e82df241b989",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.2902-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "57486577813719373272b3581309487e8b8194cd",
+        "toInclusiveProductCommitSha": "f77d8f035f0944eacf20448811e1e82df241b989"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:c89f638d83bb23aad4c8db5feda04a332a1255ab7a1393a2508c47a4d8317883",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.2901-dev",
+      "v26.8.2902-dev",
+      "v26.8.2903-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.2901-dev",
+      "v26.8.2902-dev",
+      "v26.8.2903-dev"
+    ],
+    "prNumbers": [
+      1187,
+      1189,
+      1356,
+      1357,
+      1362,
+      1366,
+      1439,
+      1512,
+      1514,
+      1616,
+      1617,
+      1619,
+      1629,
+      1631,
+      1635,
+      1638,
+      1640,
+      1641,
+      1642,
+      1643,
+      1644
+    ],
+    "commitSubjects": [
+      "fix: recover legacy Library cutover (#1644)",
+      "chore: prepare v26.8.2902-dev (#1643)",
+      "fix: admit supported Library predecessors (#1642)",
+      "chore: prepare v26.8.2901-dev (#1641)",
+      "fix: run Library Core on Windows (#1640)",
+      "fix: align claim freshness with trusted launcher (#1638)",
+      "chore: prepare v26.8.2900-dev (#1635)",
+      "feat: replace library authority with SQLite (#1616)",
+      "fix: forward Go compiler to Linux actor build (#1631)",
+      "feat: support trusted automation launchers on Linux (#1512)",
+      "fix: add event history witness repair (#1629)",
+      "chore(deps-dev): align Vite 8 build tooling (#1619)",
+      "chore(deps): bump serde_with in /packages/desktop/src-tauri (#1617)",
+      "chore(deps-dev): bump vite from 7.3.6 to 8.2.1 (#1187)",
+      "chore(deps-dev): bump globals from 16.5.0 to 17.11.0 (#1189)",
+      "chore(deps): bump react-router and react-router-dom (#1362)",
+      "chore(deps-dev): bump postcss from 8.5.23 to 8.5.24 (#1439)",
+      "chore(deps): bump the cargo-updates group across 1 directory with 2 updates (#1514)",
+      "chore(deps-dev): bump js-yaml from 4.3.0 to 4.3.1 (#1366)",
+      "chore(deps-dev): bump fast-uri from 3.1.4 to 3.1.5 (#1357)",
+      "chore(deps): bump undici from 7.28.0 to 7.29.0 (#1356)"
+    ]
+  },
+  "release": {
+    "deck": "Replace library authority with SQLite, support trusted automation launchers on Linux, and run every Library view from bounded SQLite queries",
+    "features": [
+      "Replace library authority with SQLite",
+      "Support trusted automation launchers on Linux",
+      "Run every Library view from bounded SQLite queries"
+    ],
+    "fixes": [
+      "Recover legacy Library cutover",
+      "Admit supported Library predecessors",
+      "Run Library Core on Windows",
+      "Align claim freshness with trusted launcher",
+      "Forward Go compiler to Linux actor build",
+      "Add event history witness repair",
+      "Accept historical schemas 6 through 12 at cutover"
+    ],
+    "followUps": [
+      "Align Vite 8 build tooling",
+      "Bump serde_with from 3.16.1 to 3.22.0 in /packages/desktop/src-tauri",
+      "Bump vite from 7.3.6 to 8.2.1",
+      "Bump globals from 16.5.0 to 17.11.0",
+      "Bump react-router and react-router-dom",
+      "Bump postcss from 8.5.23 to 8.5.24",
+      "Bump the cargo-updates group across 1 directory with 2 updates",
+      "Bump js-yaml from 4.3.0 to 4.3.1",
+      "Bump fast-uri from 3.1.4 to 3.1.5",
+      "Bump undici from 7.28.0 to 7.29.0",
+      "Store and sync normalized Library records without the historical engines",
+      "Freed now runs its Library on SQLite across Freed Desktop and PWA, with bounded queries, normalized sync records, and native Windows support",
+      "The SQLite release now upgrades real-world Libraries without reopening the retired engines"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.2903-dev\n\nReplace library authority with SQLite, support trusted automation launchers on Linux, and run every Library view from bounded SQLite queries\n\n### Features\n\n- Replace library authority with SQLite\n- Support trusted automation launchers on Linux\n- Run every Library view from bounded SQLite queries\n\n### Fixes\n\n- Recover legacy Library cutover\n- Admit supported Library predecessors\n- Run Library Core on Windows\n- Align claim freshness with trusted launcher\n- Forward Go compiler to Linux actor build\n- Add event history witness repair\n- Accept historical schemas 6 through 12 at cutover\n\n### Follow-ups\n\n- Align Vite 8 build tooling\n- Bump serde_with from 3.16.1 to 3.22.0 in /packages/desktop/src-tauri\n- Bump vite from 7.3.6 to 8.2.1\n- Bump globals from 16.5.0 to 17.11.0\n- Bump react-router and react-router-dom\n- Bump postcss from 8.5.23 to 8.5.24\n- Bump the cargo-updates group across 1 directory with 2 updates\n- Bump js-yaml from 4.3.0 to 4.3.1\n- Bump fast-uri from 3.1.4 to 3.1.5\n- Bump undici from 7.28.0 to 7.29.0\n- Store and sync normalized Library records without the historical engines\n- Freed now runs its Library on SQLite across Freed Desktop and PWA, with bounded queries, normalized sync records, and native Windows support\n- The SQLite release now upgrades real-world Libraries without reopening the retired engines\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.2903-dev.md
+++ b/release-notes/releases/v26.8.2903-dev.md
@@ -1,0 +1,45 @@
+(AI Generated).
+
+## Freed v26.8.2903-dev
+
+Replace library authority with SQLite, support trusted automation launchers on Linux, and run every Library view from bounded SQLite queries
+
+### Features
+
+- Replace library authority with SQLite
+- Support trusted automation launchers on Linux
+- Run every Library view from bounded SQLite queries
+
+### Fixes
+
+- Recover legacy Library cutover
+- Admit supported Library predecessors
+- Run Library Core on Windows
+- Align claim freshness with trusted launcher
+- Forward Go compiler to Linux actor build
+- Add event history witness repair
+- Accept historical schemas 6 through 12 at cutover
+
+### Follow-ups
+
+- Align Vite 8 build tooling
+- Bump serde_with from 3.16.1 to 3.22.0 in /packages/desktop/src-tauri
+- Bump vite from 7.3.6 to 8.2.1
+- Bump globals from 16.5.0 to 17.11.0
+- Bump react-router and react-router-dom
+- Bump postcss from 8.5.23 to 8.5.24
+- Bump the cargo-updates group across 1 directory with 2 updates
+- Bump js-yaml from 4.3.0 to 4.3.1
+- Bump fast-uri from 3.1.4 to 3.1.5
+- Bump undici from 7.28.0 to 7.29.0
+- Store and sync normalized Library records without the historical engines
+- Freed now runs its Library on SQLite across Freed Desktop and PWA, with bounded queries, normalized sync records, and native Windows support
+- The SQLite release now upgrades real-world Libraries without reopening the retired engines
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.8.2903-dev.md
+++ b/release-notes/releases/v26.8.2903-dev.md
@@ -2,23 +2,24 @@
 
 ## Freed v26.8.2903-dev
 
-Replace library authority with SQLite, support trusted automation launchers on Linux, and run every Library view from bounded SQLite queries
+Freed Desktop now repairs real-world legacy Library data during SQLite cutover instead of aborting at launch.
 
 ### Features
 
-- Replace library authority with SQLite
-- Support trusted automation launchers on Linux
 - Run every Library view from bounded SQLite queries
+- Store and sync normalized Library records without the historical engines
+- Support trusted automation launchers on Linux
 
 ### Fixes
 
-- Recover legacy Library cutover
-- Admit supported Library predecessors
+- Migrate tag-only content analysis without inventing confidence scores
+- Treat preserved non-finite publication timestamps as missing data
+- Keep refused cutovers in typed recovery and stop Library sync until retry succeeds
+- Accept historical schemas 6 through 12 at cutover
 - Run Library Core on Windows
 - Align claim freshness with trusted launcher
 - Forward Go compiler to Linux actor build
 - Add event history witness repair
-- Accept historical schemas 6 through 12 at cutover
 
 ### Follow-ups
 
@@ -32,9 +33,6 @@ Replace library authority with SQLite, support trusted automation launchers on L
 - Bump js-yaml from 4.3.0 to 4.3.1
 - Bump fast-uri from 3.1.4 to 3.1.5
 - Bump undici from 7.28.0 to 7.29.0
-- Store and sync normalized Library records without the historical engines
-- Freed now runs its Library on SQLite across Freed Desktop and PWA, with bounded queries, normalized sync records, and native Windows support
-- The SQLite release now upgrades real-world Libraries without reopening the retired engines
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary

- Prepare v26.8.2903-dev from product commit f77d8f035f0944eacf20448811e1e82df241b989.
- Repair real-world legacy Library analysis shapes during the SQLite cutover instead of aborting at launch.
- Version Freed Desktop and the PWA together at 26.8.2903.
- Preserve the cumulative same-day SQLite release record with no new Library Core activation transition.

## Testing

- npm run validate:feature
- PWA OPFS durability: 1 passed
- PWA unit tests: 308 passed
- Desktop unit tests: 785 passed
- Desktop startup smoke: 9 passed
- Native Desktop tests: 171 passed
- Release notes, retired-engine guard, and release identity validation passed at 670b5a1a9ca4c23c9633f8fdf034fd8d8c222acc.