### PR TITLE
fix: bootstrap clean Vercel deployments

### DIFF
--- a/scripts/lib/vercel-project-link.mjs
+++ b/scripts/lib/vercel-project-link.mjs
@@ -1,0 +1,57 @@
+import { copyFileSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const VERCEL_PROJECTS = Object.freeze({
+  website: "freed-www",
+  pwa: "freed-pwa",
+});
+
+export function resolveVercelProjectName(target) {
+  const projectName = VERCEL_PROJECTS[target];
+  if (!projectName) {
+    throw new Error(`Unknown Vercel deployment target: ${target}`);
+  }
+  return projectName;
+}
+
+export function stageExistingVercelProjectLink({ sourcePath, targetPath }) {
+  if (!existsSync(sourcePath)) return false;
+  mkdirSync(path.dirname(targetPath), { recursive: true });
+  copyFileSync(sourcePath, targetPath);
+  return true;
+}
+
+function usage() {
+  return "Usage: node scripts/lib/vercel-project-link.mjs project <website|pwa> | stage <source> <target>";
+}
+
+function main(argv) {
+  const [command, ...args] = argv;
+  if (command === "project" && args.length === 1) {
+    process.stdout.write(`${resolveVercelProjectName(args[0])}\n`);
+    return;
+  }
+  if (command === "stage" && args.length === 2) {
+    process.exitCode = stageExistingVercelProjectLink({
+      sourcePath: args[0],
+      targetPath: args[1],
+    })
+      ? 0
+      : 2;
+    return;
+  }
+  throw new Error(usage());
+}
+
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  try {
+    main(process.argv.slice(2));
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/lib/vercel-project-link.test.mjs
+++ b/scripts/lib/vercel-project-link.test.mjs
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  resolveVercelProjectName,
+  stageExistingVercelProjectLink,
+} from "./vercel-project-link.mjs";
+
+function withTempDirectory(run) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "freed-vercel-link-"));
+  try {
+    return run(directory);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+}
+
+test("deployment targets resolve to the approved Vercel projects", () => {
+  assert.equal(resolveVercelProjectName("website"), "freed-www");
+  assert.equal(resolveVercelProjectName("pwa"), "freed-pwa");
+  assert.throws(
+    () => resolveVercelProjectName("unknown"),
+    /Unknown Vercel deployment target/,
+  );
+});
+
+test("clean worktrees leave staging ready for explicit project bootstrap", () => {
+  withTempDirectory((directory) => {
+    const targetPath = path.join(directory, "staged", ".vercel", "project.json");
+    assert.equal(
+      stageExistingVercelProjectLink({
+        sourcePath: path.join(directory, "missing", "project.json"),
+        targetPath,
+      }),
+      false,
+    );
+    assert.throws(() => readFileSync(targetPath, "utf8"), /ENOENT/);
+  });
+});
+
+test("linked worktrees preserve their exact project identity", () => {
+  withTempDirectory((directory) => {
+    const sourcePath = path.join(directory, "source", "project.json");
+    const targetPath = path.join(directory, "staged", ".vercel", "project.json");
+    const identity = JSON.stringify({
+      projectId: "prj_test",
+      orgId: "team_test",
+      projectName: "freed-pwa",
+    });
+    mkdirSync(path.dirname(sourcePath), { recursive: true });
+    writeFileSync(sourcePath, identity);
+    assert.equal(
+      stageExistingVercelProjectLink({ sourcePath, targetPath }),
+      true,
+    );
+    assert.equal(readFileSync(targetPath, "utf8"), identity);
+  });
+});

--- a/scripts/vercel-deploy-preview.sh
+++ b/scripts/vercel-deploy-preview.sh
@@ -7,6 +7,7 @@ source "${SCRIPT_DIR}/lib/node-tooling.sh"
 # shellcheck source=./lib/worktree-runtime.sh
 source "${SCRIPT_DIR}/lib/worktree-runtime.sh"
 use_resolved_node_path
+NODE_BIN="$(resolve_node_bin)"
 NPM_BIN="$(resolve_npm_bin)"
 NPX_BIN="$(resolve_npx_bin)"
 
@@ -70,15 +71,12 @@ cp "$ROOT_DIR/scripts/validate-pwa-optional-assets.mjs" "$TEMP_DIR/scripts/valid
 if [[ "$STAGE_AT_ROOT" == "true" ]]; then
   cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
   cp -R "$ROOT_DIR/$APP_DIR"/. "$TEMP_DIR/"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
 else
   cp "$ROOT_DIR/package.json" "$TEMP_DIR/package.json"
   cp "$ROOT_DIR/package-lock.json" "$TEMP_DIR/package-lock.json"
   cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
   mkdir -p "$TEMP_DIR/$(dirname "$APP_DIR")"
   cp -R "$ROOT_DIR/$APP_DIR" "$TEMP_DIR/$APP_DIR"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
-
   cat >"$TEMP_DIR/vercel.json" <<'EOF'
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
@@ -88,6 +86,17 @@ else
   "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
 }
 EOF
+fi
+
+VERCEL_PROJECT="$(
+  "$NODE_BIN" "$ROOT_DIR/scripts/lib/vercel-project-link.mjs" project "$TARGET"
+)"
+PROJECT_LINK_STATE="bootstrap"
+if "$NODE_BIN" "$ROOT_DIR/scripts/lib/vercel-project-link.mjs" stage \
+  "$ROOT_DIR/$APP_DIR/.vercel/project.json" \
+  "$TEMP_DIR/.vercel/project.json"
+then
+  PROJECT_LINK_STATE="linked"
 fi
 
 for dir in "${DEPENDENCY_DIRS[@]}"; do
@@ -120,7 +129,15 @@ if [[ -n "$VERCEL_TOKEN" ]]; then
 fi
 
 echo "Pulling Vercel settings for $TARGET"
-"$NPX_BIN" vercel pull --yes --environment preview --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
+VERCEL_PULL_FLAGS=(--yes --environment preview --cwd "$TEMP_DIR")
+if [[ "$PROJECT_LINK_STATE" == "bootstrap" ]]; then
+  echo "No local Vercel link found; selecting $VERCEL_PROJECT explicitly"
+  VERCEL_PULL_FLAGS+=(--project "$VERCEL_PROJECT")
+fi
+if ! "$NPX_BIN" vercel pull "${VERCEL_PULL_FLAGS[@]}" "${VERCEL_FLAGS[@]}"; then
+  echo "Unable to access Vercel project $VERCEL_PROJECT in scope aubreyfs-projects. Verify Vercel authentication and project access." >&2
+  exit 1
+fi
 
 if [[ "$TARGET" == "website" ]]; then
   echo "Building $TARGET preview with Vercel"

--- a/scripts/vercel-deploy-production.sh
+++ b/scripts/vercel-deploy-production.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=./lib/node-tooling.sh
 source "${SCRIPT_DIR}/lib/node-tooling.sh"
 use_resolved_node_path
+NODE_BIN="$(resolve_node_bin)"
 NPM_BIN="$(resolve_npm_bin)"
 NPX_BIN="$(resolve_npx_bin)"
 
@@ -66,15 +67,12 @@ if [[ "$STAGE_AT_ROOT" == "true" ]]; then
   cp "$ROOT_DIR/package-lock.json" "$TEMP_DIR/package-lock.json"
   cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
   cp -R "$ROOT_DIR/$APP_DIR" "$TEMP_DIR/$APP_DIR"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
 else
   cp "$ROOT_DIR/package.json" "$TEMP_DIR/package.json"
   cp "$ROOT_DIR/package-lock.json" "$TEMP_DIR/package-lock.json"
   cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
   mkdir -p "$TEMP_DIR/$(dirname "$APP_DIR")"
   cp -R "$ROOT_DIR/$APP_DIR" "$TEMP_DIR/$APP_DIR"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
-
   if [[ "$TARGET" == "pwa" ]]; then
     mkdir -p "$TEMP_DIR/packages/pwa"
     cat <<'EOF' >"$TEMP_DIR/vercel.json"
@@ -87,6 +85,17 @@ else
 }
 EOF
   fi
+fi
+
+VERCEL_PROJECT="$(
+  "$NODE_BIN" "$ROOT_DIR/scripts/lib/vercel-project-link.mjs" project "$TARGET"
+)"
+PROJECT_LINK_STATE="bootstrap"
+if "$NODE_BIN" "$ROOT_DIR/scripts/lib/vercel-project-link.mjs" stage \
+  "$ROOT_DIR/$APP_DIR/.vercel/project.json" \
+  "$TEMP_DIR/.vercel/project.json"
+then
+  PROJECT_LINK_STATE="linked"
 fi
 
 for dir in "${DEPENDENCY_DIRS[@]}"; do
@@ -122,7 +131,15 @@ if [[ -n "$VERCEL_TOKEN" ]]; then
 fi
 
 echo "Pulling Vercel settings for $TARGET"
-"${NPX_BIN}" vercel pull --yes --environment production --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
+VERCEL_PULL_FLAGS=(--yes --environment production --cwd "$TEMP_DIR")
+if [[ "$PROJECT_LINK_STATE" == "bootstrap" ]]; then
+  echo "No local Vercel link found; selecting $VERCEL_PROJECT explicitly"
+  VERCEL_PULL_FLAGS+=(--project "$VERCEL_PROJECT")
+fi
+if ! "${NPX_BIN}" vercel pull "${VERCEL_PULL_FLAGS[@]}" "${VERCEL_FLAGS[@]}"; then
+  echo "Unable to access Vercel project $VERCEL_PROJECT in scope aubreyfs-projects. Verify Vercel authentication and project access." >&2
+  exit 1
+fi
 
 if [[ "$TARGET" == "website" ]]; then
   echo "Building $TARGET production bundle with Vercel"


### PR DESCRIPTION
(AI Generated).

## Summary
- Use explicit approved project names when a clean worktree has no ignored Vercel link file.
- Preserve exact existing link metadata when it is available and report authentication or project access failures clearly.
- Closes #1271

## Testing
- Focused Vercel project-link tests: 3 passed
- npm run validate:feature
- Clean unlinked PWA preview deployment READY: dpl_2jMpKfuYisYYMQWX2aSrFvnUujD1