### PR TITLE
fix: stop Friend location render loops

### DIFF
--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3390,6 +3390,15 @@ test("Map view popup exposes friend actions and supports post navigation", async
 });
 
 test("Friend detail last seen card opens the full Map view", async ({ app }) => {
+  const renderLoopErrors: string[] = [];
+  app.page.on("console", (message) => {
+    if (
+      message.type() === "error" &&
+      message.text().includes("Maximum update depth exceeded")
+    ) {
+      renderLoopErrors.push(message.text());
+    }
+  });
   await app.page.route("https://nominatim.openstreetmap.org/search**", async (route) => {
     await route.fulfill({
       contentType: "application/json",
@@ -3429,8 +3438,10 @@ test("Friend detail last seen card opens the full Map view", async ({ app }) => 
 
   await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 5_000 });
   await expect(page.getByText("Last seen")).toBeVisible({ timeout: 5_000 });
-  const lastSeenCard = page.getByRole("button", { name: /last seen paris/i });
-  await expect(lastSeenCard).toBeVisible({ timeout: 5_000 });
+  const lastSeenCard = page
+    .getByTestId("friends-sidebar")
+    .getByRole("button", { name: /last seen paris/i });
+  await expect(lastSeenCard).toBeVisible({ timeout: 10_000 });
   await lastSeenCard.evaluate((element) => {
     (element as HTMLElement).click();
   });
@@ -3444,6 +3455,10 @@ test("Friend detail last seen card opens the full Map view", async ({ app }) => 
     return state?.activeView === "map" && state.selectedPersonId === "friend-ada";
   }, { timeout: 10_000 });
   await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
+  expect(
+    renderLoopErrors,
+    `Friend location rendering looped: ${renderLoopErrors.join("\n")}`,
+  ).toHaveLength(0);
 });
 
 test("map defaults to All content when only unlinked author locations exist", async ({ app, page }) => {

--- a/packages/ui/src/components/friends/FriendDetailPanel.tsx
+++ b/packages/ui/src/components/friends/FriendDetailPanel.tsx
@@ -338,7 +338,7 @@ export function FriendDetailPanel({
 
         <MiniFriendMapCard
           friend={friend}
-          feedItems={[...locationItems]}
+          feedItems={locationItems}
           onOpenMap={onOpenMap}
         />
       </div>

--- a/packages/ui/src/components/map/MiniFriendMapCard.tsx
+++ b/packages/ui/src/components/map/MiniFriendMapCard.tsx
@@ -4,7 +4,7 @@ import { useFriendLastSeenLocation } from "../../hooks/useResolvedLocations.js";
 
 interface MiniFriendMapCardProps {
   friend: Person;
-  feedItems: FeedItem[];
+  feedItems: readonly FeedItem[];
   onOpenMap: () => void;
 }
 

--- a/packages/ui/src/hooks/useResolvedLocations.ts
+++ b/packages/ui/src/hooks/useResolvedLocations.ts
@@ -207,7 +207,7 @@ export function useResolvedLocationCandidates(
 
 export function useFriendLastSeenLocation(
   friend: Person,
-  feedItems: FeedItem[],
+  feedItems: readonly FeedItem[],
 ): {
   lastSeen: LocationMarkerSummary | null;
   resolvingCount: number;


### PR DESCRIPTION
(AI Generated).

## Summary
- Preserve the stable Friend location item array instead of cloning it on every render.
- Keep the full Map navigation regression bound to resolved location text and fail on React update-depth loops.

## Testing
- npm run validate:feature
- Friend detail Map regression repeated 10 times