### PR TITLE
fix: package PWA deployment guards

### DIFF
--- a/scripts/validate-retired-automerge-runtime.test.mjs
+++ b/scripts/validate-retired-automerge-runtime.test.mjs
@@ -175,7 +175,7 @@ test("current native core excludes the retired whole-record projector", () => {
   );
 });
 
-test("Vercel staging carries the current artifact guard without the retired patch", () => {
+test("Vercel staging carries current PWA artifact guards without the retired patch", () => {
   const repoRoot = fileURLToPath(new URL("..", import.meta.url));
   for (const fileName of [
     "vercel-deploy-preview.sh",
@@ -187,6 +187,10 @@ test("Vercel staging carries the current artifact guard without the retired patc
     );
     assert.match(source, /retired-automerge-runtime\.mjs/);
     assert.match(source, /validate-retired-automerge-runtime\.mjs/);
+    assert.match(source, /pwa-optional-assets\.mjs/);
+    assert.match(source, /pwa-optional-assets\.d\.mts/);
+    assert.match(source, /validate-pwa-optional-assets\.mjs/);
+    assert.match(source, /packages\/library-core-native/);
     assert.doesNotMatch(source, /patch-automerge\.mjs/);
   }
 });

--- a/scripts/vercel-deploy-preview.sh
+++ b/scripts/vercel-deploy-preview.sh
@@ -44,6 +44,7 @@ case "$TARGET" in
     BUILD_ENV_KEY="VITE_FREED_PREVIEW_LABEL"
     DEPENDENCY_DIRS=(
       "packages/capture-save"
+      "packages/library-core-native"
       "packages/shared"
       "packages/sync"
       "packages/ui"
@@ -61,7 +62,10 @@ cp "$ROOT_DIR/scripts/lib/build-metadata.mjs" "$TEMP_DIR/scripts/lib/build-metad
 cp "$ROOT_DIR/scripts/lib/build-metadata.d.mts" "$TEMP_DIR/scripts/lib/build-metadata.d.mts"
 cp "$ROOT_DIR/scripts/lib/retired-automerge-runtime.mjs" "$TEMP_DIR/scripts/lib/retired-automerge-runtime.mjs"
 cp "$ROOT_DIR/scripts/lib/retired-automerge-runtime.d.mts" "$TEMP_DIR/scripts/lib/retired-automerge-runtime.d.mts"
+cp "$ROOT_DIR/scripts/lib/pwa-optional-assets.mjs" "$TEMP_DIR/scripts/lib/pwa-optional-assets.mjs"
+cp "$ROOT_DIR/scripts/lib/pwa-optional-assets.d.mts" "$TEMP_DIR/scripts/lib/pwa-optional-assets.d.mts"
 cp "$ROOT_DIR/scripts/validate-retired-automerge-runtime.mjs" "$TEMP_DIR/scripts/validate-retired-automerge-runtime.mjs"
+cp "$ROOT_DIR/scripts/validate-pwa-optional-assets.mjs" "$TEMP_DIR/scripts/validate-pwa-optional-assets.mjs"
 
 if [[ "$STAGE_AT_ROOT" == "true" ]]; then
   cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"

--- a/scripts/vercel-deploy-production.sh
+++ b/scripts/vercel-deploy-production.sh
@@ -38,6 +38,7 @@ case "$TARGET" in
     STAGE_AT_ROOT="false"
     DEPENDENCY_DIRS=(
       "packages/capture-save"
+      "packages/library-core-native"
       "packages/shared"
       "packages/sync"
       "packages/ui"
@@ -55,7 +56,10 @@ cp "$ROOT_DIR/scripts/lib/build-metadata.mjs" "$TEMP_DIR/scripts/lib/build-metad
 cp "$ROOT_DIR/scripts/lib/build-metadata.d.mts" "$TEMP_DIR/scripts/lib/build-metadata.d.mts"
 cp "$ROOT_DIR/scripts/lib/retired-automerge-runtime.mjs" "$TEMP_DIR/scripts/lib/retired-automerge-runtime.mjs"
 cp "$ROOT_DIR/scripts/lib/retired-automerge-runtime.d.mts" "$TEMP_DIR/scripts/lib/retired-automerge-runtime.d.mts"
+cp "$ROOT_DIR/scripts/lib/pwa-optional-assets.mjs" "$TEMP_DIR/scripts/lib/pwa-optional-assets.mjs"
+cp "$ROOT_DIR/scripts/lib/pwa-optional-assets.d.mts" "$TEMP_DIR/scripts/lib/pwa-optional-assets.d.mts"
 cp "$ROOT_DIR/scripts/validate-retired-automerge-runtime.mjs" "$TEMP_DIR/scripts/validate-retired-automerge-runtime.mjs"
+cp "$ROOT_DIR/scripts/validate-pwa-optional-assets.mjs" "$TEMP_DIR/scripts/validate-pwa-optional-assets.mjs"
 
 if [[ "$STAGE_AT_ROOT" == "true" ]]; then
   cp "$ROOT_DIR/package.json" "$TEMP_DIR/package.json"


### PR DESCRIPTION
(AI Generated).

## Summary
- Stage the PWA optional-asset validator and its shared module in isolated Vercel builds.
- Stage the native Library Core source required by the retired-runtime guard.

## Testing
- npm run validate:feature
- Scoped PWA preview deployment reached READY: dpl_24srtdF29ae47xDu8yWCxhkrtDyR