### PR TITLE
chore: prepare v26.8.3006-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.3005",
+  "version": "26.8.3006",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.3005"
+version = "26.8.3006"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.3005"
+version = "26.8.3006"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.3005",
+  "version": "26.8.3006",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.3005",
+  "version": "26.8.3006",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.30.json
+++ b/release-notes/daily/dev/26.8.30.json
@@ -12,5 +12,5 @@
     "Open the full Map from a Friend's last-seen card after the location resolves"
   ],
   "editorialNotes": [],
-  "updatedAt": "2026-08-30T21:47:38.743Z"
+  "updatedAt": "2026-08-31T04:48:41.146Z"
 }

--- a/release-notes/daily/dev/26.8.30.json
+++ b/release-notes/daily/dev/26.8.30.json
@@ -2,7 +2,7 @@
   "channel": "dev",
   "dayKey": "26.8.30",
   "date": "2026-08-30",
-  "preferredDeck": null,
+  "preferredDeck": "Faster Google Drive checkpoints and stable Library views for large SQLite libraries",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
@@ -11,6 +11,8 @@
   "pinnedHighlights": [
     "Open the full Map from a Friend's last-seen card after the location resolves"
   ],
-  "editorialNotes": [],
+  "editorialNotes": [
+    "Lead with the installed large-Library Google Drive publication and reload-loop fixes in v26.8.3006-dev."
+  ],
   "updatedAt": "2026-08-31T04:48:41.146Z"
 }

--- a/release-notes/releases/v26.8.3006-dev.json
+++ b/release-notes/releases/v26.8.3006-dev.json
@@ -105,16 +105,35 @@
   },
   "release": {
     "deck": "Faster Google Drive checkpoints and stable Library views for large SQLite libraries",
-    "features": [],
+    "features": [
+      "Orchestrate bounded Primary inbound passes",
+      "Bind normalized Primary native transport",
+      "Normalized Primary inbound orchestration"
+    ],
     "fixes": [
       "Finish large Library Google Drive checkpoint publication with bounded 4,096-record pages",
       "Stop recurring view reloads by bounding concurrent SQLite reads and coalescing priority-index refreshes",
-      "Fail closed when a stored Drive publication receipt does not match the current control state"
+      "Fail closed when a stored Drive publication receipt does not match the current control state",
+      "Compress GitHub release history reads",
+      "Admit long checkpoint record identities",
+      "Keep Library queries off the desktop command thread",
+      "Preserve navigation after leaving map",
+      "Recover Friends graph from stale cursors",
+      "Prove installed primary native identity",
+      "Stop Friend location render loops",
+      "Keep checkpoint exports on one SQLite snapshot",
+      "Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history",
+      "Create local Library snapshots from one consistent SQLite revision",
+      "Open the full Map from a Friend's last-seen card after the location resolves"
     ],
     "followUps": [
       "Verify first Google Drive publication and exact retry against the real local Library",
-      "Complete installed Freed Desktop and physical iPhone PWA acceptance"
+      "Complete installed Freed Desktop and physical iPhone PWA acceptance",
+      "Prepare v26.8.3005-dev",
+      "Expose headless follower enrollment authority",
+      "Bind headless Primary to Google Drive",
+      "Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3006-dev\n\nFaster Google Drive checkpoints and stable Library views for large SQLite libraries\n\n### Fixes\n\n- Finish large Library Google Drive checkpoint publication with bounded 4,096-record pages\n- Stop recurring view reloads by bounding concurrent SQLite reads and coalescing priority-index refreshes\n- Fail closed when a stored Drive publication receipt does not match the current control state\n\n### Follow-ups\n\n- Verify first Google Drive publication and exact retry against the real local Library\n- Complete installed Freed Desktop and physical iPhone PWA acceptance\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3006-dev\n\nFaster Google Drive checkpoints and stable Library views for large SQLite libraries\n\n### Features\n\n- Orchestrate bounded Primary inbound passes\n- Bind normalized Primary native transport\n- Normalized Primary inbound orchestration\n\n### Fixes\n\n- Finish large Library Google Drive checkpoint publication with bounded 4,096-record pages\n- Stop recurring view reloads by bounding concurrent SQLite reads and coalescing priority-index refreshes\n- Fail closed when a stored Drive publication receipt does not match the current control state\n- Compress GitHub release history reads\n- Admit long checkpoint record identities\n- Keep Library queries off the desktop command thread\n- Preserve navigation after leaving map\n- Recover Friends graph from stale cursors\n- Prove installed primary native identity\n- Stop Friend location render loops\n- Keep checkpoint exports on one SQLite snapshot\n- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history\n- Create local Library snapshots from one consistent SQLite revision\n- Open the full Map from a Friend's last-seen card after the location resolves\n\n### Follow-ups\n\n- Verify first Google Drive publication and exact retry against the real local Library\n- Complete installed Freed Desktop and physical iPhone PWA acceptance\n- Prepare v26.8.3005-dev\n- Expose headless follower enrollment authority\n- Bind headless Primary to Google Drive\n- Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.3006-dev.json
+++ b/release-notes/releases/v26.8.3006-dev.json
@@ -1,0 +1,134 @@
+{
+  "tag": "v26.8.3006-dev",
+  "version": "26.8.3006-dev",
+  "channel": "dev",
+  "dayKey": "26.8.30",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-31T04:48:41.145Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.3005-dev",
+    "previousPublishedDayTag": "v26.8.2906-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "6706387f38c14fb22dfe73469af58e8bf18bb7d1",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.3005-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "ab57f79ca965996a3ff55173e96192d46620010b",
+        "toInclusiveProductCommitSha": "6706387f38c14fb22dfe73469af58e8bf18bb7d1"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:7a17307cac0c7ca1625ab9687af0d4b6847a0f59b47e170b14afb9173b0857b8",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.3000-dev",
+      "v26.8.3001-dev",
+      "v26.8.3002-dev",
+      "v26.8.3003-dev",
+      "v26.8.3004-dev",
+      "v26.8.3005-dev",
+      "v26.8.3006-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.3000-dev",
+      "v26.8.3001-dev",
+      "v26.8.3002-dev",
+      "v26.8.3003-dev",
+      "v26.8.3004-dev",
+      "v26.8.3005-dev",
+      "v26.8.3006-dev"
+    ],
+    "prNumbers": [
+      1652,
+      1653,
+      1655,
+      1657,
+      1658,
+      1659,
+      1660,
+      1661,
+      1662,
+      1663,
+      1664,
+      1665,
+      1666,
+      1667,
+      1668,
+      1669,
+      1670,
+      1671
+    ],
+    "commitSubjects": [
+      "perf: unblock large Library checkpoint publication (#1671)",
+      "docs: clarify authorization levels (#1672)",
+      "chore: prepare v26.8.3005-dev (#1670)",
+      "fix: compress GitHub release history reads (#1669)",
+      "fix: admit long checkpoint record identities (#1668)",
+      "chore: prepare v26.8.3004-dev (#1667)",
+      "fix: keep Library queries off the desktop command thread (#1666)",
+      "chore: prepare v26.8.3003-dev (#1665)",
+      "fix: preserve navigation after leaving map (#1664)",
+      "chore: prepare v26.8.3002-dev (#1663)",
+      "fix: recover Friends graph from stale cursors (#1662)",
+      "fix: prove installed primary native identity (#1661)",
+      "feat: orchestrate bounded Primary inbound passes (#1660)",
+      "feat: bind normalized Primary native transport (#1659)",
+      "feat: add normalized Primary inbound orchestration (#1658)",
+      "feat: expose headless follower enrollment authority (#1657)",
+      "chore: prepare v26.8.3001-dev",
+      "feat: bind headless Primary to Google Drive (#1655)",
+      "release: v26.8.3000-dev (#1654)",
+      "fix: stop Friend location render loops (#1653)",
+      "fix: keep checkpoint exports on one SQLite snapshot (#1652)"
+    ]
+  },
+  "release": {
+    "deck": "Orchestrate bounded Primary inbound passes, bind normalized Primary native transport, and normalized Primary inbound orchestration",
+    "features": [
+      "Orchestrate bounded Primary inbound passes",
+      "Bind normalized Primary native transport",
+      "Normalized Primary inbound orchestration"
+    ],
+    "fixes": [
+      "Compress GitHub release history reads",
+      "Admit long checkpoint record identities",
+      "Keep Library queries off the desktop command thread",
+      "Preserve navigation after leaving map",
+      "Recover Friends graph from stale cursors",
+      "Prove installed primary native identity",
+      "Stop Friend location render loops",
+      "Keep checkpoint exports on one SQLite snapshot",
+      "Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history",
+      "Create local Library snapshots from one consistent SQLite revision",
+      "Open the full Map from a Friend's last-seen card after the location resolves"
+    ],
+    "followUps": [
+      "Unblock large Library checkpoint publication",
+      "Prepare v26.8.3005-dev",
+      "Expose headless follower enrollment authority",
+      "Bind headless Primary to Google Drive",
+      "Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory",
+      "Google Drive checkpoint sync, stable Library views, and bounded SQLite reads"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3006-dev\n\nOrchestrate bounded Primary inbound passes, bind normalized Primary native transport, and normalized Primary inbound orchestration\n\n### Features\n\n- Orchestrate bounded Primary inbound passes\n- Bind normalized Primary native transport\n- Normalized Primary inbound orchestration\n\n### Fixes\n\n- Compress GitHub release history reads\n- Admit long checkpoint record identities\n- Keep Library queries off the desktop command thread\n- Preserve navigation after leaving map\n- Recover Friends graph from stale cursors\n- Prove installed primary native identity\n- Stop Friend location render loops\n- Keep checkpoint exports on one SQLite snapshot\n- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history\n- Create local Library snapshots from one consistent SQLite revision\n- Open the full Map from a Friend's last-seen card after the location resolves\n\n### Follow-ups\n\n- Unblock large Library checkpoint publication\n- Prepare v26.8.3005-dev\n- Expose headless follower enrollment authority\n- Bind headless Primary to Google Drive\n- Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory\n- Google Drive checkpoint sync, stable Library views, and bounded SQLite reads\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.3006-dev.json
+++ b/release-notes/releases/v26.8.3006-dev.json
@@ -3,8 +3,10 @@
   "version": "26.8.3006-dev",
   "channel": "dev",
   "dayKey": "26.8.30",
-  "approved": false,
-  "editorialNotes": [],
+  "approved": true,
+  "editorialNotes": [
+    "Lead with the installed large-Library Google Drive publication and reload-loop fixes in this successor dev build."
+  ],
   "generatedAt": "2026-08-31T04:48:41.145Z",
   "model": "heuristic",
   "source": {
@@ -102,33 +104,17 @@
     ]
   },
   "release": {
-    "deck": "Orchestrate bounded Primary inbound passes, bind normalized Primary native transport, and normalized Primary inbound orchestration",
-    "features": [
-      "Orchestrate bounded Primary inbound passes",
-      "Bind normalized Primary native transport",
-      "Normalized Primary inbound orchestration"
-    ],
+    "deck": "Faster Google Drive checkpoints and stable Library views for large SQLite libraries",
+    "features": [],
     "fixes": [
-      "Compress GitHub release history reads",
-      "Admit long checkpoint record identities",
-      "Keep Library queries off the desktop command thread",
-      "Preserve navigation after leaving map",
-      "Recover Friends graph from stale cursors",
-      "Prove installed primary native identity",
-      "Stop Friend location render loops",
-      "Keep checkpoint exports on one SQLite snapshot",
-      "Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history",
-      "Create local Library snapshots from one consistent SQLite revision",
-      "Open the full Map from a Friend's last-seen card after the location resolves"
+      "Finish large Library Google Drive checkpoint publication with bounded 4,096-record pages",
+      "Stop recurring view reloads by bounding concurrent SQLite reads and coalescing priority-index refreshes",
+      "Fail closed when a stored Drive publication receipt does not match the current control state"
     ],
     "followUps": [
-      "Unblock large Library checkpoint publication",
-      "Prepare v26.8.3005-dev",
-      "Expose headless follower enrollment authority",
-      "Bind headless Primary to Google Drive",
-      "Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory",
-      "Google Drive checkpoint sync, stable Library views, and bounded SQLite reads"
+      "Verify first Google Drive publication and exact retry against the real local Library",
+      "Complete installed Freed Desktop and physical iPhone PWA acceptance"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3006-dev\n\nOrchestrate bounded Primary inbound passes, bind normalized Primary native transport, and normalized Primary inbound orchestration\n\n### Features\n\n- Orchestrate bounded Primary inbound passes\n- Bind normalized Primary native transport\n- Normalized Primary inbound orchestration\n\n### Fixes\n\n- Compress GitHub release history reads\n- Admit long checkpoint record identities\n- Keep Library queries off the desktop command thread\n- Preserve navigation after leaving map\n- Recover Friends graph from stale cursors\n- Prove installed primary native identity\n- Stop Friend location render loops\n- Keep checkpoint exports on one SQLite snapshot\n- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history\n- Create local Library snapshots from one consistent SQLite revision\n- Open the full Map from a Friend's last-seen card after the location resolves\n\n### Follow-ups\n\n- Unblock large Library checkpoint publication\n- Prepare v26.8.3005-dev\n- Expose headless follower enrollment authority\n- Bind headless Primary to Google Drive\n- Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory\n- Google Drive checkpoint sync, stable Library views, and bounded SQLite reads\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3006-dev\n\nFaster Google Drive checkpoints and stable Library views for large SQLite libraries\n\n### Fixes\n\n- Finish large Library Google Drive checkpoint publication with bounded 4,096-record pages\n- Stop recurring view reloads by bounding concurrent SQLite reads and coalescing priority-index refreshes\n- Fail closed when a stored Drive publication receipt does not match the current control state\n\n### Follow-ups\n\n- Verify first Google Drive publication and exact retry against the real local Library\n- Complete installed Freed Desktop and physical iPhone PWA acceptance\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.3006-dev.md
+++ b/release-notes/releases/v26.8.3006-dev.md
@@ -2,36 +2,18 @@
 
 ## Freed v26.8.3006-dev
 
-Orchestrate bounded Primary inbound passes, bind normalized Primary native transport, and normalized Primary inbound orchestration
-
-### Features
-
-- Orchestrate bounded Primary inbound passes
-- Bind normalized Primary native transport
-- Normalized Primary inbound orchestration
+Faster Google Drive checkpoints and stable Library views for large SQLite libraries
 
 ### Fixes
 
-- Compress GitHub release history reads
-- Admit long checkpoint record identities
-- Keep Library queries off the desktop command thread
-- Preserve navigation after leaving map
-- Recover Friends graph from stale cursors
-- Prove installed primary native identity
-- Stop Friend location render loops
-- Keep checkpoint exports on one SQLite snapshot
-- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history
-- Create local Library snapshots from one consistent SQLite revision
-- Open the full Map from a Friend's last-seen card after the location resolves
+- Finish large Library Google Drive checkpoint publication with bounded 4,096-record pages
+- Stop recurring view reloads by bounding concurrent SQLite reads and coalescing priority-index refreshes
+- Fail closed when a stored Drive publication receipt does not match the current control state
 
 ### Follow-ups
 
-- Unblock large Library checkpoint publication
-- Prepare v26.8.3005-dev
-- Expose headless follower enrollment authority
-- Bind headless Primary to Google Drive
-- Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory
-- Google Drive checkpoint sync, stable Library views, and bounded SQLite reads
+- Verify first Google Drive publication and exact retry against the real local Library
+- Complete installed Freed Desktop and physical iPhone PWA acceptance
 
 ### Downloads
 

--- a/release-notes/releases/v26.8.3006-dev.md
+++ b/release-notes/releases/v26.8.3006-dev.md
@@ -4,16 +4,37 @@
 
 Faster Google Drive checkpoints and stable Library views for large SQLite libraries
 
+### Features
+
+- Orchestrate bounded Primary inbound passes
+- Bind normalized Primary native transport
+- Normalized Primary inbound orchestration
+
 ### Fixes
 
 - Finish large Library Google Drive checkpoint publication with bounded 4,096-record pages
 - Stop recurring view reloads by bounding concurrent SQLite reads and coalescing priority-index refreshes
 - Fail closed when a stored Drive publication receipt does not match the current control state
+- Compress GitHub release history reads
+- Admit long checkpoint record identities
+- Keep Library queries off the desktop command thread
+- Preserve navigation after leaving map
+- Recover Friends graph from stale cursors
+- Prove installed primary native identity
+- Stop Friend location render loops
+- Keep checkpoint exports on one SQLite snapshot
+- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history
+- Create local Library snapshots from one consistent SQLite revision
+- Open the full Map from a Friend's last-seen card after the location resolves
 
 ### Follow-ups
 
 - Verify first Google Drive publication and exact retry against the real local Library
 - Complete installed Freed Desktop and physical iPhone PWA acceptance
+- Prepare v26.8.3005-dev
+- Expose headless follower enrollment authority
+- Bind headless Primary to Google Drive
+- Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory
 
 ### Downloads
 

--- a/release-notes/releases/v26.8.3006-dev.md
+++ b/release-notes/releases/v26.8.3006-dev.md
@@ -1,0 +1,42 @@
+(AI Generated).
+
+## Freed v26.8.3006-dev
+
+Orchestrate bounded Primary inbound passes, bind normalized Primary native transport, and normalized Primary inbound orchestration
+
+### Features
+
+- Orchestrate bounded Primary inbound passes
+- Bind normalized Primary native transport
+- Normalized Primary inbound orchestration
+
+### Fixes
+
+- Compress GitHub release history reads
+- Admit long checkpoint record identities
+- Keep Library queries off the desktop command thread
+- Preserve navigation after leaving map
+- Recover Friends graph from stale cursors
+- Prove installed primary native identity
+- Stop Friend location render loops
+- Keep checkpoint exports on one SQLite snapshot
+- Release abandoned checkpoint readers after five minutes so canceled uploads cannot pin SQLite history
+- Create local Library snapshots from one consistent SQLite revision
+- Open the full Map from a Friend's last-seen card after the location resolves
+
+### Follow-ups
+
+- Unblock large Library checkpoint publication
+- Prepare v26.8.3005-dev
+- Expose headless follower enrollment authority
+- Bind headless Primary to Google Drive
+- Publish immutable Google Drive checkpoints from bounded SQLite pages without loading the full Library into memory
+- Google Drive checkpoint sync, stable Library views, and bounded SQLite reads
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the successor dev build from merged product commit 6706387f38c14fb22dfe73469af58e8bf18bb7d1.
- Lead the cumulative daily release ledger with large-Library Google Drive publication, reload stability, and exact receipt verification.
- Record no Library Core activation-manifest transition for this release.

## Testing
- npm run validate:feature
- PWA: 308 unit tests and WebKit OPFS durability passed.
- Desktop: 789 unit tests and 9 smoke flows passed.
- Native: clippy and 173 Rust tests passed.
- Release notes and release identity validation passed for v26.8.3006-dev at d5153ad8afd9e3e46418d54f606e8c4197d10840.