### PR TITLE
chore: prepare v26.8.3000-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.2906",
+  "version": "26.8.3000",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.2906"
+version = "26.8.3000"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.2906"
+version = "26.8.3000"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.2906",
+  "version": "26.8.3000",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.2906",
+  "version": "26.8.3000",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.30.json
+++ b/release-notes/daily/dev/26.8.30.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.8.30",
+  "date": "2026-08-30",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-08-30T09:15:52.093Z"
+}

--- a/release-notes/releases/v26.8.3000-dev.json
+++ b/release-notes/releases/v26.8.3000-dev.json
@@ -1,0 +1,70 @@
+{
+  "tag": "v26.8.3000-dev",
+  "version": "26.8.3000-dev",
+  "channel": "dev",
+  "dayKey": "26.8.30",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-30T09:15:52.093Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.2906-dev",
+    "previousPublishedDayTag": "v26.8.2906-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "fbc9bf841c9a0dab9d68ac9bfdffaa2c6bd44838",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.2906-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "1de8556adccc2d0a9eafc12d6a88d4bb46e36946",
+        "toInclusiveProductCommitSha": "fbc9bf841c9a0dab9d68ac9bfdffaa2c6bd44838"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:dc10a24093ee29b82cbd6d5eec4865c3ff1944506dd3e9d2bf2fe7fd0309c180",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.3000-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.3000-dev"
+    ],
+    "prNumbers": [
+      1652,
+      1653
+    ],
+    "commitSubjects": [
+      "fix: stop Friend location render loops (#1653)",
+      "fix: keep checkpoint exports on one SQLite snapshot (#1652)"
+    ]
+  },
+  "release": {
+    "deck": "Keep Google Drive Library backups stable during active sync and stop Friend location cards from rerendering",
+    "features": [],
+    "fixes": [
+      "Keep each Google Drive Library checkpoint on one SQLite snapshot while new items and background updates continue",
+      "Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history",
+      "Create local Library snapshots from one consistent SQLite revision",
+      "Stop Friend location cards from restarting geocoding on every render",
+      "Open the full Map from a Friend's last-seen card after the location resolves"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3000-dev\n\nKeep Google Drive Library backups stable during active sync and stop Friend location cards from rerendering\n\n### Fixes\n\n- Keep each Google Drive Library checkpoint on one SQLite snapshot while new items and background updates continue\n- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history\n- Create local Library snapshots from one consistent SQLite revision\n- Stop Friend location cards from restarting geocoding on every render\n- Open the full Map from a Friend's last-seen card after the location resolves\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.3000-dev.md
+++ b/release-notes/releases/v26.8.3000-dev.md
@@ -1,0 +1,21 @@
+(AI Generated).
+
+## Freed v26.8.3000-dev
+
+Keep Google Drive Library backups stable during active sync and stop Friend location cards from rerendering
+
+### Fixes
+
+- Keep each Google Drive Library checkpoint on one SQLite snapshot while new items and background updates continue
+- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history
+- Create local Library snapshots from one consistent SQLite revision
+- Stop Friend location cards from restarting geocoding on every render
+- Open the full Map from a Friend's last-seen card after the location resolves
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare Freed Desktop 26.8.3000-dev.
- Keep Google Drive Library checkpoint exports on one stable SQLite snapshot.
- Stop Friend last-seen cards from restarting geocoding on every render.

## Testing
- npm run validate:feature
- Release identity validation for v26.8.3000-dev
- No provider-visible diff