### PR TITLE
fix: repair PWA browser fixture preferences

### DIFF
--- a/packages/pwa/tests/app.spec.ts
+++ b/packages/pwa/tests/app.spec.ts
@@ -457,7 +457,6 @@ async function seedFriendsWorkspace(
     const store = w.__FREED_STORE__ as {
       getState: () => {
         setActiveView: (view: string) => void;
-        updatePreferences: (update: unknown) => Promise<void>;
       };
     };
 
@@ -575,12 +574,6 @@ async function seedFriendsWorkspace(
         topics: [],
       },
     ]);
-
-    await store.getState().updatePreferences({
-      display: {
-        friendsSidebarWidth: 340,
-      },
-    });
 
     store.getState().setActiveView("friends");
   });


### PR DESCRIPTION
(AI Generated).

## Summary

- stop the Friends browser fixture from writing a device-local sidebar width through synchronized preferences
- preserve the production preference boundary while letting the fixture use the supported default display state
- close the remaining Library Core browser fixture failures tracked by #1608

## Testing

- `npm test -- tests/app.spec.ts tests/safari-viewport.spec.ts` from `packages/pwa`: 40 passed in 23.8 seconds
- `npm run validate:feature`: root typecheck, PWA production build, PWA typecheck, and 311 PWA unit tests passed

Closes #1608