### PR TITLE
fix: use synchronized reading preferences in feed e2e

### DIFF
--- a/packages/desktop/tests/e2e/fixtures/app.ts
+++ b/packages/desktop/tests/e2e/fixtures/app.ts
@@ -78,6 +78,24 @@ export async function setDeviceDisplayPreferences(
   }, update);
 }
 
+async function updatePreferences(
+  page: Page,
+  update: Readonly<Record<string, unknown>>,
+): Promise<void> {
+  await page.evaluate(async (values) => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | {
+          getState: () => {
+            updatePreferences: (next: Record<string, unknown>) => Promise<void>;
+          };
+        }
+      | undefined;
+    const state = store?.getState();
+    if (!state) throw new Error("Freed store is unavailable");
+    await state.updatePreferences(values);
+  }, update);
+}
+
 export class AppFixture {
   constructor(public readonly page: Page) {}
 
@@ -85,6 +103,12 @@ export class AppFixture {
     update: Readonly<Record<string, unknown>>,
   ): Promise<void> {
     await setDeviceDisplayPreferences(this.page, update);
+  }
+
+  async updatePreferences(
+    update: Readonly<Record<string, unknown>>,
+  ): Promise<void> {
+    await updatePreferences(this.page, update);
   }
 
   async acceptLegalGateIfPresent(timeout = 5_000): Promise<boolean> {

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -2752,7 +2752,11 @@ test("feed toolbar bulk action counts follow the active filter", async ({ app, p
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
-  await app.setDeviceDisplayPreferences({ markReadOnScroll: false });
+  await app.updatePreferences({
+    display: {
+      reading: { markReadOnScroll: false },
+    },
+  });
 
   const activeFeedUrl = "https://bench.example/active-filter-feed.xml";
   const otherFeedUrl = "https://bench.example/other-filter-feed.xml";


### PR DESCRIPTION
(AI Generated).

## Summary
- Route the feed bulk-count regression through the live synchronized preference mutation instead of writing an unsupported device-local field.
- Keep the test aligned with the SQLite-backed preference authority used by Freed Desktop.

## Testing
- Exact failed regression passed 10 consecutive runs.
- npm run validate:feature