### PR TITLE
fix: preserve navigation after leaving map

### DIFF
--- a/packages/desktop/src-tauri/src/lib.rs
+++ b/packages/desktop/src-tauri/src/lib.rs
@@ -20,7 +20,7 @@ use std::mem::MaybeUninit;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::{
-    atomic::{AtomicBool, AtomicU64, Ordering},
+    atomic::{AtomicU64, Ordering},
     Arc, Mutex as StdMutex, RwLock as StdRwLock,
 };
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
@@ -799,12 +799,10 @@ enum WindowDestroyedReason {
     LoginFlow,
     JobComplete,
     StartupRecovery,
-    MapRendererRelease,
 }
 
 static WINDOW_CREATED_AT: std::sync::LazyLock<StdMutex<HashMap<String, Instant>>> =
     std::sync::LazyLock::new(|| StdMutex::new(HashMap::new()));
-static MAP_RENDERER_RELEASE_PENDING: AtomicBool = AtomicBool::new(false);
 
 /// Record when a tracked webview window was (re)created so kill records can
 /// report the victim's age. Insert-if-absent: ensure-window paths call this
@@ -12702,43 +12700,6 @@ fn recover_main_window(
     )
 }
 
-#[tauri::command]
-fn release_main_renderer_memory(app: tauri::AppHandle) -> Result<(), String> {
-    if MAP_RENDERER_RELEASE_PENDING.swap(true, Ordering::AcqRel) {
-        return Ok(());
-    }
-
-    append_runtime_health(
-        &app,
-        serde_json::json!({
-            "event": "map_renderer_memory_release_requested",
-        }),
-    );
-
-    tauri::async_runtime::spawn(async move {
-        tokio::time::sleep(Duration::from_millis(100)).await;
-        let outcome = recover_main_window(
-            &app,
-            WindowDestroyedReason::MapRendererRelease,
-            "geographic map renderer memory release",
-        );
-        MAP_RENDERER_RELEASE_PENDING.store(false, Ordering::Release);
-
-        if let Err(error) = outcome {
-            warn!("[map] failed to release native renderer memory: {}", error);
-            append_runtime_health(
-                &app,
-                serde_json::json!({
-                    "event": "map_renderer_memory_release_failed",
-                    "error": error,
-                }),
-            );
-        }
-    });
-
-    Ok(())
-}
-
 fn recover_main_window_hidden(
     app: &tauri::AppHandle,
     reason_enum: WindowDestroyedReason,
@@ -14198,7 +14159,6 @@ pub fn run() {
             download_local_ai_model_file,
             cancel_local_ai_model_download,
             get_runtime_memory_stats,
-            release_main_renderer_memory,
             trim_webkit_network_cache_now,
             get_recent_runtime_health,
             get_runtime_health_history,

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -1436,10 +1436,6 @@ function App() {
         import.meta.env.VITE_TEST_TAURI === "1" || isTauri()
           ? () => getCurrentWindow().startDragging()
           : undefined,
-      releaseMapRendererMemory:
-        import.meta.env.VITE_TEST_TAURI === "1" || isTauri()
-          ? () => invoke("release_main_renderer_memory")
-          : undefined,
       SourceIndicator: XSourceIndicator,
       HeaderSyncIndicator: null,
       SettingsExtraSections: MobileSyncTab,

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -3464,6 +3464,32 @@ test("Friend detail last seen card opens the full Map view", async ({ app }) => 
   ).toHaveLength(0);
 });
 
+test("leaving Map keeps the destination mounted without destroying the main renderer", async ({
+  app,
+  ipc,
+  page,
+}) => {
+  await app.goto();
+  await app.waitForReady();
+  await dismissCloudSyncNudgeIfPresent(page);
+
+  await page.getByRole("button", { name: /^Map/ }).click();
+  await expect(page.getByTestId("map-surface")).toBeVisible({ timeout: 10_000 });
+
+  await page.getByTestId("source-row-friends").click();
+  await expect(page.getByTestId("friends-sidebar")).toBeVisible({ timeout: 10_000 });
+  await page.waitForFunction(() => {
+    const store = (window as Record<string, unknown>).__FREED_STORE__ as
+      | { getState: () => { activeView: string } }
+      | undefined;
+    return store?.getState().activeView === "friends";
+  });
+
+  expect((await ipc.invocations()).map((invocation) => invocation.cmd)).not.toContain(
+    "release_main_renderer_memory",
+  );
+});
+
 test("map defaults to All content when only unlinked author locations exist", async ({ app, page }) => {
   await app.goto();
   await app.waitForReady();

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -16,7 +16,7 @@ import { toast } from "../Toast.js";
 import { AddFeedDialog } from "../AddFeedDialog.js";
 import { SavedContentDialog } from "../SavedContentDialog.js";
 import { LibraryDialog } from "../LibraryDialog.js";
-import { addDebugEvent, useDebugStore } from "../../lib/debug-store.js";
+import { useDebugStore } from "../../lib/debug-store.js";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
 import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import { ContactSyncModal } from "../friends/ContactSyncModal.js";
@@ -107,10 +107,8 @@ export function AppShell({ children }: AppShellProps) {
     queryLibraryCore,
     readLibraryAccountDetail,
     readLibraryPersonDetail,
-    releaseMapRendererMemory,
     replaceLibraryFriend,
   } = usePlatform();
-  const previousActiveViewRef = useRef(activeView);
   const isInitialized = useAppStore((s) => s.isInitialized);
   const animationIntensity = useAppStore((s) =>
     resolveAnimationIntensity(s.preferences.display.animationIntensity),
@@ -129,23 +127,6 @@ export function AppShell({ children }: AppShellProps) {
   const libraryDialogOpen = useCommandSurfaceStore((s) => s.libraryDialogOpen);
   const libraryDialogTab = useCommandSurfaceStore((s) => s.libraryDialogTab);
   const closeLibraryDialog = useCommandSurfaceStore((s) => s.closeLibraryDialog);
-
-  useEffect(() => {
-    const previousActiveView = previousActiveViewRef.current;
-    previousActiveViewRef.current = activeView;
-    if (previousActiveView !== "map" || activeView === "map" || !releaseMapRendererMemory) {
-      return;
-    }
-
-    void releaseMapRendererMemory().catch((error) => {
-      addDebugEvent(
-        "error",
-        `[map] native renderer memory release failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
-    });
-  }, [activeView, releaseMapRendererMemory]);
 
   // Mount the contact sync hook here (not in FriendsView) so the 15-minute
   // interval and focus listener run regardless of which view is active.

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -515,7 +515,6 @@ export interface PlatformConfig {
    * Rebuild the native main WebView after leaving the geographic map so WebKit
    * releases MapLibre's high-water GPU and tile allocations. Desktop only.
    */
-  releaseMapRendererMemory?: () => Promise<void>;
 
   // -- Layout slot components (null = not rendered) --
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Remove the native whole-window renderer recycle that could destroy Friends immediately after leaving Map.
- Keep Map memory cleanup inside the existing MapLibre stop, remove, WebGL context loss, and canvas shrink path.
- Add a Desktop regression that proves Map to Friends remains mounted and never invokes the retired native command.

## Testing
- npm run validate:feature
- Focused Map to Friends Desktop e2e passed in 1.9 seconds.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `d41fbd3154f5b292d7ada020877e0b31f43f632c`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `map-renderer-release-crash-20260830`
- Provider review decision: `diff_authorized`
- Provider review artifact: `0f2ede5c3303d5c955c9a007779cf4d95ef76cb359b31890b7fc4a4b95c83e35`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider-observable behavior is unchanged. The classified diff removes the Desktop callback and native command that destroyed and rebuilt Freed's main renderer after leaving Map. It does not change any provider request, endpoint, scope, navigation, timing, retry, cookie, header, scrolling, click, extraction, login, media, or background activity.
- Fingerprinting risk: No provider fingerprinting risk is added because the diff creates no provider contact and changes no provider-observable behavior.
- Lowest profile alternative: The lowest-profile provider alternative is identical to this change: keep every provider path untouched at runtime and reclaim MapLibre resources locally through the existing stop, remove, WebGL context loss, and canvas shrink cleanup.

Files bound into this provider review:
- `packages/desktop/src-tauri/src/lib.rs`
- `packages/desktop/src/App.tsx`
- `packages/ui/src/context/PlatformContext.tsx`