### PR TITLE
feat: bind headless Primary to Google Drive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -77,6 +77,7 @@
 /packages/desktop/src/lib/authenticated-essay-*.ts @AubreyF
 /packages/desktop/src/lib/substack-*.ts @AubreyF
 /packages/desktop/src/lib/medium-*.ts @AubreyF
+/packages/library-service/src/ @AubreyF
 /packages/sync/ @AubreyF
 /packages/capture-facebook/ @AubreyF
 /packages/capture-instagram/ @AubreyF

--- a/docs/PHASE-11-OPENCLAW.md
+++ b/docs/PHASE-11-OPENCLAW.md
@@ -1,6 +1,6 @@
 # Phase 11: Headless Library Authority and Agent Integrations
 
-> **Status:** 🚧 In Progress (the shared transport-neutral Primary scheduler, normalized native SQLite authority, local process lease, native and PWA actor capability enforcement with separate signed mutation and query grants, authority-signed actor retirement, fail-closed service supervisor, descriptor-bound normalized sidecar startup, bounded checkpoint and query ingress, native mutation and signed agent query admission, exact local writer reassignment, production macOS and Linux ACL proofs, deterministic service definitions, and provider-neutral headless runtime have landed; installed Drive coordination, Windows service transport, and capture workers remain open)
+> **Status:** 🚧 In Progress (the shared transport-neutral Primary scheduler, normalized native SQLite authority, local process lease, native and PWA actor capability enforcement with separate signed mutation and query grants, authority-signed actor retirement, fail-closed service supervisor, descriptor-bound normalized sidecar startup, bounded checkpoint and query ingress, native mutation and signed agent query admission, exact local writer reassignment, production macOS and Linux ACL proofs, deterministic service definitions, macOS Drive PKCE and Keychain custody, and installed immutable checkpoint publication have landed; inbound follower processing, Linux and Windows Drive secret custody, Windows service transport, and capture workers remain open)
 
 > **Architecture:** The headless Primary and Freed Desktop consume the
 > same extracted native Rust Library Core and the same stock SQLite contract.
@@ -108,10 +108,21 @@ The current product already provides the protocol foundation:
   writer. Its compiled artifacts bundle the shared coordinator and need no
   unpublished workspace package at installation time.
 
-These pieces do not yet create a complete installed headless authority. The
-service CLI has no Drive OAuth store or Drive publication binding. Freed
-Desktop retains its existing host-owned Drive credential and adapter. The
-native sidecar acquires the
+The installed macOS service now binds the shared Primary scheduler to Google
+Drive without giving Node an authority key or the native sidecar a Drive
+token. `drive-auth` uses PKCE through the existing Freed OAuth proxy, requests
+only `drive.appdata` and `drive.file`, and stores one refresh token in an exact
+Keychain record. `serve` resolves short-lived access tokens into memory, proves
+the current cloud writer, exports one pinned SQLite read transaction through
+bounded native pages, publishes the existing immutable checkpoint protocol,
+and persists only the committed control receipt through an already-bound
+private state-file descriptor. The coordinator stops before service
+settlement. A missing token, changed Library identity, cloud writer conflict,
+malformed response, or unavailable secret backend fails closed. Linux sealed
+credential custody and complete inbound enrollment, intent, and result
+processing remain open.
+
+The native sidecar acquires the
 data-root lease before opening only the final normalized SQLite catalog in the
 private `library-sqlite` directory. It verifies the exact schema, application,
 contract, and protocol identity before it reports ready. It creates no
@@ -135,10 +146,10 @@ sidecar never opens that store. The sidecar command channel calls normalized
 checkpoint staging, pinned export, and registered query functions directly. It
 does not translate the old import, status, database-copy, or whole-item DTOs.
 Canonical mutation admission now loads the established authority and Primary
-actor keys only inside the native sidecar. The provider-neutral recurring
-headless runtime is present, but `serve` does not start it until installed
-Drive OAuth custody and immutable transport are bound. No service-side
-provider request occurs today.
+actor keys only inside the native sidecar. A configuration without the exact
+`cloud` block remains provider-dormant. A configuration with that block starts
+the recurring scheduler only after local SQLite authority and Keychain custody
+both pass.
 
 The macOS and Linux native authorities never reopen a verified root through a
 discovered pathname and never change the process working directory. A shared
@@ -247,10 +258,10 @@ digest, data and state root identities, and credential descriptor digest. Only
 one private bounded `freed_library_primary_credentials_v1` mounted record is
 accepted today. It binds exact Library identity plus authority and Primary
 actor Ed25519 keys. Parsing, identity checks, and signing happen only in the
-native sidecar, with decoded keys held in zeroizing memory. `os-vault`, Drive
-OAuth, cloud writer readiness, and every provider request fail closed or
-remain absent until task 11.5. A true ready receipt proves local native signing
-custody, not cloud authentication or writer promotion.
+native sidecar, with decoded keys held in zeroizing memory. The native
+`credentialsReady` receipt proves local signing custody only. Drive OAuth and
+cloud writer readiness remain separate Node-host proofs and never change that
+native receipt.
 
 Planned commands:
 
@@ -518,16 +529,16 @@ review before implementation.
 | 11.2  | Complete    | Enforce one operating system backed Library data-root lease before SQLite opens                                                                                                                                                                                                                                                                                                                                                    |
 | 11.3  | Complete    | Extract the reusable native SQLite authority package without changing Tauri behavior                                                                                                                                                                                                                                                                                                                                               |
 | 11.4  | Complete    | Add the headless service supervisor, explicit role config, and fail-closed startup                                                                                                                                                                                                                                                                                                                                                 |
-| 11.5  | Open        | Add Drive PKCE setup and platform-safe secret stores                                                                                                                                                                                                                                                                                                                                                                               |
-| 11.6  | In Progress | Open final normalized SQLite behind the descriptor-bound sidecar and provide generated bounded checkpoint, pinned export, registered query, Primary signing, canonical commit, follower-intent admission, actor state, and result export commands; bind installed Drive coordination next                                                                                                                                          |
-| 11.7  | In Progress | Apply exact writer promotion through the generated native sidecar command and bind the shared 15-second revision plus 60-second inbound schedule to native actor and checkpoint identity. Bind the installed Drive publication port next                                                                                                                                                                                           |
+| 11.5  | In Progress | macOS `drive-auth` now uses PKCE through the existing OAuth proxy, requests only Library Core Drive scopes, stores only the refresh token in Keychain, and keeps access tokens memory-only. Complete the versioned Linux sealed credential store and Windows vault adapter next.                                                                                                                                                   |
+| 11.6  | In Progress | Open final normalized SQLite behind the descriptor-bound sidecar and provide generated bounded checkpoint, pinned export, registered query, Primary signing, canonical commit, follower-intent admission, actor state, and result export commands. Installed Drive checkpoint export now consumes the pinned bounded page contract. Complete service-side enrollment, intent, and result transport next.                           |
+| 11.7  | In Progress | Apply exact writer promotion through the generated native sidecar command and bind the shared 15-second revision plus 60-second inbound schedule to native actor and checkpoint identity. The installed macOS service now starts and stops that scheduler with immutable Drive checkpoint publication and durable exact control receipts. Complete installed promotion and competing-Primary acceptance next.                      |
 | 11.8  | Complete    | Prove actor capability certificates and the frozen transition policy in native SQLite. Phase 6 carries the same proof into PWA SQLite before activation.                                                                                                                                                                                                                                                                           |
 | 11.9  | Complete    | Apply authority-signed actor retirement atomically, return exact replay receipts, and verify the normalized retirement record during native and PWA checkpoint activation                                                                                                                                                                                                                                                          |
 | 11.10 | In Progress | Bind generated local actor protocol 2 to a private macOS and Linux Unix socket with bounded frames, connections, rate, timeout, exact replay, native signed query and intent admission, owned cleanup, and Primary fencing. Complete the Windows service-account named-pipe binding with task 11.14.                                                                                                                               |
 | 11.11 | Complete    | Bind exact generated search, item, Saved, and Friends query grants into signed version 2 agent capabilities, normalized SQLite, and checkpoints. Canonical signed query bytes now cross local actor protocol 2, and native SQLite proves the active actor, exact capability certificate, Library-wide scope, registered query grant, body digest, and Ed25519 signature before dispatch. Signed edits use the local intent method. |
 | 11.12 | Open        | Add provider-neutral RSS and explicit-save workers                                                                                                                                                                                                                                                                                                                                                                                 |
 | 11.13 | Blocked     | Add social capture workers after provider-specific owner approval                                                                                                                                                                                                                                                                                                                                                                  |
-| 11.14 | In Progress | Emit deterministic digest-bound macOS LaunchAgent and Linux systemd user-service definitions from one verified config with no shell, mode `0077`, exact writable roots, bounded restart behavior, and production ACL proofs. Complete installed lifecycle receipts and the Windows service-account inherited-handle plus named-pipe ACL contract.                                                                                   |
+| 11.14 | In Progress | Emit deterministic digest-bound macOS LaunchAgent and Linux systemd user-service definitions from one verified config with no shell, mode `0077`, exact writable roots, bounded restart behavior, and production ACL proofs. Complete installed lifecycle receipts and the Windows service-account inherited-handle plus named-pipe ACL contract.                                                                                  |
 | 11.15 | Open        | Complete installed Primary migration and editable follower acceptance                                                                                                                                                                                                                                                                                                                                                              |
 | 11.16 | Open        | Complete forward recovery, competing-Primary, and fault-injection acceptance                                                                                                                                                                                                                                                                                                                                                       |
 | 11.20 | Open        | Define the signed Omi actor and user-triggered voice capture contract                                                                                                                                                                                                                                                                                                                                                              |
@@ -538,6 +549,10 @@ review before implementation.
 
 ## Acceptance criteria
 
+- [x] The macOS service uses PKCE with only Library Core Drive scopes, keeps
+      the refresh token in Keychain, keeps access tokens memory-only, exports
+      bounded pinned SQLite pages, and persists state only after the immutable
+      control compare and swap commits.
 - [ ] A headless service imports a verified checkpoint into a fresh SQLite
       generation without copying a SQLite file from another host.
 - [ ] One exact writer promotion succeeds and a competing Primary loses the

--- a/package-lock.json
+++ b/package-lock.json
@@ -14792,6 +14792,7 @@
         "freed-library": "dist/bin.js"
       },
       "devDependencies": {
+        "@freed/shared": "*",
         "@freed/sync": "*",
         "@types/node": "^24.10.1",
         "esbuild": "0.28.2",

--- a/packages/library-service/README.md
+++ b/packages/library-service/README.md
@@ -5,10 +5,11 @@ headless Library Primary. It supervises the explicitly pinned
 `library-authority-sidecar` binary from `freed-library-core`. Node never opens
 the Library SQLite database or acquires its data-root lease.
 
-The compiled `freed-library` CLI currently provides four commands:
+The compiled `freed-library` CLI currently provides five commands:
 
 ```text
 freed-library doctor --config /physical/path/service.json
+freed-library drive-auth --config /physical/path/service.json
 freed-library service-definition --config /physical/path/service.json
 freed-library status --config /physical/path/service.json
 freed-library serve --config /physical/path/service.json
@@ -43,6 +44,12 @@ directories owned by that user with mode `0700`.
   "stateRoot": "/srv/freed/library-state",
   "admissionFile": "/srv/freed/library-state/admission.json",
   "credentialDescriptorFile": "/srv/freed/library-state/credentials.json",
+  "cloud": {
+    "provider": "google-drive",
+    "installationWitness": "0000000000000000000000000000000000000000000000000000000000000000",
+    "credentialRecordId": "freed-library-primary-drive",
+    "publicationStateFile": "/srv/freed/library-state/library-drive-state.json"
+  },
   "sidecar": {
     "executable": "/opt/freed/bin/library-authority-sidecar",
     "sha256": "0000000000000000000000000000000000000000000000000000000000000000",
@@ -80,10 +87,10 @@ record identifier, never credential bytes:
 }
 ```
 
-The supervisor accepts `os-vault` or `mounted-credential` as descriptor
-syntax. The current native sidecar supports only `mounted-credential` and
-fails closed for `os-vault` until task 11.5 provides the platform vault
-adapter. A mounted record lives at
+The supervisor accepts `os-vault` or `mounted-credential` as native authority
+descriptor syntax. The current native sidecar supports only
+`mounted-credential`. That record remains separate from the Google Drive
+credential. A mounted record lives at
 `<stateRoot>/mounted-credentials/<recordId>`. The directory must be a physical
 directory owned by the service user with mode `0700`. The record must be one
 physical file owned by the service user with mode `0600`, exactly one link,
@@ -128,17 +135,22 @@ client, the closed reason `initial`, `local_revision`, or `inbound_refresh`,
 and an abort signal. It owns any transport credential or provider adapter.
 
 The compiled `dist/index.js` and `dist/bin.js` artifacts bundle the shared
-provider-neutral coordinator. An installed service does not need an
-unpublished `@freed/sync` package at runtime. The `serve` command does not yet
-bind a Drive OAuth store or Drive publication port, so it does not start the
-recurring cloud loop. Task 11.5 owns that installed credential and transport
-binding.
+provider-neutral coordinator and immutable Google Drive adapter. An installed
+service does not need an unpublished workspace package at runtime. When the
+exact `cloud` block is present, `serve` requires the precreated private
+publication state file, retrieves the refresh token from the named macOS
+Keychain record, resolves one short-lived access token through the existing
+OAuth proxy, and starts the shared recurring cloud loop. Without that block,
+the service remains provider-dormant.
 
 `credentialsReady: true` proves that exact native Primary signing custody. It
 does not prove Drive authentication, OAuth validity, cloud reachability, or
-writer promotion. The sidecar never interprets a Drive token and makes no
-provider request in this slice. Drive OAuth remains a separate credential and
-task 11.5 remains responsible for its platform-safe custody.
+writer promotion. The sidecar never interprets a Drive token or makes a
+provider request. On macOS, `drive-auth` performs one interactive PKCE flow and
+writes only the refresh token to Keychain. The token is sent to `security`
+through standard input, never an argument or environment value. Linux and
+Windows Drive secret stores remain fail-closed until their platform custody
+contracts land.
 
 The admission record on fd6 is exact-shape JSON. It binds the operator's local
 Primary admission to the start envelope, executable, both inherited root

--- a/packages/library-service/package.json
+++ b/packages/library-service/package.json
@@ -23,6 +23,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json && tsc --noEmit -p tsconfig.test.json"
   },
   "devDependencies": {
+    "@freed/shared": "*",
     "@freed/sync": "*",
     "@types/node": "^24.10.1",
     "esbuild": "0.28.2",

--- a/packages/library-service/src/cli-runtime.ts
+++ b/packages/library-service/src/cli-runtime.ts
@@ -16,9 +16,10 @@ import {
 } from "./status.js";
 import { createLibraryServiceDefinitionV1 } from "./service-definition.js";
 import { LibraryServiceSupervisor } from "./supervisor.js";
+import { authorizeNodeGoogleDriveV1 } from "./node-google-drive-auth.js";
 
 interface ParsedArguments {
-  command: "serve" | "status" | "doctor" | "service-definition";
+  command: "serve" | "status" | "doctor" | "service-definition" | "drive-auth";
   configPath: string;
 }
 
@@ -31,7 +32,8 @@ function parseArguments(argv: readonly string[]): ParsedArguments {
     command !== "serve" &&
     command !== "status" &&
     command !== "doctor" &&
-    command !== "service-definition"
+    command !== "service-definition" &&
+    command !== "drive-auth"
   ) {
     throw new LibraryServiceFailure("config_invalid");
   }
@@ -65,6 +67,7 @@ async function serve(configPath: string): Promise<number> {
     clock: ports.clock,
     entropy: ports.entropy,
     localActorIngress: ports.localActorIngress,
+    primaryCloud: ports.primaryCloud,
   });
   const startup = new AbortController();
   let signalCount = 0;
@@ -100,7 +103,6 @@ async function serve(configPath: string): Promise<number> {
     const startResult = await supervisor.start(startup.signal);
     started = true;
     writeStandardReport({
-      schemaVersion: 1,
       service: "freed-library",
       ok: true,
       ...startResult,
@@ -169,6 +171,35 @@ async function writeServiceDefinition(configPath: string): Promise<number> {
   }
 }
 
+async function authorizeGoogleDrive(configPath: string): Promise<number> {
+  const ports = createNodeLibraryServicePorts();
+  const bound = await bindLibraryServiceConfig(
+    configPath,
+    ports.fileSystem,
+    ports.identity,
+    ports.aclProof,
+  );
+  try {
+    if (bound.config.cloud === null) {
+      throw new LibraryServiceFailure("config_invalid");
+    }
+    const receipt = await authorizeNodeGoogleDriveV1(
+      bound.config.cloud.credentialRecordId,
+    );
+    await assertLibraryServiceBindingsStable(bound, ports.fileSystem);
+    writeStandardReport({
+      service: "freed-library",
+      ok: true,
+      role: "primary",
+      phase: "drive-authenticated",
+      ...receipt,
+    });
+    return 0;
+  } finally {
+    await bound.close();
+  }
+}
+
 export async function runLibraryServiceCli(
   argv: readonly string[],
 ): Promise<number> {
@@ -216,6 +247,9 @@ export async function runLibraryServiceCli(
     }
     if (parsed.command === "service-definition") {
       return await writeServiceDefinition(parsed.configPath);
+    }
+    if (parsed.command === "drive-auth") {
+      return await authorizeGoogleDrive(parsed.configPath);
     }
     return await serve(parsed.configPath);
   } catch (error) {

--- a/packages/library-service/src/config.test.ts
+++ b/packages/library-service/src/config.test.ts
@@ -48,6 +48,56 @@ describe("loadLibraryServiceConfig", () => {
     );
   });
 
+  it("binds one private Google Drive publication state file", async () => {
+    const fileSystem = validConfigFileSystem();
+    const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    raw.cloud = {
+      provider: "google-drive",
+      installationWitness: "e".repeat(64),
+      credentialRecordId: "library-drive",
+      publicationStateFile: "/safe/state/library-drive-state.json",
+    };
+    fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+    fileSystem.addFile("/safe/state/library-drive-state.json", "");
+
+    const bound = await bindLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    );
+    try {
+      expect(bound.config.cloud).toEqual(raw.cloud);
+      expect(bound.cloudState?.path).toBe(
+        "/safe/state/library-drive-state.json",
+      );
+    } finally {
+      await bound.close();
+    }
+  });
+
+  it("rejects a Google Drive state file outside the private state root", async () => {
+    const fileSystem = validConfigFileSystem();
+    const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    raw.cloud = {
+      provider: "google-drive",
+      installationWitness: "e".repeat(64),
+      credentialRecordId: "library-drive",
+      publicationStateFile: "/safe/cloud-state.json",
+    };
+    fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+    fileSystem.addFile("/safe/cloud-state.json", "");
+
+    await expect(
+      bindLibraryServiceConfig(
+        "/safe/config.json",
+        fileSystem,
+        new FakeIdentity(),
+        new FakeAclProof(),
+      ),
+    ).rejects.toMatchObject({ code: "config_invalid" });
+  });
+
   it("fails closed when the configured role is not Primary", async () => {
     const fileSystem = validConfigFileSystem();
     const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);

--- a/packages/library-service/src/config.ts
+++ b/packages/library-service/src/config.ts
@@ -27,6 +27,12 @@ const CONFIG_KEYS = new Set([
   "credentialDescriptorFile",
   "sidecar",
 ]);
+const CLOUD_CONFIG_KEYS = new Set([
+  "provider",
+  "installationWitness",
+  "credentialRecordId",
+  "publicationStateFile",
+]);
 const SIDECAR_KEYS = new Set([
   "executable",
   "sha256",
@@ -60,6 +66,7 @@ export interface BoundLibraryServiceConfiguration {
   admissionDigest: string;
   credentialDescriptorDigest: string;
   configFile: LibraryServiceBoundPath;
+  cloudState: LibraryServiceBoundPath | null;
   bindings: LibraryServiceBoundInputs;
   close(): Promise<void>;
 }
@@ -318,7 +325,11 @@ function parseConfig(text: string): LibraryServiceConfig {
   } catch {
     throw new LibraryServiceFailure("config_invalid");
   }
-  if (!isObject(raw) || !hasExactKeys(raw, CONFIG_KEYS)) {
+  if (
+    !isObject(raw) ||
+    (!hasExactKeys(raw, CONFIG_KEYS) &&
+      !hasExactKeys(raw, new Set([...CONFIG_KEYS, "cloud"])))
+  ) {
     throw new LibraryServiceFailure("config_invalid");
   }
   if (
@@ -350,6 +361,29 @@ function parseConfig(text: string): LibraryServiceConfig {
     raw.sidecar.executable,
     "sidecar_invalid",
   );
+  let cloud: LibraryServiceConfig["cloud"] = null;
+  if ("cloud" in raw && raw.cloud !== null) {
+    if (
+      !isObject(raw.cloud) ||
+      !hasExactKeys(raw.cloud, CLOUD_CONFIG_KEYS) ||
+      raw.cloud.provider !== "google-drive" ||
+      typeof raw.cloud.installationWitness !== "string" ||
+      !LOWERCASE_SHA256.test(raw.cloud.installationWitness) ||
+      typeof raw.cloud.credentialRecordId !== "string" ||
+      !SAFE_RECORD_ID.test(raw.cloud.credentialRecordId)
+    ) {
+      throw new LibraryServiceFailure("config_invalid");
+    }
+    cloud = {
+      provider: "google-drive",
+      installationWitness: raw.cloud.installationWitness,
+      credentialRecordId: raw.cloud.credentialRecordId,
+      publicationStateFile: requireAbsolutePhysicalPath(
+        raw.cloud.publicationStateFile,
+        "cloud_state_missing",
+      ),
+    };
+  }
 
   if (
     typeof raw.sidecar.sha256 !== "string" ||
@@ -375,6 +409,7 @@ function parseConfig(text: string): LibraryServiceConfig {
     stateRoot,
     admissionFile,
     credentialDescriptorFile,
+    cloud,
     sidecar: {
       executable,
       sha256: raw.sidecar.sha256,
@@ -429,6 +464,7 @@ function validatePathSeparation(
   config: LibraryServiceConfig,
 ): void {
   const statusPath = path.join(config.stateRoot, "library-service-status.json");
+  const cloudStatePath = config.cloud?.publicationStateFile ?? null;
   if (
     config.dataRoot === config.stateRoot ||
     isWithinOrEqual(config.dataRoot, config.stateRoot) ||
@@ -443,7 +479,13 @@ function validatePathSeparation(
     !isStrictChild(config.credentialDescriptorFile, config.stateRoot) ||
     config.admissionFile === config.credentialDescriptorFile ||
     config.admissionFile === statusPath ||
-    config.credentialDescriptorFile === statusPath
+    config.credentialDescriptorFile === statusPath ||
+    (cloudStatePath !== null &&
+      (!isStrictChild(cloudStatePath, config.stateRoot) ||
+        isWithinOrEqual(cloudStatePath, config.dataRoot) ||
+        cloudStatePath === statusPath ||
+        cloudStatePath === config.admissionFile ||
+        cloudStatePath === config.credentialDescriptorFile))
   ) {
     throw new LibraryServiceFailure("config_invalid");
   }
@@ -475,7 +517,11 @@ export async function assertLibraryServiceBindingsStable(
   fileSystem: LibraryServiceFileSystemPort,
   signal?: AbortSignal,
 ): Promise<void> {
-  const paths = [bound.configFile, ...Object.values(bound.bindings)];
+  const paths = [
+    bound.configFile,
+    ...Object.values(bound.bindings),
+    ...(bound.cloudState === null ? [] : [bound.cloudState]),
+  ];
   for (const resource of paths) {
     throwIfAborted(signal);
     try {
@@ -601,6 +647,21 @@ export async function bindLibraryServiceConfig(
     parseCredentialDescriptor(
       decodeBoundedText(credentialBytes, "credential_descriptor_invalid"),
     );
+    const cloudState =
+      config.cloud === null
+        ? null
+        : await bindPrivateFile(
+            config.cloud.publicationStateFile,
+            context,
+            "cloud_state_missing",
+            "cloud_state_not_private",
+          );
+    if (cloudState !== null) {
+      opened.push(cloudState);
+      if (cloudState.metadata.size > LIBRARY_SERVICE_MAX_DESCRIPTOR_BYTES) {
+        throw new LibraryServiceFailure("cloud_state_invalid");
+      }
+    }
     const sidecar = await bindPinnedSidecar(config, context);
     opened.push(sidecar.bound);
 
@@ -620,6 +681,7 @@ export async function bindLibraryServiceConfig(
       admissionDigest: await admission.sha256(),
       credentialDescriptorDigest: sha256(credentialBytes),
       configFile,
+      cloudState,
       bindings: {
         executable: sidecar.bound,
         dataRoot,
@@ -635,6 +697,7 @@ export async function bindLibraryServiceConfig(
           stateRoot,
           admission,
           credentialDescriptor,
+          ...(cloudState === null ? [] : [cloudState]),
         ]);
       },
     };

--- a/packages/library-service/src/contracts.ts
+++ b/packages/library-service/src/contracts.ts
@@ -28,9 +28,15 @@ export const LIBRARY_SERVICE_FAILURE_CODES = Object.freeze([
   "config_not_private",
   "command_channel_failed",
   "command_response_invalid",
+  "cloud_runtime_failed",
+  "cloud_state_invalid",
+  "cloud_state_missing",
+  "cloud_state_not_private",
   "credential_descriptor_invalid",
   "credential_descriptor_missing",
   "credential_descriptor_not_private",
+  "drive_auth_failed",
+  "drive_credential_unavailable",
   "data_root_invalid",
   "data_root_not_private",
   "filesystem_failure",
@@ -90,7 +96,15 @@ export interface LibraryServiceConfig {
   stateRoot: string;
   admissionFile: string;
   credentialDescriptorFile: string;
+  cloud: LibraryServiceGoogleDriveConfig | null;
   sidecar: LibraryServiceSidecarConfig;
+}
+
+export interface LibraryServiceGoogleDriveConfig {
+  provider: "google-drive";
+  installationWitness: string;
+  credentialRecordId: string;
+  publicationStateFile: string;
 }
 
 export interface LibraryServiceCredentialDescriptor {
@@ -248,11 +262,7 @@ export interface LibraryServiceProcessPort {
 }
 
 export type LibraryServicePhase =
-  | "starting"
-  | "running"
-  | "stopping"
-  | "stopped"
-  | "failed";
+  "starting" | "running" | "stopping" | "stopped" | "failed";
 
 export interface LibraryServiceStatusRecord {
   schemaVersion: typeof LIBRARY_SERVICE_STATUS_SCHEMA_VERSION;

--- a/packages/library-service/src/google-drive-publication.test.ts
+++ b/packages/library-service/src/google-drive-publication.test.ts
@@ -1,0 +1,220 @@
+import { createHash, webcrypto } from "node:crypto";
+
+import {
+  createLibraryCoreNormalizedCheckpointRecordV2,
+  encodeLibraryCoreNormalizedCheckpointRecordV2,
+  parseLibraryCoreImmutableObjectDescriptorV1,
+  type LibraryCoreImmutableObjectDescriptorV1,
+} from "@freed/shared/library-core";
+import type {
+  LibraryCoreControlCompareAndSwapResultV1,
+  LibraryCoreControlReadV1,
+  LibraryCoreImmutablePublicationAdapterV1,
+  LibraryCorePreparedImmutableObjectV1,
+  LibraryCorePublishedImmutableObjectReceiptV1,
+} from "@freed/sync/cloud/library-core";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+
+import type { LibraryCoreNativeCommandClientV1 } from "./native-command.js";
+import {
+  createLibraryServiceGoogleDrivePublicationV1,
+  type LibraryServiceGoogleDrivePublicationStateV1,
+} from "./google-drive-publication.js";
+
+beforeAll(() => {
+  if (globalThis.crypto === undefined) {
+    Object.defineProperty(globalThis, "crypto", { value: webcrypto });
+  }
+});
+
+const libraryId = "a".repeat(64);
+const authorityEpoch = "b".repeat(64);
+const writerId = "c".repeat(64);
+const frontier = "d".repeat(64);
+
+const record = createLibraryCoreNormalizedCheckpointRecordV2({
+  registryKey: "00_checkpoint_header",
+  primaryKey: "checkpoint",
+  payload: {
+    authorityEpoch,
+    checkpointId: `${libraryId}:${authorityEpoch}:7`,
+    createdAtMs: 1_000,
+    libraryId,
+    schemaVersion: 1,
+    sourceRevision: 7,
+  },
+});
+
+function descriptor(writer = writerId) {
+  return Object.freeze({
+    authorityEpoch,
+    causalFrontierDigest: frontier,
+    format: "freed_normalized_checkpoint_export_v2",
+    itemCount: 0,
+    libraryId,
+    protocolVersion: 2,
+    recordCount: 1,
+    sourceRevision: 7,
+    writerId: writer,
+  });
+}
+
+class MemoryAdapter implements LibraryCoreImmutablePublicationAdapterV1<Uint8Array> {
+  readonly objects = new Map<
+    string,
+    {
+      readonly bytes: Uint8Array;
+      readonly descriptor: LibraryCoreImmutableObjectDescriptorV1;
+    }
+  >();
+  control: LibraryCoreControlReadV1 = {
+    revision: "control-0",
+    bytes: new TextEncoder().encode("{}"),
+  };
+
+  async readControl(): Promise<LibraryCoreControlReadV1> {
+    return {
+      revision: this.control.revision,
+      bytes: this.control.bytes?.slice() ?? null,
+    };
+  }
+
+  async putImmutable(
+    object: LibraryCorePreparedImmutableObjectV1<Uint8Array>,
+  ): Promise<{ readonly transportObjectId: string }> {
+    const id = `object-${(this.objects.size + 1).toLocaleString("en-US", { useGrouping: false })}`;
+    this.objects.set(id, {
+      bytes: object.source.slice(),
+      descriptor: object.descriptor,
+    });
+    return { transportObjectId: id };
+  }
+
+  async verifyImmutable(
+    receipt: LibraryCorePublishedImmutableObjectReceiptV1,
+  ): Promise<LibraryCoreImmutableObjectDescriptorV1> {
+    const stored = this.objects.get(receipt.transportObjectId);
+    if (stored === undefined) throw new Error("missing object");
+    return parseLibraryCoreImmutableObjectDescriptorV1({
+      ...stored.descriptor,
+      byteLength: stored.bytes.byteLength,
+      contentDigest: createHash("sha256").update(stored.bytes).digest("hex"),
+    });
+  }
+
+  async compareAndSwapControl(input: {
+    readonly expectedRevision: string | null;
+    readonly bytes: Uint8Array;
+  }): Promise<LibraryCoreControlCompareAndSwapResultV1> {
+    if (input.expectedRevision !== this.control.revision) {
+      return { status: "conflict", current: await this.readControl() };
+    }
+    this.control = { revision: "control-1", bytes: input.bytes.slice() };
+    return { status: "committed", revision: "control-1" };
+  }
+}
+
+function native(checkpoint = descriptor()): LibraryCoreNativeCommandClientV1 {
+  return {
+    execute: vi.fn(async (commandId: string) => {
+      if (commandId === "describe_checkpoint_export_v2") return checkpoint;
+      if (commandId === "export_checkpoint_page_v2") {
+        return {
+          canonicalRecordBytes:
+            encodeLibraryCoreNormalizedCheckpointRecordV2(record).byteLength,
+          done: true,
+          nextCursor: null,
+          records: [record],
+        };
+      }
+      throw new Error(`unexpected command ${commandId}`);
+    }),
+  } as LibraryCoreNativeCommandClientV1;
+}
+
+describe("headless Google Drive checkpoint publication", () => {
+  it("publishes bounded native records and persists only the committed receipt", async () => {
+    const adapter = new MemoryAdapter();
+    let state: LibraryServiceGoogleDrivePublicationStateV1 | null = null;
+    const publication = createLibraryServiceGoogleDrivePublicationV1({
+      state: {
+        read: async () => state,
+        write: async (next) => {
+          state = next;
+        },
+      },
+      token: { accessToken: async () => "access-token" },
+      transport: {
+        provision: async () => ({ controlFileId: "control-file" }),
+        adapter: () => adapter,
+      },
+    });
+    const client = native();
+
+    await expect(
+      publication.publish({
+        native: client,
+        reason: "initial",
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({ status: "published", revision: 7 });
+
+    expect(state).toEqual({
+      schemaVersion: 1,
+      libraryId,
+      authorityEpoch,
+      writerId,
+      controlFileId: "control-file",
+      controlRevision: "control-1",
+      lastPublishedRevision: 7,
+    });
+    expect(adapter.objects.size).toBeGreaterThan(1);
+    expect(
+      (client.execute as ReturnType<typeof vi.fn>).mock.calls.map(
+        ([commandId]) => commandId,
+      ),
+    ).toEqual(["describe_checkpoint_export_v2", "export_checkpoint_page_v2"]);
+    await expect(publication.lastPublishedRevision()).resolves.toBe(7);
+  });
+
+  it("returns ownership_required without exporting when Drive names another writer", async () => {
+    const adapter = new MemoryAdapter();
+    const remotePublication = createLibraryServiceGoogleDrivePublicationV1({
+      state: { read: async () => null, write: async () => undefined },
+      token: { accessToken: async () => "access-token" },
+      transport: {
+        provision: async () => ({ controlFileId: "control-file" }),
+        adapter: () => adapter,
+      },
+    });
+    await remotePublication.publish({
+      native: native(descriptor("f".repeat(64))),
+      reason: "initial",
+      signal: new AbortController().signal,
+    });
+    const objectCountAfterRemotePublication = adapter.objects.size;
+    const publication = createLibraryServiceGoogleDrivePublicationV1({
+      state: { read: async () => null, write: async () => undefined },
+      token: { accessToken: async () => "access-token" },
+      transport: {
+        provision: async () => ({ controlFileId: "control-file" }),
+        adapter: () => adapter,
+      },
+    });
+    const client = native();
+
+    await expect(
+      publication.publish({
+        native: client,
+        reason: "inbound_refresh",
+        signal: new AbortController().signal,
+      }),
+    ).resolves.toEqual({
+      status: "ownership_required",
+      currentWriterId: "f".repeat(64),
+      localWriterId: writerId,
+    });
+    expect(client.execute).toHaveBeenCalledTimes(1);
+    expect(adapter.objects.size).toBe(objectCountAfterRemotePublication);
+  });
+});

--- a/packages/library-service/src/google-drive-publication.ts
+++ b/packages/library-service/src/google-drive-publication.ts
@@ -1,0 +1,387 @@
+import {
+  LIBRARY_CORE_CHECKPOINT_PAGE_MAXIMUM_RECORDS,
+  LIBRARY_CORE_NATIVE_EXPORT_MAXIMUM_RESPONSE_BYTES,
+  decodeLibraryCoreCanonicalValue,
+  parseLibraryCoreControlPointerV1,
+  parseLibraryCoreNormalizedCheckpointExportDescriptorV2,
+  parseLibraryCoreNormalizedCheckpointExportPageV2,
+  type LibraryCoreControlPointerV1,
+  type LibraryCoreNormalizedCheckpointExportDescriptorV2,
+  type LibraryCoreNormalizedCheckpointRecordV2,
+} from "@freed/shared/library-core";
+import {
+  createGoogleDriveLibraryCoreAdapterV1,
+  provisionGoogleDriveLibraryCoreControlV1,
+  publishLibraryCoreNormalizedCheckpointV2,
+  type GoogleDriveFetch,
+  type LibraryCoreControlReadV1,
+  type LibraryCoreImmutablePublicationAdapterV1,
+} from "@freed/sync/cloud/library-core";
+
+import { LibraryServiceFailure } from "./contracts.js";
+import {
+  LIBRARY_SERVICE_MAX_DESCRIPTOR_BYTES,
+  type LibraryServiceBoundPath,
+  type LibraryServiceFileSystemPort,
+} from "./contracts.js";
+import type { LibraryCoreNativeCommandClientV1 } from "./native-command.js";
+import type { LibraryServicePrimaryPublicationPortV1 } from "./primary-runtime.js";
+
+const LOWERCASE_HEX_64 = /^[a-f0-9]{64}$/u;
+const MAX_CONTROL_REVISION_BYTES = 1_024;
+
+export interface LibraryServiceGoogleDrivePublicationStateV1 {
+  readonly schemaVersion: 1;
+  readonly libraryId: string;
+  readonly authorityEpoch: string;
+  readonly writerId: string;
+  readonly controlFileId: string;
+  readonly controlRevision: string;
+  readonly lastPublishedRevision: number;
+}
+
+export interface LibraryServiceGoogleDrivePublicationStatePortV1 {
+  read(): Promise<LibraryServiceGoogleDrivePublicationStateV1 | null>;
+  write(state: LibraryServiceGoogleDrivePublicationStateV1): Promise<void>;
+}
+
+export interface LibraryServiceGoogleDriveTokenPortV1 {
+  accessToken(signal: AbortSignal): Promise<string>;
+}
+
+export type LibraryServiceGoogleDrivePublicationResultV1 =
+  | { readonly status: "published"; readonly revision: number }
+  | { readonly status: "current"; readonly revision: number }
+  | {
+      readonly status: "ownership_required";
+      readonly currentWriterId: string;
+      readonly localWriterId: string;
+    };
+
+interface ProvisionedControlV1 {
+  readonly controlFileId: string;
+}
+
+interface GoogleDrivePublicationTransportV1 {
+  provision(input: {
+    readonly accessToken: string;
+    readonly libraryId: string;
+    readonly signal: AbortSignal;
+  }): Promise<ProvisionedControlV1>;
+  adapter(input: {
+    readonly accessToken: string;
+    readonly controlFileId: string;
+    readonly libraryId: string;
+    readonly signal: AbortSignal;
+  }): LibraryCoreImmutablePublicationAdapterV1<Uint8Array>;
+}
+
+export interface LibraryServiceGoogleDrivePublicationOptionsV1 {
+  readonly googleFetch?: GoogleDriveFetch;
+  readonly state: LibraryServiceGoogleDrivePublicationStatePortV1;
+  readonly token: LibraryServiceGoogleDriveTokenPortV1;
+  readonly transport?: GoogleDrivePublicationTransportV1;
+}
+
+export function createBoundGoogleDrivePublicationStatePortV1(
+  stateFile: LibraryServiceBoundPath,
+  fileSystem: LibraryServiceFileSystemPort,
+): LibraryServiceGoogleDrivePublicationStatePortV1 {
+  return Object.freeze({
+    async read(): Promise<LibraryServiceGoogleDrivePublicationStateV1 | null> {
+      let bytes: Uint8Array;
+      try {
+        bytes = await stateFile.readBoundedBytes(
+          LIBRARY_SERVICE_MAX_DESCRIPTOR_BYTES,
+        );
+      } catch {
+        throw new LibraryServiceFailure("cloud_state_invalid");
+      }
+      if (bytes.byteLength === 0) return null;
+      try {
+        const decoded = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+        return closedState(JSON.parse(decoded));
+      } catch (error) {
+        if (error instanceof LibraryServiceFailure) throw error;
+        throw new LibraryServiceFailure("cloud_state_invalid");
+      }
+    },
+    async write(
+      state: LibraryServiceGoogleDrivePublicationStateV1,
+    ): Promise<void> {
+      const parsed = closedState(state);
+      if (parsed === null) {
+        throw new LibraryServiceFailure("cloud_state_invalid");
+      }
+      try {
+        await fileSystem.writePrivateStatusText(
+          stateFile,
+          `${JSON.stringify(parsed)}\n`,
+        );
+      } catch {
+        throw new LibraryServiceFailure("cloud_state_invalid");
+      }
+    },
+  });
+}
+
+function closedState(
+  value: LibraryServiceGoogleDrivePublicationStateV1 | null,
+): LibraryServiceGoogleDrivePublicationStateV1 | null {
+  if (value === null) return null;
+  if (
+    Object.getPrototypeOf(value) !== Object.prototype ||
+    Object.getOwnPropertySymbols(value).length !== 0 ||
+    Object.keys(value).sort().join(",") !==
+      "authorityEpoch,controlFileId,controlRevision,lastPublishedRevision,libraryId,schemaVersion,writerId" ||
+    value.schemaVersion !== 1 ||
+    !LOWERCASE_HEX_64.test(value.libraryId) ||
+    !LOWERCASE_HEX_64.test(value.authorityEpoch) ||
+    !LOWERCASE_HEX_64.test(value.writerId) ||
+    typeof value.controlFileId !== "string" ||
+    value.controlFileId.length === 0 ||
+    value.controlFileId.length > MAX_CONTROL_REVISION_BYTES ||
+    typeof value.controlRevision !== "string" ||
+    value.controlRevision.length === 0 ||
+    value.controlRevision.length > MAX_CONTROL_REVISION_BYTES ||
+    !Number.isSafeInteger(value.lastPublishedRevision) ||
+    value.lastPublishedRevision < 0
+  ) {
+    throw new LibraryServiceFailure("command_response_invalid");
+  }
+  return Object.freeze({ ...value });
+}
+
+function parseControl(
+  read: LibraryCoreControlReadV1,
+): LibraryCoreControlPointerV1 | null {
+  if (read.bytes === null) {
+    throw new LibraryServiceFailure("command_response_invalid");
+  }
+  let value: unknown;
+  try {
+    value = decodeLibraryCoreCanonicalValue(read.bytes.slice());
+  } catch {
+    throw new LibraryServiceFailure("command_response_invalid");
+  }
+  if (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 0
+  ) {
+    return null;
+  }
+  try {
+    return parseLibraryCoreControlPointerV1(value);
+  } catch {
+    throw new LibraryServiceFailure("command_response_invalid");
+  }
+}
+
+function exactDescriptor(
+  value: unknown,
+): LibraryCoreNormalizedCheckpointExportDescriptorV2 {
+  try {
+    return parseLibraryCoreNormalizedCheckpointExportDescriptorV2(value);
+  } catch {
+    throw new LibraryServiceFailure("command_response_invalid");
+  }
+}
+
+async function* checkpointRecords(
+  native: LibraryCoreNativeCommandClientV1,
+  snapshot: LibraryCoreNormalizedCheckpointExportDescriptorV2,
+): AsyncIterable<LibraryCoreNormalizedCheckpointRecordV2> {
+  let after: {
+    readonly registryKey: string;
+    readonly primaryKeyJson: string;
+  } | null = null;
+  let recordCount = 0;
+  for (;;) {
+    let page;
+    try {
+      page = parseLibraryCoreNormalizedCheckpointExportPageV2(
+        await native.execute("export_checkpoint_page_v2", {
+          snapshot,
+          page: {
+            after,
+            maximumRecords: LIBRARY_CORE_CHECKPOINT_PAGE_MAXIMUM_RECORDS,
+            maximumResponseBytes:
+              LIBRARY_CORE_NATIVE_EXPORT_MAXIMUM_RESPONSE_BYTES,
+          },
+        }),
+      );
+    } catch (error) {
+      if (error instanceof LibraryServiceFailure) throw error;
+      throw new LibraryServiceFailure("command_response_invalid");
+    }
+    for (const record of page.records) {
+      recordCount += 1;
+      yield record;
+    }
+    if (page.done) break;
+    if (
+      page.nextCursor === null ||
+      (after !== null &&
+        after.registryKey === page.nextCursor.registryKey &&
+        after.primaryKeyJson === page.nextCursor.primaryKeyJson)
+    ) {
+      throw new LibraryServiceFailure("command_response_invalid");
+    }
+    after = page.nextCursor;
+  }
+  if (recordCount !== snapshot.recordCount) {
+    throw new LibraryServiceFailure("command_response_invalid");
+  }
+}
+
+function sameAuthority(
+  state: LibraryServiceGoogleDrivePublicationStateV1,
+  descriptor: LibraryCoreNormalizedCheckpointExportDescriptorV2,
+): boolean {
+  return (
+    state.libraryId === descriptor.libraryId &&
+    state.authorityEpoch === descriptor.authorityEpoch &&
+    state.writerId === descriptor.writerId
+  );
+}
+
+function defaultTransport(
+  googleFetch?: GoogleDriveFetch,
+): GoogleDrivePublicationTransportV1 {
+  return Object.freeze({
+    provision: (input: {
+      readonly accessToken: string;
+      readonly libraryId: string;
+      readonly signal: AbortSignal;
+    }) => provisionGoogleDriveLibraryCoreControlV1({ ...input, googleFetch }),
+    adapter: (input: {
+      readonly accessToken: string;
+      readonly controlFileId: string;
+      readonly libraryId: string;
+      readonly signal: AbortSignal;
+    }) => createGoogleDriveLibraryCoreAdapterV1({ ...input, googleFetch }),
+  });
+}
+
+/**
+ * Bind the headless Primary to the existing immutable Google Drive protocol.
+ *
+ * This port owns no timer and no credential persistence. Each pass resolves one
+ * access token, proves the current cloud writer, exports bounded native pages,
+ * and records durable state only after the control compare and swap commits.
+ */
+export function createLibraryServiceGoogleDrivePublicationV1(
+  options: LibraryServiceGoogleDrivePublicationOptionsV1,
+): LibraryServicePrimaryPublicationPortV1<LibraryServiceGoogleDrivePublicationResultV1> & {
+  lastPublishedRevision(): Promise<number | null>;
+} {
+  const transport = options.transport ?? defaultTransport(options.googleFetch);
+  return Object.freeze({
+    async lastPublishedRevision(): Promise<number | null> {
+      return (
+        closedState(await options.state.read())?.lastPublishedRevision ?? null
+      );
+    },
+    async publish({
+      native,
+      signal,
+    }: {
+      readonly native: LibraryCoreNativeCommandClientV1;
+      readonly reason: "initial" | "local_revision" | "inbound_refresh";
+      readonly signal: AbortSignal;
+    }): Promise<LibraryServiceGoogleDrivePublicationResultV1> {
+      if (signal.aborted) throw new LibraryServiceFailure("startup_cancelled");
+      const descriptor = exactDescriptor(
+        await native.execute("describe_checkpoint_export_v2", {}),
+      );
+      const persisted = closedState(await options.state.read());
+      if (persisted !== null && !sameAuthority(persisted, descriptor)) {
+        throw new LibraryServiceFailure("authority_not_primary");
+      }
+      const accessToken = await options.token.accessToken(signal);
+      if (
+        typeof accessToken !== "string" ||
+        accessToken.length === 0 ||
+        accessToken.length > 16_384
+      ) {
+        throw new LibraryServiceFailure("credential_descriptor_invalid");
+      }
+      const provisioned = await transport.provision({
+        accessToken,
+        libraryId: descriptor.libraryId,
+        signal,
+      });
+      const adapter = transport.adapter({
+        accessToken,
+        controlFileId: provisioned.controlFileId,
+        libraryId: descriptor.libraryId,
+        signal,
+      });
+      const controlRead = await adapter.readControl();
+      const pointer = parseControl(controlRead);
+      if (
+        pointer !== null &&
+        (String(pointer.writerId) !== String(descriptor.writerId) ||
+          String(pointer.storageEpoch) !== String(descriptor.authorityEpoch))
+      ) {
+        return Object.freeze({
+          status: "ownership_required" as const,
+          currentWriterId: pointer.writerId,
+          localWriterId: descriptor.writerId,
+        });
+      }
+      if (
+        pointer !== null &&
+        pointer.causalFrontierDigest === descriptor.causalFrontierDigest &&
+        persisted?.lastPublishedRevision === descriptor.sourceRevision &&
+        persisted.controlFileId === provisioned.controlFileId &&
+        persisted.controlRevision === controlRead.revision
+      ) {
+        return Object.freeze({
+          status: "current" as const,
+          revision: descriptor.sourceRevision,
+        });
+      }
+      const result = await publishLibraryCoreNormalizedCheckpointV2({
+        activeTransport: "google_drive_app_data_v1",
+        adapter,
+        descriptor,
+        expectedControl: { revision: controlRead.revision, pointer },
+        generation: pointer === null ? 0 : pointer.generation + 1,
+        records: checkpointRecords(native, descriptor),
+        subtle: crypto.subtle,
+      });
+      if (result.status === "conflict") {
+        if (
+          result.currentControlPointer !== null &&
+          String(result.currentControlPointer.writerId) !==
+            String(descriptor.writerId)
+        ) {
+          return Object.freeze({
+            status: "ownership_required" as const,
+            currentWriterId: result.currentControlPointer.writerId,
+            localWriterId: descriptor.writerId,
+          });
+        }
+        throw new LibraryServiceFailure("command_channel_failed");
+      }
+      await options.state.write(
+        Object.freeze({
+          schemaVersion: 1 as const,
+          libraryId: descriptor.libraryId,
+          authorityEpoch: descriptor.authorityEpoch,
+          writerId: descriptor.writerId,
+          controlFileId: provisioned.controlFileId,
+          controlRevision: result.revision,
+          lastPublishedRevision: descriptor.sourceRevision,
+        }),
+      );
+      return Object.freeze({
+        status: "published" as const,
+        revision: descriptor.sourceRevision,
+      });
+    },
+  });
+}

--- a/packages/library-service/src/index.ts
+++ b/packages/library-service/src/index.ts
@@ -13,6 +13,11 @@ export {
 } from "./contracts.js";
 export { runLibraryServiceCli } from "./cli-runtime.js";
 export {
+  authorizeNodeGoogleDriveV1,
+  type NodeGoogleDriveAuthDependenciesV1,
+  type NodeGoogleDriveAuthReceiptV1,
+} from "./node-google-drive-auth.js";
+export {
   createLibraryServiceDefinitionV1,
   LIBRARY_SERVICE_DEFINITION_SCHEMA_VERSION,
   LIBRARY_SERVICE_LAUNCHD_LABEL,
@@ -41,3 +46,16 @@ export {
   type LibraryServicePrimaryRuntimeOptionsV1,
   type LibraryServicePrimaryRuntimeV1,
 } from "./primary-runtime.js";
+export {
+  createBoundGoogleDrivePublicationStatePortV1,
+  createLibraryServiceGoogleDrivePublicationV1,
+  type LibraryServiceGoogleDrivePublicationOptionsV1,
+  type LibraryServiceGoogleDrivePublicationResultV1,
+  type LibraryServiceGoogleDrivePublicationStatePortV1,
+  type LibraryServiceGoogleDrivePublicationStateV1,
+  type LibraryServiceGoogleDriveTokenPortV1,
+} from "./google-drive-publication.js";
+export {
+  createNodeLibraryServicePrimaryCloudPortV1,
+  type LibraryServicePrimaryCloudPortV1,
+} from "./primary-cloud-runtime.js";

--- a/packages/library-service/src/node-google-drive-auth.test.ts
+++ b/packages/library-service/src/node-google-drive-auth.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { authorizeNodeGoogleDriveV1 } from "./node-google-drive-auth.js";
+
+describe("headless Google Drive PKCE authorization", () => {
+  it("requests only Library Core Drive scopes and stores only the refresh token", async () => {
+    let authorizationUrl: URL | null = null;
+    let persisted = "";
+    const proxyFetch = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        const body = JSON.parse(String(init?.body));
+        expect(body.code).toBe("authorization-code");
+        expect(body.verifier).toMatch(/^[A-Za-z0-9_-]+$/u);
+        expect(body.redirectUri).toMatch(
+          /^http:\/\/127\.0\.0\.1:\d+\/callback$/u,
+        );
+        return new Response(
+          JSON.stringify({
+            access_token: "short-lived-access-token",
+            refresh_token: "refresh-secret",
+            expires_in: 3_600,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    );
+
+    const receipt = await authorizeNodeGoogleDriveV1("library-drive", {
+      platform: "darwin",
+      fetch: proxyFetch,
+      async openAuthorizationUrl(url) {
+        authorizationUrl = new URL(url);
+        const callback = new URL(
+          authorizationUrl.searchParams.get("redirect_uri")!,
+        );
+        callback.searchParams.set("code", "authorization-code");
+        callback.searchParams.set(
+          "state",
+          authorizationUrl.searchParams.get("state")!,
+        );
+        setImmediate(() => void fetch(callback));
+      },
+      async persistCredential(_recordId, credential) {
+        persisted = credential;
+      },
+    });
+
+    expect(authorizationUrl).not.toBeNull();
+    const scopes = authorizationUrl!.searchParams.get("scope")!.split(" ");
+    expect(scopes).toEqual([
+      "https://www.googleapis.com/auth/drive.appdata",
+      "https://www.googleapis.com/auth/drive.file",
+    ]);
+    expect(scopes).not.toContain(
+      "https://www.googleapis.com/auth/contacts.readonly",
+    );
+    expect(JSON.parse(persisted)).toEqual({
+      schemaVersion: 1,
+      refreshToken: "refresh-secret",
+    });
+    expect(persisted).not.toContain("short-lived-access-token");
+    expect(receipt).toEqual({
+      schemaVersion: 1,
+      provider: "google-drive",
+      credentialRecordId: "library-drive",
+      scopes,
+    });
+  });
+
+  it("rejects a callback with the wrong state before token exchange", async () => {
+    const proxyFetch = vi.fn();
+    await expect(
+      authorizeNodeGoogleDriveV1("library-drive", {
+        platform: "darwin",
+        fetch: proxyFetch,
+        async openAuthorizationUrl(url) {
+          const authorization = new URL(url);
+          const callback = new URL(
+            authorization.searchParams.get("redirect_uri")!,
+          );
+          callback.searchParams.set("code", "authorization-code");
+          callback.searchParams.set("state", "wrong-state");
+          setImmediate(() => void fetch(callback));
+        },
+        persistCredential: async () => undefined,
+        timeoutMs: 1_000,
+      }),
+    ).rejects.toMatchObject({ code: "drive_auth_failed" });
+    expect(proxyFetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/library-service/src/node-google-drive-auth.ts
+++ b/packages/library-service/src/node-google-drive-auth.ts
@@ -1,0 +1,269 @@
+import { execFile, spawn } from "node:child_process";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import { createServer } from "node:http";
+import { promisify } from "node:util";
+
+import { LibraryServiceFailure } from "./contracts.js";
+
+const execFileAsync = promisify(execFile);
+const KEYCHAIN_HELPER = "/usr/bin/security";
+const OPEN_HELPER = "/usr/bin/open";
+const KEYCHAIN_SERVICE = "wtf.freed.library-service.google-drive";
+const TOKEN_PROXY_URL = "https://app.freed.wtf/api/oauth/google";
+const GOOGLE_DESKTOP_CLIENT_ID =
+  "304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com";
+const GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const GOOGLE_DRIVE_SCOPES = [
+  "https://www.googleapis.com/auth/drive.appdata",
+  "https://www.googleapis.com/auth/drive.file",
+] as const;
+const CALLBACK_TIMEOUT_MS = 5 * 60_000;
+const MAX_SECRET_BYTES = 16_384;
+
+export interface NodeGoogleDriveAuthDependenciesV1 {
+  readonly platform?: NodeJS.Platform;
+  readonly fetch?: typeof fetch;
+  readonly openAuthorizationUrl?: (url: string) => Promise<void>;
+  readonly persistCredential?: (
+    recordId: string,
+    credential: string,
+  ) => Promise<void>;
+  readonly timeoutMs?: number;
+}
+
+export interface NodeGoogleDriveAuthReceiptV1 {
+  readonly schemaVersion: 1;
+  readonly provider: "google-drive";
+  readonly credentialRecordId: string;
+  readonly scopes: typeof GOOGLE_DRIVE_SCOPES;
+}
+
+function base64Url(bytes: Uint8Array): string {
+  return Buffer.from(bytes)
+    .toString("base64")
+    .replaceAll("+", "-")
+    .replaceAll("/", "_")
+    .replace(/=+$/u, "");
+}
+
+async function openAuthorizationUrl(url: string): Promise<void> {
+  try {
+    await execFileAsync(OPEN_HELPER, [url], {
+      encoding: "utf8",
+      maxBuffer: 1_024,
+      timeout: 5_000,
+      windowsHide: true,
+    });
+  } catch {
+    throw new LibraryServiceFailure("drive_auth_failed");
+  }
+}
+
+async function persistMacOsCredential(
+  recordId: string,
+  credential: string,
+): Promise<void> {
+  if (Buffer.byteLength(credential, "utf8") > MAX_SECRET_BYTES) {
+    throw new LibraryServiceFailure("drive_auth_failed");
+  }
+  await new Promise<void>((resolve, reject) => {
+    const child = spawn(
+      KEYCHAIN_HELPER,
+      [
+        "add-generic-password",
+        "-a",
+        recordId,
+        "-s",
+        KEYCHAIN_SERVICE,
+        "-U",
+        "-w",
+      ],
+      {
+        cwd: "/",
+        env: {},
+        shell: false,
+        stdio: ["pipe", "ignore", "ignore"],
+        windowsHide: true,
+      },
+    );
+    let settled = false;
+    const finish = (error?: unknown): void => {
+      if (settled) return;
+      settled = true;
+      if (error === undefined) resolve();
+      else reject(new LibraryServiceFailure("drive_auth_failed"));
+    };
+    child.once("error", finish);
+    child.once("exit", (code) => {
+      if (code === 0) finish();
+      else finish(new Error("keychain write failed"));
+    });
+    child.stdin.on("error", finish);
+    child.stdin.end(`${credential}\n`, "utf8");
+  });
+}
+
+async function receiveAuthorizationCode(input: {
+  readonly state: string;
+  readonly timeoutMs: number;
+  readonly open: (url: string) => Promise<void>;
+  readonly buildUrl: (redirectUri: string) => string;
+}): Promise<{ readonly code: string; readonly redirectUri: string }> {
+  let settle:
+    | ((result: {
+        readonly code: string;
+        readonly redirectUri: string;
+      }) => void)
+    | null = null;
+  let refuse: ((error: unknown) => void) | null = null;
+  const callback = new Promise<{
+    readonly code: string;
+    readonly redirectUri: string;
+  }>((resolve, reject) => {
+    settle = resolve;
+    refuse = reject;
+  });
+  let redirectUri = "";
+  const server = createServer((request, response) => {
+    const remote = request.socket.remoteAddress;
+    if (remote !== "127.0.0.1" && remote !== "::1") {
+      response.writeHead(403).end("Forbidden");
+      return;
+    }
+    let url: URL;
+    try {
+      url = new URL(request.url ?? "", redirectUri);
+    } catch {
+      response.writeHead(400).end("Invalid callback");
+      return;
+    }
+    const code = url.searchParams.get("code");
+    const state = url.searchParams.get("state");
+    if (url.pathname !== "/callback" || state !== input.state || !code) {
+      response.writeHead(400).end("Google Drive authorization did not match.");
+      refuse?.(new LibraryServiceFailure("drive_auth_failed"));
+      return;
+    }
+    response
+      .writeHead(200, { "Content-Type": "text/plain; charset=utf-8" })
+      .end("Google Drive is connected. You can close this tab.");
+    settle?.({ code, redirectUri });
+  });
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(0, "127.0.0.1", resolve);
+    });
+    const address = server.address();
+    if (address === null || typeof address === "string") {
+      throw new LibraryServiceFailure("drive_auth_failed");
+    }
+    redirectUri = `http://127.0.0.1:${address.port.toLocaleString("en-US", { useGrouping: false })}/callback`;
+    await input.open(input.buildUrl(redirectUri));
+    return await new Promise((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new LibraryServiceFailure("drive_auth_failed")),
+        input.timeoutMs,
+      );
+      callback.then(
+        (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      );
+    });
+  } catch (error) {
+    if (error instanceof LibraryServiceFailure) throw error;
+    throw new LibraryServiceFailure("drive_auth_failed");
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+}
+
+/** Complete one interactive PKCE grant and persist only the refresh token. */
+export async function authorizeNodeGoogleDriveV1(
+  recordId: string,
+  dependencies: NodeGoogleDriveAuthDependenciesV1 = {},
+): Promise<NodeGoogleDriveAuthReceiptV1> {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(recordId)) {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+  const platform = dependencies.platform ?? process.platform;
+  if (platform !== "darwin" && dependencies.persistCredential === undefined) {
+    throw new LibraryServiceFailure("unsupported_secret_store_or_acl_backend");
+  }
+  const verifier = base64Url(randomBytes(64));
+  const challenge = base64Url(
+    createHash("sha256").update(verifier, "utf8").digest(),
+  );
+  const state = randomUUID();
+  const { code, redirectUri } = await receiveAuthorizationCode({
+    state,
+    timeoutMs: dependencies.timeoutMs ?? CALLBACK_TIMEOUT_MS,
+    open: dependencies.openAuthorizationUrl ?? openAuthorizationUrl,
+    buildUrl(callbackUri) {
+      const params = new URLSearchParams({
+        client_id: GOOGLE_DESKTOP_CLIENT_ID,
+        redirect_uri: callbackUri,
+        response_type: "code",
+        scope: GOOGLE_DRIVE_SCOPES.join(" "),
+        include_granted_scopes: "true",
+        code_challenge: challenge,
+        code_challenge_method: "S256",
+        access_type: "offline",
+        prompt: "consent",
+        state,
+      });
+      return `${GOOGLE_AUTH_URL}?${params.toString()}`;
+    },
+  });
+  const proxyFetch = dependencies.fetch ?? fetch;
+  let response: Response;
+  try {
+    response = await proxyFetch(TOKEN_PROXY_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        code,
+        verifier,
+        redirectUri,
+        clientId: GOOGLE_DESKTOP_CLIENT_ID,
+      }),
+    });
+  } catch {
+    throw new LibraryServiceFailure("drive_auth_failed");
+  }
+  if (!response.ok) throw new LibraryServiceFailure("drive_auth_failed");
+  let value: unknown;
+  try {
+    value = await response.json();
+  } catch {
+    throw new LibraryServiceFailure("drive_auth_failed");
+  }
+  const refreshToken =
+    value !== null && typeof value === "object" && !Array.isArray(value)
+      ? (value as { refresh_token?: unknown }).refresh_token
+      : null;
+  if (
+    typeof refreshToken !== "string" ||
+    refreshToken.length === 0 ||
+    Buffer.byteLength(refreshToken, "utf8") > MAX_SECRET_BYTES
+  ) {
+    throw new LibraryServiceFailure("drive_auth_failed");
+  }
+  const credential = JSON.stringify({ schemaVersion: 1, refreshToken });
+  await (dependencies.persistCredential ?? persistMacOsCredential)(
+    recordId,
+    credential,
+  );
+  return Object.freeze({
+    schemaVersion: 1,
+    provider: "google-drive",
+    credentialRecordId: recordId,
+    scopes: GOOGLE_DRIVE_SCOPES,
+  });
+}

--- a/packages/library-service/src/node-google-drive-token.test.ts
+++ b/packages/library-service/src/node-google-drive-token.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { createNodeGoogleDriveTokenPortV1 } from "./node-google-drive-token.js";
+
+describe("headless Google Drive token custody", () => {
+  it("reads one refresh token from the platform boundary and caches only the access token", async () => {
+    let nowMs = 1_000;
+    const readCredential = vi.fn(async () =>
+      JSON.stringify({ schemaVersion: 1, refreshToken: "refresh-secret" }),
+    );
+    const fetcher = vi.fn(
+      async (_input: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.body).toContain("refresh-secret");
+        return new Response(
+          JSON.stringify({ access_token: "access-secret", expires_in: 3_600 }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      },
+    );
+    const token = createNodeGoogleDriveTokenPortV1("library-record", {
+      platform: "darwin",
+      nowMs: () => nowMs,
+      readCredential,
+      fetch: fetcher,
+    });
+
+    await expect(token.accessToken(new AbortController().signal)).resolves.toBe(
+      "access-secret",
+    );
+    nowMs += 1_000;
+    await expect(token.accessToken(new AbortController().signal)).resolves.toBe(
+      "access-secret",
+    );
+    expect(readCredential).toHaveBeenCalledTimes(1);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails closed without exposing a provider response", async () => {
+    const token = createNodeGoogleDriveTokenPortV1("library-record", {
+      platform: "darwin",
+      readCredential: async () =>
+        JSON.stringify({ schemaVersion: 1, refreshToken: "refresh-secret" }),
+      fetch: async () =>
+        new Response("refresh-secret provider diagnostic", { status: 401 }),
+    });
+
+    await expect(
+      token.accessToken(new AbortController().signal),
+    ).rejects.toMatchObject({
+      code: "drive_auth_failed",
+      message: "drive_auth_failed",
+    });
+  });
+});

--- a/packages/library-service/src/node-google-drive-token.ts
+++ b/packages/library-service/src/node-google-drive-token.ts
@@ -1,0 +1,175 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+
+import { LibraryServiceFailure } from "./contracts.js";
+import type { LibraryServiceGoogleDriveTokenPortV1 } from "./google-drive-publication.js";
+
+const execFileAsync = promisify(execFile);
+const KEYCHAIN_HELPER = "/usr/bin/security";
+const KEYCHAIN_SERVICE = "wtf.freed.library-service.google-drive";
+const TOKEN_PROXY_URL = "https://app.freed.wtf/api/oauth/google";
+const GOOGLE_DESKTOP_CLIENT_ID =
+  "304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com";
+const MAX_SECRET_BYTES = 16_384;
+const TOKEN_REFRESH_SKEW_MS = 60_000;
+const TOKEN_REFRESH_FALLBACK_MS = 55 * 60_000;
+
+interface StoredGoogleDriveCredentialV1 {
+  readonly schemaVersion: 1;
+  readonly refreshToken: string;
+}
+
+interface TokenProxyResponseV1 {
+  readonly access_token?: unknown;
+  readonly expires_in?: unknown;
+}
+
+export interface NodeGoogleDriveTokenDependenciesV1 {
+  readonly platform?: NodeJS.Platform;
+  readonly nowMs?: () => number;
+  readonly readCredential?: (recordId: string) => Promise<string>;
+  readonly fetch?: typeof fetch;
+}
+
+function parseStoredCredential(text: string): StoredGoogleDriveCredentialV1 {
+  if (Buffer.byteLength(text, "utf8") > MAX_SECRET_BYTES) {
+    throw new LibraryServiceFailure("drive_credential_unavailable");
+  }
+  let value: unknown;
+  try {
+    value = JSON.parse(text);
+  } catch {
+    throw new LibraryServiceFailure("drive_credential_unavailable");
+  }
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    Object.getPrototypeOf(value) !== Object.prototype ||
+    Object.keys(value).sort().join(",") !== "refreshToken,schemaVersion" ||
+    (value as { schemaVersion?: unknown }).schemaVersion !== 1 ||
+    typeof (value as { refreshToken?: unknown }).refreshToken !== "string" ||
+    (value as { refreshToken: string }).refreshToken.length === 0 ||
+    Buffer.byteLength(
+      (value as { refreshToken: string }).refreshToken,
+      "utf8",
+    ) > MAX_SECRET_BYTES
+  ) {
+    throw new LibraryServiceFailure("drive_credential_unavailable");
+  }
+  return Object.freeze({
+    schemaVersion: 1,
+    refreshToken: (value as { refreshToken: string }).refreshToken,
+  });
+}
+
+async function readMacOsCredential(recordId: string): Promise<string> {
+  try {
+    const result = await execFileAsync(
+      KEYCHAIN_HELPER,
+      ["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", recordId, "-w"],
+      {
+        encoding: "utf8",
+        maxBuffer: MAX_SECRET_BYTES + 1,
+        timeout: 5_000,
+        windowsHide: true,
+      },
+    );
+    return result.stdout.trimEnd();
+  } catch {
+    throw new LibraryServiceFailure("drive_credential_unavailable");
+  }
+}
+
+function parseAccessToken(
+  value: TokenProxyResponseV1,
+  nowMs: number,
+): { readonly accessToken: string; readonly expiresAt: number } {
+  if (
+    typeof value.access_token !== "string" ||
+    value.access_token.length === 0 ||
+    Buffer.byteLength(value.access_token, "utf8") > MAX_SECRET_BYTES
+  ) {
+    throw new LibraryServiceFailure("drive_auth_failed");
+  }
+  const expiresAt =
+    typeof value.expires_in === "number" &&
+    Number.isSafeInteger(value.expires_in) &&
+    value.expires_in > 0 &&
+    value.expires_in <= 86_400
+      ? nowMs + value.expires_in * 1_000
+      : nowMs + TOKEN_REFRESH_FALLBACK_MS;
+  return Object.freeze({ accessToken: value.access_token, expiresAt });
+}
+
+/** Resolve short-lived Google Drive access tokens without persisting them. */
+export function createNodeGoogleDriveTokenPortV1(
+  recordId: string,
+  dependencies: NodeGoogleDriveTokenDependenciesV1 = {},
+): LibraryServiceGoogleDriveTokenPortV1 {
+  if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(recordId)) {
+    throw new LibraryServiceFailure("config_invalid");
+  }
+  const platform = dependencies.platform ?? process.platform;
+  if (platform !== "darwin" && dependencies.readCredential === undefined) {
+    throw new LibraryServiceFailure("unsupported_secret_store_or_acl_backend");
+  }
+  const readCredential = dependencies.readCredential ?? readMacOsCredential;
+  const googleFetch = dependencies.fetch ?? fetch;
+  const now = dependencies.nowMs ?? Date.now;
+  let cached: {
+    readonly accessToken: string;
+    readonly expiresAt: number;
+  } | null = null;
+  let pending: Promise<string> | null = null;
+
+  return Object.freeze({
+    async accessToken(signal: AbortSignal): Promise<string> {
+      const currentTime = now();
+      if (
+        cached !== null &&
+        cached.expiresAt - currentTime > TOKEN_REFRESH_SKEW_MS
+      ) {
+        return cached.accessToken;
+      }
+      if (pending !== null) return pending;
+      pending = (async () => {
+        if (signal.aborted) {
+          throw new LibraryServiceFailure("startup_cancelled");
+        }
+        const credential = parseStoredCredential(
+          await readCredential(recordId),
+        );
+        let response: Response;
+        try {
+          response = await googleFetch(TOKEN_PROXY_URL, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              grantType: "refresh_token",
+              refreshToken: credential.refreshToken,
+              clientId: GOOGLE_DESKTOP_CLIENT_ID,
+            }),
+            signal,
+          });
+        } catch {
+          throw new LibraryServiceFailure("drive_auth_failed");
+        }
+        if (!response.ok) {
+          throw new LibraryServiceFailure("drive_auth_failed");
+        }
+        let payload: TokenProxyResponseV1;
+        try {
+          payload = (await response.json()) as TokenProxyResponseV1;
+        } catch {
+          throw new LibraryServiceFailure("drive_auth_failed");
+        }
+        cached = parseAccessToken(payload, now());
+        return cached.accessToken;
+      })().finally(() => {
+        pending = null;
+      });
+      return pending;
+    },
+  });
+}

--- a/packages/library-service/src/node-ports.ts
+++ b/packages/library-service/src/node-ports.ts
@@ -32,6 +32,7 @@ import { LIBRARY_CORE_NATIVE_COMMAND_MAXIMUM_FRAME_BYTES } from "./library-core-
 import { assertLinuxAclOutputHasOnlyModeEntries } from "./linux-acl-proof.js";
 import { createNodeLibraryServiceLocalActorIngressPortV1 } from "./local-actor-node-server.js";
 import type { LibraryServiceLocalActorIngressPortV1 } from "./local-actor-transport.js";
+import type { LibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runtime.js";
 
 const execFileAsync = promisify(execFile);
 const MAX_ACL_OUTPUT_BYTES = 32 * 1_024;
@@ -951,6 +952,7 @@ interface NodeLibraryServicePorts {
   entropy: LibraryServiceEntropyPort;
   process: LibraryServiceProcessPort;
   localActorIngress: LibraryServiceLocalActorIngressPortV1;
+  primaryCloud: LibraryServicePrimaryCloudPortV1;
 }
 
 interface NodeLibraryServicePortsOptions {
@@ -970,5 +972,12 @@ export function createNodeLibraryServicePorts(
     entropy: new NodeLibraryServiceEntropy(),
     process: new NodeLibraryServiceProcess(clock, options.spawnChild ?? spawn),
     localActorIngress: createNodeLibraryServiceLocalActorIngressPortV1(),
+    primaryCloud: {
+      async start(input) {
+        const { createNodeLibraryServicePrimaryCloudPortV1 } =
+          await import("./primary-cloud-runtime.js");
+        return createNodeLibraryServicePrimaryCloudPortV1().start(input);
+      },
+    },
   };
 }

--- a/packages/library-service/src/primary-cloud-runtime.ts
+++ b/packages/library-service/src/primary-cloud-runtime.ts
@@ -1,0 +1,65 @@
+import type {
+  LibraryServiceBoundPath,
+  LibraryServiceClockPort,
+  LibraryServiceFileSystemPort,
+  LibraryServiceGoogleDriveConfig,
+} from "./contracts.js";
+import {
+  createBoundGoogleDrivePublicationStatePortV1,
+  createLibraryServiceGoogleDrivePublicationV1,
+} from "./google-drive-publication.js";
+import type { LibraryCoreNativeCommandClientV1 } from "./native-command.js";
+import { createNodeGoogleDriveTokenPortV1 } from "./node-google-drive-token.js";
+import {
+  createLibraryServicePrimaryRuntimeV1,
+  type LibraryServicePrimaryRuntimeV1,
+} from "./primary-runtime.js";
+
+export interface LibraryServicePrimaryCloudPortV1 {
+  start(input: {
+    readonly config: LibraryServiceGoogleDriveConfig;
+    readonly stateFile: LibraryServiceBoundPath;
+    readonly fileSystem: LibraryServiceFileSystemPort;
+    readonly clock: LibraryServiceClockPort;
+    readonly native: LibraryCoreNativeCommandClientV1;
+  }): Promise<LibraryServicePrimaryRuntimeV1<{ readonly status: string }>>;
+}
+
+type PrimaryCloudStartInputV1 = Parameters<
+  LibraryServicePrimaryCloudPortV1["start"]
+>[0];
+
+/** Create the installed Node host for the shared Primary coordinator. */
+export function createNodeLibraryServicePrimaryCloudPortV1(): LibraryServicePrimaryCloudPortV1 {
+  return Object.freeze({
+    async start(input: PrimaryCloudStartInputV1) {
+      const publication = createLibraryServiceGoogleDrivePublicationV1({
+        state: createBoundGoogleDrivePublicationStatePortV1(
+          input.stateFile,
+          input.fileSystem,
+        ),
+        token: createNodeGoogleDriveTokenPortV1(
+          input.config.credentialRecordId,
+        ),
+      });
+      const runtime = createLibraryServicePrimaryRuntimeV1({
+        clock: { nowMs: () => input.clock.nowMs() },
+        diagnostics: { record() {} },
+        installationWitness: input.config.installationWitness,
+        native: input.native,
+        publication,
+        publicationState: publication,
+        scheduler: {
+          schedule(callback, delayMs) {
+            return setTimeout(() => void callback(), delayMs);
+          },
+          cancel(handle) {
+            clearTimeout(handle);
+          },
+        },
+      });
+      await runtime.start();
+      return runtime;
+    },
+  });
+}

--- a/packages/library-service/src/supervisor.test.ts
+++ b/packages/library-service/src/supervisor.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { LibraryServiceFailure } from "./contracts.js";
 import { LibraryServiceSupervisor } from "./supervisor.js";
+import type { LibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runtime.js";
 import {
   Deferred,
   FakeAclProof,
@@ -22,6 +23,7 @@ function createSupervisor(
     fileSystem?: FakeFileSystem;
     aclProof?: FakeAclProof;
     localActorIngress?: FakeLocalActorIngress;
+    primaryCloud?: LibraryServicePrimaryCloudPortV1;
   } = {},
 ) {
   const child = input.child ?? new FakeSidecarProcess();
@@ -40,6 +42,7 @@ function createSupervisor(
     clock,
     entropy: new FakeEntropy(),
     localActorIngress,
+    primaryCloud: input.primaryCloud,
   });
   return {
     child,
@@ -147,6 +150,42 @@ describe("LibraryServiceSupervisor", () => {
       JSON.parse(contents),
     );
     expect(statuses.map(({ phase }) => phase)).toEqual(["starting", "running"]);
+  });
+
+  it("starts and stops the recurring Primary when Google Drive is explicitly configured", async () => {
+    const fileSystem = validConfigFileSystem();
+    const config = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    config.cloud = {
+      provider: "google-drive",
+      installationWitness: "e".repeat(64),
+      credentialRecordId: "library-drive",
+      publicationStateFile: "/safe/state/library-drive-state.json",
+    };
+    fileSystem.addFile("/safe/config.json", JSON.stringify(config));
+    fileSystem.addFile("/safe/state/library-drive-state.json", "");
+    const stop = vi.fn();
+    const primaryCloud: LibraryServicePrimaryCloudPortV1 = {
+      start: vi.fn(async () => ({
+        start: async () => ({ status: "current" }),
+        stop,
+      })),
+    };
+    const { supervisor } = createSupervisor({ fileSystem, primaryCloud });
+
+    await supervisor.start();
+    expect(primaryCloud.start).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          credentialRecordId: "library-drive",
+        }),
+        stateFile: expect.objectContaining({
+          path: "/safe/state/library-drive-state.json",
+        }),
+      }),
+    );
+
+    await supervisor.stop();
+    expect(stop).toHaveBeenCalledTimes(1);
   });
 
   it("maps signed local actor methods into their closed native commands", async () => {

--- a/packages/library-service/src/supervisor.ts
+++ b/packages/library-service/src/supervisor.ts
@@ -50,6 +50,8 @@ import {
   createLibraryServiceStatusRecord,
   writeLibraryServiceStatus,
 } from "./status.js";
+import type { LibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runtime.js";
+import type { LibraryServicePrimaryRuntimeV1 } from "./primary-runtime.js";
 
 const READY_KEYS = new Set([
   "type",
@@ -86,6 +88,7 @@ export interface LibraryServiceSupervisorDependencies {
   clock: LibraryServiceClockPort;
   entropy: LibraryServiceEntropyPort;
   localActorIngress: LibraryServiceLocalActorIngressPortV1;
+  primaryCloud?: LibraryServicePrimaryCloudPortV1;
 }
 
 export interface LibraryServiceStartResult {
@@ -264,6 +267,7 @@ export class LibraryServiceSupervisor {
   readonly #clock: LibraryServiceClockPort;
   readonly #entropy: LibraryServiceEntropyPort;
   readonly #localActorIngress: LibraryServiceLocalActorIngressPortV1;
+  readonly #primaryCloud: LibraryServicePrimaryCloudPortV1 | null;
   #config: LibraryServiceConfig | null = null;
   #state: SupervisorState = "idle";
   #child: LibraryServiceSidecarProcess | null = null;
@@ -275,6 +279,10 @@ export class LibraryServiceSupervisor {
   #startupCommitted = false;
   #statusTail: Promise<void> = Promise.resolve();
   #localActor: LibraryServiceLocalActorListenerV1 | null = null;
+  #cloudState: LibraryServiceBoundPath | null = null;
+  #primaryRuntime: LibraryServicePrimaryRuntimeV1<{
+    readonly status: string;
+  }> | null = null;
 
   constructor(dependencies: LibraryServiceSupervisorDependencies) {
     this.#configPath = dependencies.configPath;
@@ -285,6 +293,7 @@ export class LibraryServiceSupervisor {
     this.#clock = dependencies.clock;
     this.#entropy = dependencies.entropy;
     this.#localActorIngress = dependencies.localActorIngress;
+    this.#primaryCloud = dependencies.primaryCloud ?? null;
   }
 
   #requireConfig(): LibraryServiceConfig {
@@ -354,11 +363,14 @@ export class LibraryServiceSupervisor {
   async #closeRuntimeBindings(): Promise<void> {
     const stateRoot = this.#stateRoot;
     const statusFile = this.#statusFile;
+    const cloudState = this.#cloudState;
     this.#stateRoot = null;
     this.#statusFile = null;
+    this.#cloudState = null;
     await Promise.all([
       stateRoot?.close().catch(() => undefined),
       statusFile?.close().catch(() => undefined),
+      cloudState?.close().catch(() => undefined),
     ]);
   }
 
@@ -493,6 +505,8 @@ export class LibraryServiceSupervisor {
     const localActorSettlement =
       this.#localActor?.stop().catch(() => undefined) ?? Promise.resolve();
     this.#localActor = null;
+    this.#primaryRuntime?.stop();
+    this.#primaryRuntime = null;
     const child = this.#child;
     const settlement =
       child === null
@@ -557,6 +571,7 @@ export class LibraryServiceSupervisor {
 
       this.#config = bound.config;
       this.#stateRoot = bound.bindings.stateRoot;
+      this.#cloudState = bound.cloudState;
       this.#startedAt = new Date(this.#clock.nowMs()).toISOString();
       throwIfAborted(signal);
       const statusBindingPromise = bindLibraryServiceStatusFile(
@@ -725,6 +740,24 @@ export class LibraryServiceSupervisor {
       });
       throwIfAborted(signal);
 
+      if (bound.config.cloud !== null) {
+        if (this.#primaryCloud === null || bound.cloudState === null) {
+          throw new LibraryServiceFailure("cloud_runtime_failed");
+        }
+        try {
+          this.#primaryRuntime = await this.#primaryCloud.start({
+            config: bound.config.cloud,
+            stateFile: bound.cloudState,
+            fileSystem: this.#fileSystem,
+            clock: this.#clock,
+            native: commandClient,
+          });
+        } catch (error) {
+          throw toFailure(error, "cloud_runtime_failed");
+        }
+      }
+      throwIfAborted(signal);
+
       this.#state = "running";
       if (localActorFailed) {
         throw new LibraryServiceFailure("local_actor_failed");
@@ -737,6 +770,8 @@ export class LibraryServiceSupervisor {
           this.#state = "settled";
           const localActorAtExit = this.#localActor;
           this.#localActor = null;
+          this.#primaryRuntime?.stop();
+          this.#primaryRuntime = null;
           await localActorAtExit?.stop().catch(() => undefined);
           try {
             await this.#settleAfterKill(
@@ -803,6 +838,7 @@ export class LibraryServiceSupervisor {
         } else {
           await bound.close().catch(() => undefined);
           this.#stateRoot = null;
+          this.#cloudState = null;
           await this.#statusFile?.close().catch(() => undefined);
           this.#statusFile = null;
         }
@@ -827,6 +863,8 @@ export class LibraryServiceSupervisor {
     const child = this.#child;
     const localActor = this.#localActor;
     this.#localActor = null;
+    this.#primaryRuntime?.stop();
+    this.#primaryRuntime = null;
     const localActorSettlement = localActor?.stop() ?? Promise.resolve();
     const settlement = this.#settleAfterTerm(
       child,
@@ -867,6 +905,8 @@ export class LibraryServiceSupervisor {
     this.#state = "stopping";
     const localActor = this.#localActor;
     this.#localActor = null;
+    this.#primaryRuntime?.stop();
+    this.#primaryRuntime = null;
     void localActor?.stop().catch(() => undefined);
     try {
       child.terminate("SIGKILL");

--- a/packages/library-service/src/testing/fakes.ts
+++ b/packages/library-service/src/testing/fakes.ts
@@ -581,6 +581,7 @@ export function validConfig(): LibraryServiceConfig {
     stateRoot: "/safe/state",
     admissionFile: "/safe/state/admission.json",
     credentialDescriptorFile: "/safe/state/credentials.json",
+    cloud: null,
     sidecar: {
       executable: "/trusted/sidecar",
       sha256: "a".repeat(64),

--- a/packages/library-service/tsconfig.json
+++ b/packages/library-service/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "lib": ["ES2022"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "types": ["node"],
     "outDir": "dist",
     "rootDir": "src",

--- a/scripts/lib/provider-visible-paths.mjs
+++ b/scripts/lib/provider-visible-paths.mjs
@@ -196,6 +196,14 @@ const ALL_PROVIDER_SCOPES = Object.freeze([
 export const PROVIDER_VISIBLE_EXACT_SCOPES = new Map([
   ["packages/capture-rss/src/discovery.ts", ["other"]],
   ["packages/capture-save/src/extract.ts", ["other"]],
+  ["packages/library-service/src/cli-runtime.ts", ["other"]],
+  ["packages/library-service/src/config.ts", ["other"]],
+  ["packages/library-service/src/google-drive-publication.ts", ["other"]],
+  ["packages/library-service/src/node-google-drive-auth.ts", ["other"]],
+  ["packages/library-service/src/node-google-drive-token.ts", ["other"]],
+  ["packages/library-service/src/node-ports.ts", ["other"]],
+  ["packages/library-service/src/primary-cloud-runtime.ts", ["other"]],
+  ["packages/library-service/src/supervisor.ts", ["other"]],
   ["packages/desktop/src-tauri/src/webkit-mask.js", ALL_SOCIAL_PROVIDER_SCOPES],
   [
     "packages/desktop/src-tauri/src/lib.rs",

--- a/scripts/lib/provider-visible-paths.test.mjs
+++ b/scripts/lib/provider-visible-paths.test.mjs
@@ -424,6 +424,20 @@ test("background media and Google sync network surfaces are provider-visible", (
     isProviderVisiblePath("packages/sync/src/cloud/gdrive.ts"),
     true,
   );
+  assert.equal(
+    isProviderVisiblePath(
+      "packages/library-service/src/google-drive-publication.ts",
+    ),
+    true,
+  );
+  assert.equal(
+    isProviderVisiblePath("packages/library-service/src/supervisor.ts"),
+    true,
+  );
+  assert.deepEqual(
+    providerIdsForPath("packages/library-service/src/node-google-drive-auth.ts"),
+    ["other"],
+  );
 });
 
 test("non-provider paths are not provider-visible", () => {


### PR DESCRIPTION
(AI Generated).

## Summary
- Add macOS PKCE and Keychain custody for the headless Library service.
- Start the shared Primary coordinator with bounded immutable checkpoint publication and durable compare-and-swap receipts.
- Keep unconfigured services provider-dormant and fail closed on missing credentials or writer conflicts.

## Testing
- npm run validate:feature

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `57546338df2bfd49fbcef9b773c35a3abbe3551f`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `headless-primary-google-drive-20260830`
- Provider review decision: `behavior_approved`
- Provider review artifact: `b00ad9864acef649c28e95d2ab5d113126e6445d1730ff9824f07e61eaaf32bd`
- Providers: other
- Observable behavior: An explicitly configured headless Primary service may authenticate to Google Drive through Freed's existing OAuth proxy, read the Library control pointer on the shared 15-second control cadence, run the shared 60-second maintenance cadence, and publish immutable normalized SQLite Library checkpoints when the local revision changes. Request shapes, endpoints, retry rules, and cadence remain the same as the existing shared Library Core coordinator. The service remains fail closed and makes no Google Drive request without a valid platform-custodied refresh token and explicit cloud configuration.
- Fingerprinting risk: Google Drive currently observes no requests from the headless service. Periodic authenticated control reads and checkpoint publications add a recognizable service cadence and could make that installation easier for Google to distinguish or rate limit.
- Lowest profile alternative: Keep headless Google Drive dormant and require manual sync-now and checkpoint-now commands. That reduces background contact but leaves the headless Primary operational environment incomplete.

Files bound into this provider review:
- `packages/library-service/src/cli-runtime.ts`
- `packages/library-service/src/config.ts`
- `packages/library-service/src/google-drive-publication.ts`
- `packages/library-service/src/node-google-drive-auth.ts`
- `packages/library-service/src/node-google-drive-token.ts`
- `packages/library-service/src/node-ports.ts`
- `packages/library-service/src/primary-cloud-runtime.ts`
- `packages/library-service/src/supervisor.ts`