### PR TITLE
fix: recover Friends graph from stale cursors

### DIFF
--- a/packages/ui/src/lib/friends-galaxy-product-worker-client.ts
+++ b/packages/ui/src/lib/friends-galaxy-product-worker-client.ts
@@ -1,4 +1,5 @@
 import type { FriendsGalaxyRendererScene } from "./friends-galaxy-renderer.js";
+import { normalizeFriendsGalaxySqliteSourceFailure } from "./friends-galaxy-sqlite-source.js";
 import {
   FRIENDS_GALAXY_PRODUCT_WORKER_PROTOCOL_VERSION,
   validateFriendsGalaxyProductWorkerResponse,
@@ -73,12 +74,7 @@ export interface FriendsGalaxyProductWorkerPort {
 }
 
 export type FriendsGalaxyProductWorkerFailurePhase =
-  | "source"
-  | "presentation"
-  | "activity"
-  | "protocol"
-  | "runtime"
-  | "post";
+  "source" | "presentation" | "activity" | "protocol" | "runtime" | "post";
 
 export interface FriendsGalaxyProductWorkerFailure {
   phase: FriendsGalaxyProductWorkerFailurePhase;
@@ -107,7 +103,8 @@ function createProductWorker(): FriendsGalaxyProductWorkerPort {
 }
 
 function defaultNow(): number {
-  return typeof performance !== "undefined" && typeof performance.now === "function"
+  return typeof performance !== "undefined" &&
+    typeof performance.now === "function"
     ? performance.now()
     : Date.now();
 }
@@ -164,13 +161,18 @@ export class FriendsGalaxyProductWorkerClient {
   private generation = 0;
   private nextRequestId = 1;
   private currentSourceRevision: number | null = null;
-  private sourceRequest: FriendsGalaxyProductWorkerSourceLaneRequest | null = null;
+  private sourceRequest: FriendsGalaxyProductWorkerSourceLaneRequest | null =
+    null;
   private normalizedSourceJob: FriendsGalaxyNormalizedSourceJob | null = null;
   private residentScene: FriendsGalaxyRendererScene | null = null;
-  private inFlightPresentation: FriendsGalaxyProductWorkerPresentationRequest | null = null;
-  private queuedPresentation: FriendsGalaxyProductWorkerPresentationRequest | null = null;
-  private inFlightActivity: FriendsGalaxyProductWorkerActivityRequest | null = null;
-  private queuedActivity: FriendsGalaxyProductWorkerActivityRequest | null = null;
+  private inFlightPresentation: FriendsGalaxyProductWorkerPresentationRequest | null =
+    null;
+  private queuedPresentation: FriendsGalaxyProductWorkerPresentationRequest | null =
+    null;
+  private inFlightActivity: FriendsGalaxyProductWorkerActivityRequest | null =
+    null;
+  private queuedActivity: FriendsGalaxyProductWorkerActivityRequest | null =
+    null;
   private latestPresentationRequestId = 0;
   private latestActivityRevision = -1;
   private sourceDeadline = 0;
@@ -255,7 +257,9 @@ export class FriendsGalaxyProductWorkerClient {
     return request.requestId;
   }
 
-  private startSourceLane(request: FriendsGalaxyProductWorkerSourceLaneRequest): void {
+  private startSourceLane(
+    request: FriendsGalaxyProductWorkerSourceLaneRequest,
+  ): void {
     this.sourceRequest = request;
     try {
       if (!this.worker) {
@@ -263,18 +267,20 @@ export class FriendsGalaxyProductWorkerClient {
         const worker = this.createWorker();
         this.worker = worker;
         worker.onmessage = (event) => this.receive(generation, event.data);
-        worker.onmessageerror = () => this.receivePortFailure(
-          generation,
-          "protocol",
-          "Friends Galaxy worker response could not be deserialized.",
-          request,
-        );
-        worker.onerror = (event) => this.receivePortFailure(
-          generation,
-          "runtime",
-          event.message || "Friends Galaxy worker failed.",
-          request,
-        );
+        worker.onmessageerror = () =>
+          this.receivePortFailure(
+            generation,
+            "protocol",
+            "Friends Galaxy worker response could not be deserialized.",
+            request,
+          );
+        worker.onerror = (event) =>
+          this.receivePortFailure(
+            generation,
+            "runtime",
+            event.message || "Friends Galaxy worker failed.",
+            request,
+          );
       }
       this.post(request);
     } catch (error) {
@@ -286,7 +292,8 @@ export class FriendsGalaxyProductWorkerClient {
     input: FriendsGalaxyProductWorkerPresentationInput,
   ): number | null {
     this.assertActive();
-    if (this.currentSourceRevision !== input.sourceRevision || !this.worker) return null;
+    if (this.currentSourceRevision !== input.sourceRevision || !this.worker)
+      return null;
     const request: FriendsGalaxyProductWorkerPresentationRequest = {
       ...input,
       kind: "presentation",
@@ -299,7 +306,9 @@ export class FriendsGalaxyProductWorkerClient {
     return request.requestId;
   }
 
-  requestActivity(input: FriendsGalaxyProductWorkerActivityInput): number | null {
+  requestActivity(
+    input: FriendsGalaxyProductWorkerActivityInput,
+  ): number | null {
     this.assertActive();
     if (
       this.currentSourceRevision !== input.sourceRevision ||
@@ -307,7 +316,8 @@ export class FriendsGalaxyProductWorkerClient {
       !Number.isSafeInteger(input.activityRevision) ||
       input.activityRevision < 0 ||
       input.activityRevision <= this.latestActivityRevision
-    ) return null;
+    )
+      return null;
     const request: FriendsGalaxyProductWorkerActivityRequest = {
       ...input,
       patches: cloneActivityPatches(input.patches),
@@ -379,8 +389,10 @@ export class FriendsGalaxyProductWorkerClient {
       request.kind === "normalized-source-begin" ||
       request.kind === "normalized-source-page" ||
       request.kind === "normalized-source-commit"
-    ) this.sourceDeadline = deadline;
-    else if (request.kind === "presentation") this.presentationDeadline = deadline;
+    )
+      this.sourceDeadline = deadline;
+    else if (request.kind === "presentation")
+      this.presentationDeadline = deadline;
     else this.activityDeadline = deadline;
     this.worker.postMessage(request);
   }
@@ -444,7 +456,9 @@ export class FriendsGalaxyProductWorkerClient {
         request.kind === "normalized-source-page"
       ) {
         if (candidate.kind !== "normalized-source-staged") {
-          throw new Error("Friends Galaxy worker returned the wrong normalized source response.");
+          throw new Error(
+            "Friends Galaxy worker returned the wrong normalized source response.",
+          );
         }
         this.sourceDeadline = 0;
         this.sourceRequest = null;
@@ -461,7 +475,9 @@ export class FriendsGalaxyProductWorkerClient {
         return;
       }
       if (candidate.kind !== "source-ready") {
-        throw new Error("Friends Galaxy worker returned the wrong source response.");
+        throw new Error(
+          "Friends Galaxy worker returned the wrong source response.",
+        );
       }
       this.sourceDeadline = 0;
       this.sourceRequest = null;
@@ -475,7 +491,9 @@ export class FriendsGalaxyProductWorkerClient {
     }
   }
 
-  private queryNormalizedSourcePage(job: FriendsGalaxyNormalizedSourceJob): void {
+  private queryNormalizedSourcePage(
+    job: FriendsGalaxyNormalizedSourceJob,
+  ): void {
     const queryId = NORMALIZED_SOURCE_QUERY_IDS[job.queryIndex];
     if (!queryId) {
       this.fail(
@@ -503,7 +521,8 @@ export class FriendsGalaxyProductWorkerClient {
           this.normalizedSourceJob !== job ||
           job.queryToken !== queryToken ||
           this.sourceRequest
-        ) return;
+        )
+          return;
         const request: FriendsGalaxyProductWorkerNormalizedSourcePageRequest = {
           cursor: job.cursor,
           kind: "normalized-source-page",
@@ -519,8 +538,13 @@ export class FriendsGalaxyProductWorkerClient {
           this.disposed ||
           this.normalizedSourceJob !== job ||
           job.queryToken !== queryToken
-        ) return;
-        this.fail("source", error, null);
+        )
+          return;
+        this.fail(
+          "source",
+          normalizeFriendsGalaxySqliteSourceFailure(error),
+          null,
+        );
       });
   }
 
@@ -569,7 +593,9 @@ export class FriendsGalaxyProductWorkerClient {
         return;
       }
       if (candidate.kind !== "presentation-ready") {
-        throw new Error("Friends Galaxy worker returned the wrong presentation response.");
+        throw new Error(
+          "Friends Galaxy worker returned the wrong presentation response.",
+        );
       }
       this.presentationDeadline = 0;
       this.inFlightPresentation = null;
@@ -602,7 +628,9 @@ export class FriendsGalaxyProductWorkerClient {
         return;
       }
       if (candidate.kind !== "activity-ready") {
-        throw new Error("Friends Galaxy worker returned the wrong activity response.");
+        throw new Error(
+          "Friends Galaxy worker returned the wrong activity response.",
+        );
       }
       this.activityDeadline = 0;
       this.inFlightActivity = null;
@@ -615,9 +643,13 @@ export class FriendsGalaxyProductWorkerClient {
 
   private flushPresentation(): void {
     if (
-      !this.worker || !this.residentScene || this.sourceRequest ||
-      this.inFlightPresentation || !this.queuedPresentation
-    ) return;
+      !this.worker ||
+      !this.residentScene ||
+      this.sourceRequest ||
+      this.inFlightPresentation ||
+      !this.queuedPresentation
+    )
+      return;
     const request = this.queuedPresentation;
     this.queuedPresentation = null;
     this.inFlightPresentation = request;
@@ -630,9 +662,13 @@ export class FriendsGalaxyProductWorkerClient {
 
   private flushActivity(): void {
     if (
-      !this.worker || !this.residentScene || this.sourceRequest ||
-      this.inFlightActivity || !this.queuedActivity
-    ) return;
+      !this.worker ||
+      !this.residentScene ||
+      this.sourceRequest ||
+      this.inFlightActivity ||
+      !this.queuedActivity
+    )
+      return;
     const request = this.queuedActivity;
     this.queuedActivity = null;
     this.inFlightActivity = request;

--- a/packages/ui/src/lib/friends-galaxy-product-worker-client.ts
+++ b/packages/ui/src/lib/friends-galaxy-product-worker-client.ts
@@ -74,7 +74,12 @@ export interface FriendsGalaxyProductWorkerPort {
 }
 
 export type FriendsGalaxyProductWorkerFailurePhase =
-  "source" | "presentation" | "activity" | "protocol" | "runtime" | "post";
+  | "source"
+  | "presentation"
+  | "activity"
+  | "protocol"
+  | "runtime"
+  | "post";
 
 export interface FriendsGalaxyProductWorkerFailure {
   phase: FriendsGalaxyProductWorkerFailurePhase;
@@ -103,8 +108,7 @@ function createProductWorker(): FriendsGalaxyProductWorkerPort {
 }
 
 function defaultNow(): number {
-  return typeof performance !== "undefined" &&
-    typeof performance.now === "function"
+  return typeof performance !== "undefined" && typeof performance.now === "function"
     ? performance.now()
     : Date.now();
 }
@@ -161,18 +165,13 @@ export class FriendsGalaxyProductWorkerClient {
   private generation = 0;
   private nextRequestId = 1;
   private currentSourceRevision: number | null = null;
-  private sourceRequest: FriendsGalaxyProductWorkerSourceLaneRequest | null =
-    null;
+  private sourceRequest: FriendsGalaxyProductWorkerSourceLaneRequest | null = null;
   private normalizedSourceJob: FriendsGalaxyNormalizedSourceJob | null = null;
   private residentScene: FriendsGalaxyRendererScene | null = null;
-  private inFlightPresentation: FriendsGalaxyProductWorkerPresentationRequest | null =
-    null;
-  private queuedPresentation: FriendsGalaxyProductWorkerPresentationRequest | null =
-    null;
-  private inFlightActivity: FriendsGalaxyProductWorkerActivityRequest | null =
-    null;
-  private queuedActivity: FriendsGalaxyProductWorkerActivityRequest | null =
-    null;
+  private inFlightPresentation: FriendsGalaxyProductWorkerPresentationRequest | null = null;
+  private queuedPresentation: FriendsGalaxyProductWorkerPresentationRequest | null = null;
+  private inFlightActivity: FriendsGalaxyProductWorkerActivityRequest | null = null;
+  private queuedActivity: FriendsGalaxyProductWorkerActivityRequest | null = null;
   private latestPresentationRequestId = 0;
   private latestActivityRevision = -1;
   private sourceDeadline = 0;
@@ -257,9 +256,7 @@ export class FriendsGalaxyProductWorkerClient {
     return request.requestId;
   }
 
-  private startSourceLane(
-    request: FriendsGalaxyProductWorkerSourceLaneRequest,
-  ): void {
+  private startSourceLane(request: FriendsGalaxyProductWorkerSourceLaneRequest): void {
     this.sourceRequest = request;
     try {
       if (!this.worker) {
@@ -267,20 +264,18 @@ export class FriendsGalaxyProductWorkerClient {
         const worker = this.createWorker();
         this.worker = worker;
         worker.onmessage = (event) => this.receive(generation, event.data);
-        worker.onmessageerror = () =>
-          this.receivePortFailure(
-            generation,
-            "protocol",
-            "Friends Galaxy worker response could not be deserialized.",
-            request,
-          );
-        worker.onerror = (event) =>
-          this.receivePortFailure(
-            generation,
-            "runtime",
-            event.message || "Friends Galaxy worker failed.",
-            request,
-          );
+        worker.onmessageerror = () => this.receivePortFailure(
+          generation,
+          "protocol",
+          "Friends Galaxy worker response could not be deserialized.",
+          request,
+        );
+        worker.onerror = (event) => this.receivePortFailure(
+          generation,
+          "runtime",
+          event.message || "Friends Galaxy worker failed.",
+          request,
+        );
       }
       this.post(request);
     } catch (error) {
@@ -292,8 +287,7 @@ export class FriendsGalaxyProductWorkerClient {
     input: FriendsGalaxyProductWorkerPresentationInput,
   ): number | null {
     this.assertActive();
-    if (this.currentSourceRevision !== input.sourceRevision || !this.worker)
-      return null;
+    if (this.currentSourceRevision !== input.sourceRevision || !this.worker) return null;
     const request: FriendsGalaxyProductWorkerPresentationRequest = {
       ...input,
       kind: "presentation",
@@ -306,9 +300,7 @@ export class FriendsGalaxyProductWorkerClient {
     return request.requestId;
   }
 
-  requestActivity(
-    input: FriendsGalaxyProductWorkerActivityInput,
-  ): number | null {
+  requestActivity(input: FriendsGalaxyProductWorkerActivityInput): number | null {
     this.assertActive();
     if (
       this.currentSourceRevision !== input.sourceRevision ||
@@ -316,8 +308,7 @@ export class FriendsGalaxyProductWorkerClient {
       !Number.isSafeInteger(input.activityRevision) ||
       input.activityRevision < 0 ||
       input.activityRevision <= this.latestActivityRevision
-    )
-      return null;
+    ) return null;
     const request: FriendsGalaxyProductWorkerActivityRequest = {
       ...input,
       patches: cloneActivityPatches(input.patches),
@@ -389,10 +380,8 @@ export class FriendsGalaxyProductWorkerClient {
       request.kind === "normalized-source-begin" ||
       request.kind === "normalized-source-page" ||
       request.kind === "normalized-source-commit"
-    )
-      this.sourceDeadline = deadline;
-    else if (request.kind === "presentation")
-      this.presentationDeadline = deadline;
+    ) this.sourceDeadline = deadline;
+    else if (request.kind === "presentation") this.presentationDeadline = deadline;
     else this.activityDeadline = deadline;
     this.worker.postMessage(request);
   }
@@ -456,9 +445,7 @@ export class FriendsGalaxyProductWorkerClient {
         request.kind === "normalized-source-page"
       ) {
         if (candidate.kind !== "normalized-source-staged") {
-          throw new Error(
-            "Friends Galaxy worker returned the wrong normalized source response.",
-          );
+          throw new Error("Friends Galaxy worker returned the wrong normalized source response.");
         }
         this.sourceDeadline = 0;
         this.sourceRequest = null;
@@ -475,9 +462,7 @@ export class FriendsGalaxyProductWorkerClient {
         return;
       }
       if (candidate.kind !== "source-ready") {
-        throw new Error(
-          "Friends Galaxy worker returned the wrong source response.",
-        );
+        throw new Error("Friends Galaxy worker returned the wrong source response.");
       }
       this.sourceDeadline = 0;
       this.sourceRequest = null;
@@ -491,9 +476,7 @@ export class FriendsGalaxyProductWorkerClient {
     }
   }
 
-  private queryNormalizedSourcePage(
-    job: FriendsGalaxyNormalizedSourceJob,
-  ): void {
+  private queryNormalizedSourcePage(job: FriendsGalaxyNormalizedSourceJob): void {
     const queryId = NORMALIZED_SOURCE_QUERY_IDS[job.queryIndex];
     if (!queryId) {
       this.fail(
@@ -521,8 +504,7 @@ export class FriendsGalaxyProductWorkerClient {
           this.normalizedSourceJob !== job ||
           job.queryToken !== queryToken ||
           this.sourceRequest
-        )
-          return;
+        ) return;
         const request: FriendsGalaxyProductWorkerNormalizedSourcePageRequest = {
           cursor: job.cursor,
           kind: "normalized-source-page",
@@ -538,8 +520,7 @@ export class FriendsGalaxyProductWorkerClient {
           this.disposed ||
           this.normalizedSourceJob !== job ||
           job.queryToken !== queryToken
-        )
-          return;
+        ) return;
         this.fail(
           "source",
           normalizeFriendsGalaxySqliteSourceFailure(error),
@@ -593,9 +574,7 @@ export class FriendsGalaxyProductWorkerClient {
         return;
       }
       if (candidate.kind !== "presentation-ready") {
-        throw new Error(
-          "Friends Galaxy worker returned the wrong presentation response.",
-        );
+        throw new Error("Friends Galaxy worker returned the wrong presentation response.");
       }
       this.presentationDeadline = 0;
       this.inFlightPresentation = null;
@@ -628,9 +607,7 @@ export class FriendsGalaxyProductWorkerClient {
         return;
       }
       if (candidate.kind !== "activity-ready") {
-        throw new Error(
-          "Friends Galaxy worker returned the wrong activity response.",
-        );
+        throw new Error("Friends Galaxy worker returned the wrong activity response.");
       }
       this.activityDeadline = 0;
       this.inFlightActivity = null;
@@ -643,13 +620,9 @@ export class FriendsGalaxyProductWorkerClient {
 
   private flushPresentation(): void {
     if (
-      !this.worker ||
-      !this.residentScene ||
-      this.sourceRequest ||
-      this.inFlightPresentation ||
-      !this.queuedPresentation
-    )
-      return;
+      !this.worker || !this.residentScene || this.sourceRequest ||
+      this.inFlightPresentation || !this.queuedPresentation
+    ) return;
     const request = this.queuedPresentation;
     this.queuedPresentation = null;
     this.inFlightPresentation = request;
@@ -662,13 +635,9 @@ export class FriendsGalaxyProductWorkerClient {
 
   private flushActivity(): void {
     if (
-      !this.worker ||
-      !this.residentScene ||
-      this.sourceRequest ||
-      this.inFlightActivity ||
-      !this.queuedActivity
-    )
-      return;
+      !this.worker || !this.residentScene || this.sourceRequest ||
+      this.inFlightActivity || !this.queuedActivity
+    ) return;
     const request = this.queuedActivity;
     this.queuedActivity = null;
     this.inFlightActivity = request;

--- a/packages/ui/src/lib/friends-galaxy-sqlite-source.test.ts
+++ b/packages/ui/src/lib/friends-galaxy-sqlite-source.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  FRIENDS_GALAXY_SQLITE_SOURCE_FENCE_CHANGED,
+  normalizeFriendsGalaxySqliteSourceFailure,
+} from "./friends-galaxy-sqlite-source.js";
+
+describe("Friends Galaxy SQLite source recovery", () => {
+  it.each([
+    "normalized Person graph page cursor is stale",
+    "normalized Account graph page cursor is stale",
+    "normalized RSS Feed page cursor is stale",
+  ])("maps the native %s failure to a recoverable source fence", (message) => {
+    expect(
+      normalizeFriendsGalaxySqliteSourceFailure(new Error(message)),
+    ).toMatchObject({ message: FRIENDS_GALAXY_SQLITE_SOURCE_FENCE_CHANGED });
+  });
+
+  it("preserves unrelated query failures", () => {
+    const failure = new Error("normalized Person graph page row is invalid");
+    expect(normalizeFriendsGalaxySqliteSourceFailure(failure)).toBe(failure);
+  });
+});

--- a/packages/ui/src/lib/friends-galaxy-sqlite-source.ts
+++ b/packages/ui/src/lib/friends-galaxy-sqlite-source.ts
@@ -97,12 +97,10 @@ function sameFence(
   left: FriendsGalaxySqliteSourceFence,
   right: FriendsGalaxySqliteSourceFence,
 ): boolean {
-  return (
-    left.generationId === right.generationId &&
+  return left.generationId === right.generationId &&
     left.layoutRevision === right.layoutRevision &&
     left.projectionRevision === right.projectionRevision &&
-    left.transitionSequence === right.transitionSequence
-  );
+    left.transitionSequence === right.transitionSequence;
 }
 
 function nextPhase(phase: Exclude<SourcePhase, "complete">): SourcePhase {
@@ -177,24 +175,19 @@ export class FriendsGalaxySqliteSourceAccumulator {
     return this.#fence;
   }
 
-  append(
-    input: FriendsGalaxySqliteSourcePageInput,
-  ): FriendsGalaxySqliteSourceProgress {
+  append(input: FriendsGalaxySqliteSourcePageInput): FriendsGalaxySqliteSourceProgress {
     if (this.#taken || this.#phase === "complete") {
       throw new Error("Friends Galaxy SQLite source is already complete.");
     }
     if (input.cursor !== this.#expectedCursor) {
-      throw new Error(
-        "Friends Galaxy SQLite source page cursor is not contiguous.",
-      );
+      throw new Error("Friends Galaxy SQLite source page cursor is not contiguous.");
     }
     const request = requestFor(this.#phase, input.cursor);
-    const parsed =
-      this.#phase === LIBRARY_CORE_PERSON_GRAPH_PAGE_QUERY_ID
-        ? parseLibraryCorePersonGraphPageResponseV1(input.page, request)
-        : this.#phase === LIBRARY_CORE_ACCOUNT_GRAPH_PAGE_QUERY_ID
-          ? parseLibraryCoreAccountGraphPageResponseV1(input.page, request)
-          : parseLibraryCoreRssFeedPageResponseV1(input.page, request);
+    const parsed = this.#phase === LIBRARY_CORE_PERSON_GRAPH_PAGE_QUERY_ID
+      ? parseLibraryCorePersonGraphPageResponseV1(input.page, request)
+      : this.#phase === LIBRARY_CORE_ACCOUNT_GRAPH_PAGE_QUERY_ID
+        ? parseLibraryCoreAccountGraphPageResponseV1(input.page, request)
+        : parseLibraryCoreRssFeedPageResponseV1(input.page, request);
     if (!parsed.ok) throw new Error(parsed.error);
     const page = parsed.value;
     const fence = sourceFence(page.source, page.layoutRevision);
@@ -205,33 +198,25 @@ export class FriendsGalaxySqliteSourceAccumulator {
     for (const row of page.rows) {
       const identity = "id" in row ? row.id : row.url;
       if (this.#lastIdentity !== null && identity <= this.#lastIdentity) {
-        throw new Error(
-          "Friends Galaxy SQLite source identities are not strictly increasing.",
-        );
+        throw new Error("Friends Galaxy SQLite source identities are not strictly increasing.");
       }
       this.#lastIdentity = identity;
       this.#totalRows += 1;
       if (this.#totalRows > FRIENDS_GALAXY_SQLITE_SOURCE_ROW_CAP) {
-        throw new Error(
-          "Friends Galaxy SQLite source exceeded its semantic row cap.",
-        );
+        throw new Error("Friends Galaxy SQLite source exceeded its semantic row cap.");
       }
       if (page.queryId === LIBRARY_CORE_PERSON_GRAPH_PAGE_QUERY_ID) {
-        const person =
-          row as LibraryCorePersonGraphPageResponseV1["rows"][number];
-        this.#persons.push(
-          Object.freeze({
-            avatarUrl: person.avatarUrl ?? undefined,
-            careLevel: person.careLevel as Person["careLevel"],
-            id: person.id,
-            name: person.name,
-            relationshipStatus: person.relationshipStatus,
-            ...graphPosition(person),
-          }),
-        );
+        const person = row as LibraryCorePersonGraphPageResponseV1["rows"][number];
+        this.#persons.push(Object.freeze({
+          avatarUrl: person.avatarUrl ?? undefined,
+          careLevel: person.careLevel as Person["careLevel"],
+          id: person.id,
+          name: person.name,
+          relationshipStatus: person.relationshipStatus,
+          ...graphPosition(person),
+        }));
       } else if (page.queryId === LIBRARY_CORE_ACCOUNT_GRAPH_PAGE_QUERY_ID) {
-        const account =
-          row as LibraryCoreAccountGraphPageResponseV1["rows"][number];
+        const account = row as LibraryCoreAccountGraphPageResponseV1["rows"][number];
         if (account.kind !== "social") continue;
         this.#accounts[account.id] = Object.freeze({
           activityCount: account.activityCount,

--- a/packages/ui/src/lib/friends-galaxy-sqlite-source.ts
+++ b/packages/ui/src/lib/friends-galaxy-sqlite-source.ts
@@ -23,6 +23,21 @@ export const FRIENDS_GALAXY_SQLITE_SOURCE_ROW_CAP = 100_000;
 export const FRIENDS_GALAXY_SQLITE_SOURCE_FENCE_CHANGED =
   "Friends Galaxy SQLite source page moved to a different source fence.";
 
+const FRIENDS_GALAXY_NATIVE_STALE_CURSOR_MESSAGES = new Set([
+  "normalized Person graph page cursor is stale",
+  "normalized Account graph page cursor is stale",
+  "normalized RSS Feed page cursor is stale",
+]);
+
+export function normalizeFriendsGalaxySqliteSourceFailure(
+  error: unknown,
+): unknown {
+  const message = error instanceof Error ? error.message : String(error ?? "");
+  return FRIENDS_GALAXY_NATIVE_STALE_CURSOR_MESSAGES.has(message.trim())
+    ? new Error(FRIENDS_GALAXY_SQLITE_SOURCE_FENCE_CHANGED)
+    : error;
+}
+
 export type FriendsGalaxySqliteSourcePage =
   | LibraryCorePersonGraphPageResponseV1
   | LibraryCoreAccountGraphPageResponseV1
@@ -82,10 +97,12 @@ function sameFence(
   left: FriendsGalaxySqliteSourceFence,
   right: FriendsGalaxySqliteSourceFence,
 ): boolean {
-  return left.generationId === right.generationId &&
+  return (
+    left.generationId === right.generationId &&
     left.layoutRevision === right.layoutRevision &&
     left.projectionRevision === right.projectionRevision &&
-    left.transitionSequence === right.transitionSequence;
+    left.transitionSequence === right.transitionSequence
+  );
 }
 
 function nextPhase(phase: Exclude<SourcePhase, "complete">): SourcePhase {
@@ -160,19 +177,24 @@ export class FriendsGalaxySqliteSourceAccumulator {
     return this.#fence;
   }
 
-  append(input: FriendsGalaxySqliteSourcePageInput): FriendsGalaxySqliteSourceProgress {
+  append(
+    input: FriendsGalaxySqliteSourcePageInput,
+  ): FriendsGalaxySqliteSourceProgress {
     if (this.#taken || this.#phase === "complete") {
       throw new Error("Friends Galaxy SQLite source is already complete.");
     }
     if (input.cursor !== this.#expectedCursor) {
-      throw new Error("Friends Galaxy SQLite source page cursor is not contiguous.");
+      throw new Error(
+        "Friends Galaxy SQLite source page cursor is not contiguous.",
+      );
     }
     const request = requestFor(this.#phase, input.cursor);
-    const parsed = this.#phase === LIBRARY_CORE_PERSON_GRAPH_PAGE_QUERY_ID
-      ? parseLibraryCorePersonGraphPageResponseV1(input.page, request)
-      : this.#phase === LIBRARY_CORE_ACCOUNT_GRAPH_PAGE_QUERY_ID
-        ? parseLibraryCoreAccountGraphPageResponseV1(input.page, request)
-        : parseLibraryCoreRssFeedPageResponseV1(input.page, request);
+    const parsed =
+      this.#phase === LIBRARY_CORE_PERSON_GRAPH_PAGE_QUERY_ID
+        ? parseLibraryCorePersonGraphPageResponseV1(input.page, request)
+        : this.#phase === LIBRARY_CORE_ACCOUNT_GRAPH_PAGE_QUERY_ID
+          ? parseLibraryCoreAccountGraphPageResponseV1(input.page, request)
+          : parseLibraryCoreRssFeedPageResponseV1(input.page, request);
     if (!parsed.ok) throw new Error(parsed.error);
     const page = parsed.value;
     const fence = sourceFence(page.source, page.layoutRevision);
@@ -183,25 +205,33 @@ export class FriendsGalaxySqliteSourceAccumulator {
     for (const row of page.rows) {
       const identity = "id" in row ? row.id : row.url;
       if (this.#lastIdentity !== null && identity <= this.#lastIdentity) {
-        throw new Error("Friends Galaxy SQLite source identities are not strictly increasing.");
+        throw new Error(
+          "Friends Galaxy SQLite source identities are not strictly increasing.",
+        );
       }
       this.#lastIdentity = identity;
       this.#totalRows += 1;
       if (this.#totalRows > FRIENDS_GALAXY_SQLITE_SOURCE_ROW_CAP) {
-        throw new Error("Friends Galaxy SQLite source exceeded its semantic row cap.");
+        throw new Error(
+          "Friends Galaxy SQLite source exceeded its semantic row cap.",
+        );
       }
       if (page.queryId === LIBRARY_CORE_PERSON_GRAPH_PAGE_QUERY_ID) {
-        const person = row as LibraryCorePersonGraphPageResponseV1["rows"][number];
-        this.#persons.push(Object.freeze({
-          avatarUrl: person.avatarUrl ?? undefined,
-          careLevel: person.careLevel as Person["careLevel"],
-          id: person.id,
-          name: person.name,
-          relationshipStatus: person.relationshipStatus,
-          ...graphPosition(person),
-        }));
+        const person =
+          row as LibraryCorePersonGraphPageResponseV1["rows"][number];
+        this.#persons.push(
+          Object.freeze({
+            avatarUrl: person.avatarUrl ?? undefined,
+            careLevel: person.careLevel as Person["careLevel"],
+            id: person.id,
+            name: person.name,
+            relationshipStatus: person.relationshipStatus,
+            ...graphPosition(person),
+          }),
+        );
       } else if (page.queryId === LIBRARY_CORE_ACCOUNT_GRAPH_PAGE_QUERY_ID) {
-        const account = row as LibraryCoreAccountGraphPageResponseV1["rows"][number];
+        const account =
+          row as LibraryCoreAccountGraphPageResponseV1["rows"][number];
         if (account.kind !== "social") continue;
         this.#accounts[account.id] = Object.freeze({
           activityCount: account.activityCount,


### PR DESCRIPTION
(AI Generated).

## Summary
- Treat native normalized graph cursor invalidation as a recoverable SQLite source-fence change.
- Restart the bounded Friends graph source read through the existing retry path instead of leaving a blank graph.

## Testing
- npm run validate:feature