### PR TITLE
fix: keep Library queries off the desktop command thread

### DIFF
--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -190,7 +190,9 @@
         generated query reads at most eleven result rows, returns ten rows
         under 512 KiB, and filters exact evidence-bound dismissals before the
         renderer receives them. Friends retains only that visible window.
-        The Friends review surface retains only this result window.
+        The Friends review surface retains only this result window. Desktop
+        runs normalized SQLite reads on its blocking worker pool so this
+        ranking query cannot stall Galaxy page reads or renderer heartbeats.
   - [x] `rss_feed_detail_v1` now performs one primary-key SQLite lookup through
         the shared native and PWA dispatch and returns every synchronized RSS
         Feed field under a 64 KiB ceiling. Freed Desktop uses it when a partial

--- a/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
@@ -721,13 +721,26 @@ pub(super) fn ensure_fresh_normalized_desktop_library(
 }
 
 #[tauri::command]
-pub(super) fn query_normalized_library(
+pub(super) async fn query_normalized_library(
     app: tauri::AppHandle,
     request: Value,
 ) -> Result<Value, String> {
-    let mut connection = open_normalized_database(&app)?;
-    freed_library_core::query_normalized_json_v1(&mut connection, request)
-        .map_err(|error| error.to_string())
+    run_normalized_query_off_main(move || {
+        let mut connection = open_normalized_database(&app)?;
+        freed_library_core::query_normalized_json_v1(&mut connection, request)
+            .map_err(|error| error.to_string())
+    })
+    .await
+}
+
+async fn run_normalized_query_off_main<T, F>(query: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(query)
+        .await
+        .map_err(|error| format!("normalized Library query worker failed: {error}"))?
 }
 
 #[tauri::command]
@@ -1836,6 +1849,18 @@ pub(super) fn reset_normalized_library(app: tauri::AppHandle) -> Result<(), Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn normalized_library_queries_leave_the_command_thread() {
+        let command_thread = std::thread::current().id();
+        let query_thread =
+            tauri::async_runtime::block_on(run_normalized_query_off_main(move || {
+                Ok(std::thread::current().id())
+            }))
+            .expect("run normalized query worker");
+
+        assert_ne!(query_thread, command_thread);
+    }
 
     #[test]
     fn cloud_writer_admission_is_device_local_normalized_sqlite_state() {


### PR DESCRIPTION
(AI Generated).

## Summary
- Run normalized SQLite reads on Tauri's blocking worker pool so expensive Friends ranking cannot starve Galaxy paging or renderer heartbeats.
- Add a native regression test proving query work leaves the command thread, and record the Desktop Library contract in Phase 5.

## Testing
- npm run validate:feature
- Copied 3.2 GB hydrated Library fixture: friend_candidate_review_v1 completed in about 0.55 seconds over 3,686 accounts, 20,484 items, and 51,887 signals.