### PR TITLE
fix: compress GitHub release history reads

### DIFF
--- a/scripts/lib/github-release-publications.mjs
+++ b/scripts/lib/github-release-publications.mjs
@@ -174,6 +174,7 @@ export function readGithubReleasePublications({
           "--fail",
           "--silent",
           "--show-error",
+          "--compressed",
           "--proto",
           "=https",
           "--tlsv1.2",

--- a/scripts/lib/github-release-publications.test.mjs
+++ b/scripts/lib/github-release-publications.test.mjs
@@ -42,6 +42,7 @@ test("GitHub release pagination accepts a page larger than one MiB within its bo
   assert.equal(releases[0].body.length, body.length);
   assert.equal(request.command, "/usr/bin/curl");
   assert.equal(request.args[0], "--disable");
+  assert.equal(request.args.includes("--compressed"), true);
   assert.equal(request.options.maxBuffer, GITHUB_RELEASE_PAGE_MAX_BYTES);
   assert.equal(
     request.options.input,


### PR DESCRIPTION
(AI Generated).

## Summary
- Request compressed GitHub API responses so the canonical release-history reader completes within its existing bounded timeout.

## Testing
- npm run validate:feature