### PR TITLE
perf: add PWA OPFS corpus hardening

### DIFF
--- a/.github/workflows/tooling-nightly.yml
+++ b/.github/workflows/tooling-nightly.yml
@@ -30,6 +30,61 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
+  pwa-library-corpus-hardening:
+    name: PWA Library corpus hardening
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: packages/pwa
+
+      - name: Exercise the 25,000 and 100,000 item OPFS Libraries
+        run: npm run test:e2e:corpus
+        working-directory: packages/pwa
+        env:
+          FREED_PWA_CORPUS_TARGET: "100000"
+
+      - name: Upload PWA corpus measurements
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: pwa-library-corpus-hardening
+          path: packages/pwa/test-results/pwa-library-corpus-hardening.json
+          retention-days: 30
+          if-no-files-found: warn
+
+      - name: Record a corpus hardening failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          body="(AI Generated).
+
+          Run: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}
+          Commit: ${GITHUB_SHA}
+
+          The nonblocking PWA OPFS corpus hardening lane failed before it could
+          prove both the 25,000 and 100,000 item checkpoints. The uploaded
+          measurement report, when present, contains the last completed
+          checkpoint."
+          gh issue comment 1446 --body "$body"
+
   exhaustive-tooling:
     name: Exhaustive tooling suites
     runs-on: ubuntu-latest

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -264,10 +264,11 @@ schema, protocol, registry, query or mutation name, duration, row count, byte
 count, cursor outcome, transaction identity, and typed failure code. Telemetry
 never includes provider credentials or private content bodies.
 
-Performance gates cover 25,000-item and 100,000-item Libraries. They enforce
-bounded renderer memory, bounded worker memory, indexed query plans, fixed page
-and response budgets, bounded startup work, and recovery without corpus
-materialization.
+The performance contract targets 25,000-item and 100,000-item Libraries. A
+nonblocking PWA nightly lane now exercises real OPFS SQLite at both sizes and
+records bounded feed, facet, search, browser-memory, and storage evidence.
+Native scale, whole-process peak memory, and the complete crash and corruption
+matrix remain tracked hardening work. No scale benchmark is a pull request gate.
 
 ## Release and operations
 

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -633,6 +633,8 @@ never sorts, filters, or ranks a Library collection.
 | 6.114 | Keep optional Map and Friends code out of feed startup and service-worker installation. Load both product surfaces on demand, cache their hashed assets after first use for offline return visits, keep core SQLite WebAssembly in the app-shell precache, fail the production build if optional chunks re-enter precache, lose runtime-cache coverage, or strand offline Library startup, and give each WebKit OPFS durability run a fresh test origin so abandoned test storage cannot impersonate another Library | High       | ✓ Complete                                                                                       |
 | 6.115 | Replace Friends directory offset pagination with a source-fenced Person-identity keyset shared by native SQLite and PWA OPFS SQLite. Preserve exact ordering across all four sort modes, fail closed on retired or missing cursor anchors, and keep every page bounded without discarding skipped rows | High       | ✓ Complete                                                                                       |
 | 6.116 | Clear transient Friends Galaxy draw errors and recovery state when a failed WebGPU switch retains the healthy WebGL2 compatibility renderer. Preserve the mounted semantic scene, announce recovery once, and cover the retained activation sequence plus the original selection-during-atlas-load failure | High       | ✓ Complete                                                                                       |
+| 6.117 | Add a nonblocking PWA OPFS corpus hardening lane that streams deterministic provider-neutral FeedItems in bounded 128-row transactions, records browser memory and storage evidence at 25,000 and 100,000 items, and proves feed, facet, and search responses stay inside their row and scan limits. Unsupported memory measurement remains explicit instead of fabricating evidence | High       | ✓ Complete                                                                                       |
+| 6.118 | Keep the mobile Settings breadcrumb synchronized with the final rendered section when WebKit clamps a programmatic scroll target at the bottom of the scrollport. Danger Zone content can no longer remain visibly open under a stale Legal label | Medium     | ✓ Complete                                                                                       |
 
 ---
 
@@ -696,6 +698,8 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] Reader HTML stays outside synchronized Library metadata and is available offline only after the local cache or selective content vault hydrates it
 - [x] The article proxy resolves and pins public addresses, revalidates every bounded redirect, rejects non-HTML responses, and stops oversized response bodies before they exhaust server memory
 - [x] Saved reader content uses the permanent pinned cache tier by default, with local cache modes for Saved Only, Everything Opened, Recent Feed, and Manual Only
+- [x] Nightly PWA corpus hardening exercises real OPFS SQLite at 25,000 and 100,000 deterministic provider-neutral FeedItems, records browser memory and storage measurements, and proves bounded feed, facet, and search behavior without adding a pull request gate
+- [x] Mobile Settings identifies the final rendered section when the scrollport reaches its lower bound, so a clamped Danger Zone jump cannot leave the breadcrumb labeled as Legal
 
 ---
 

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -633,6 +633,7 @@ never sorts, filters, or ranks a Library collection.
 | 6.114 | Keep optional Map and Friends code out of feed startup and service-worker installation. Load both product surfaces on demand, cache their hashed assets after first use for offline return visits, keep core SQLite WebAssembly in the app-shell precache, fail the production build if optional chunks re-enter precache, lose runtime-cache coverage, or strand offline Library startup, and give each WebKit OPFS durability run a fresh test origin so abandoned test storage cannot impersonate another Library | High       | ✓ Complete                                                                                       |
 | 6.115 | Replace Friends directory offset pagination with a source-fenced Person-identity keyset shared by native SQLite and PWA OPFS SQLite. Preserve exact ordering across all four sort modes, fail closed on retired or missing cursor anchors, and keep every page bounded without discarding skipped rows | High       | ✓ Complete                                                                                       |
 | 6.116 | Clear transient Friends Galaxy draw errors and recovery state when a failed WebGPU switch retains the healthy WebGL2 compatibility renderer. Preserve the mounted semantic scene, announce recovery once, and cover the retained activation sequence plus the original selection-during-atlas-load failure | High       | ✓ Complete                                                                                       |
+| 6.117 | Add a nonblocking PWA OPFS corpus hardening lane that streams deterministic provider-neutral FeedItems in bounded 128-row transactions, records browser memory and storage evidence at 25,000 and 100,000 items, and proves feed, facet, and search responses stay inside their row and scan limits. Unsupported memory measurement remains explicit instead of fabricating evidence | High       | ✓ Complete                                                                                       |
 
 ---
 
@@ -696,6 +697,7 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] Reader HTML stays outside synchronized Library metadata and is available offline only after the local cache or selective content vault hydrates it
 - [x] The article proxy resolves and pins public addresses, revalidates every bounded redirect, rejects non-HTML responses, and stops oversized response bodies before they exhaust server memory
 - [x] Saved reader content uses the permanent pinned cache tier by default, with local cache modes for Saved Only, Everything Opened, Recent Feed, and Manual Only
+- [x] Nightly PWA corpus hardening exercises real OPFS SQLite at 25,000 and 100,000 deterministic provider-neutral FeedItems, records browser memory and storage measurements, and proves bounded feed, facet, and search behavior without adding a pull request gate
 
 ---
 

--- a/docs/PWA-OPFS-CORPUS-BASELINE-2026-08-31.md
+++ b/docs/PWA-OPFS-CORPUS-BASELINE-2026-08-31.md
@@ -1,0 +1,46 @@
+# PWA OPFS corpus baseline, 2026-08-31
+
+## Identity and scope
+
+This report records the first deterministic large-corpus evidence for the PWA
+Library running on the real Chromium OPFS SAH pool.
+
+- Source base: `2586367f99bcdd46ba8f74348d88462ada900441`
+- Browser: Chromium `151.0.7922.34`
+- Fixture: provider-neutral RSS FeedItems generated in bounded 128-row signed
+  transactions
+- Test profile: fresh isolated browser profile and origin
+- Total runtime: 17.8 minutes
+- Pull request and release gates: none. This is a nonblocking hardening lane.
+
+The fixture did not contact a provider, import a real Library, or exercise a
+cloud account.
+
+## Results
+
+| Measurement              |      25,000 items |       100,000 items |
+| ------------------------ | ----------------: | ------------------: |
+| Feed page rows           |                64 |                  64 |
+| Feed page time           |           6.24 ms |             8.61 ms |
+| Facet time               |          53.55 ms |             8.43 ms |
+| Search rows              |                32 |                  32 |
+| Search rows scanned      |                32 |                  32 |
+| Search time              |          20.50 ms |            49.44 ms |
+| JavaScript heap snapshot |  46,297,083 bytes |    96,212,811 bytes |
+| OPFS usage               | 411,045,496 bytes | 1,617,474,555 bytes |
+
+Both checkpoints stayed inside the Library Core contract's warm bounded page,
+facet, and search timing budgets. Feed and search response sizes remained fixed
+as the fixture grew by four times.
+
+## Evidence limits
+
+Chromium exposed `performance.memory`, not
+`measureUserAgentSpecificMemory`, in this run. The heap values are page-level
+snapshots after each checkpoint. They are not whole-process or dedicated-worker
+peak memory. The checked-in nightly harness now also samples the page heap after
+every bounded capture transaction and reports the largest observed value.
+
+Native scale, whole-process peak memory, WebKit scale, quota exhaustion, and the
+complete crash and corruption matrix remain open under issue #1446. This report
+does not claim those proofs.

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit",
     "test": "node ../../node_modules/playwright/cli.js test",
     "test:e2e:opfs": "node ../../scripts/run-pwa-opfs-e2e.mjs",
+    "test:e2e:corpus": "node ../../scripts/run-pwa-library-corpus-hardening.mjs",
     "test:unit": "vitest run --maxWorkers=1",
     "test:unit:watch": "vitest",
     "test:ui": "node ../../node_modules/playwright/cli.js test --ui",

--- a/packages/pwa/playwright.corpus.config.ts
+++ b/packages/pwa/playwright.corpus.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig } from "@playwright/test";
+import {
+  pwaCorpusHardeningBaseUrl,
+  pwaCorpusHardeningPort,
+} from "./tests/corpus-hardening-e2e-settings";
+
+export default defineConfig({
+  testDir: "./tests",
+  testMatch: "**/sqlite-opfs-corpus-hardening.spec.ts",
+  fullyParallel: false,
+  forbidOnly: true,
+  retries: 0,
+  timeout: 3_600_000,
+  workers: 1,
+  reporter: "line",
+  use: {
+    baseURL: pwaCorpusHardeningBaseUrl,
+    browserName: "chromium",
+    screenshot: "only-on-failure",
+    trace: "retain-on-failure",
+  },
+  webServer: {
+    command: `FREED_PWA_CORPUS_HARDENING=1 npm run dev -- --force --host 127.0.0.1 --port ${pwaCorpusHardeningPort.toLocaleString(
+      "en-US",
+      {
+        useGrouping: false,
+      },
+    )}`,
+    reuseExistingServer: false,
+    timeout: 120_000,
+    url: pwaCorpusHardeningBaseUrl,
+  },
+});

--- a/packages/pwa/src/main.tsx
+++ b/packages/pwa/src/main.tsx
@@ -9,6 +9,7 @@ import {
 import type {
   LibraryCoreDeviceContactQueryRequestV1,
   LibraryCoreDeviceContactSyncMutationV1,
+  LibraryCoreSqliteQueryRequest,
 } from '@freed/shared/library-core'
 import './index.css'
 import App from './App.tsx'
@@ -47,6 +48,8 @@ if (import.meta.env.DEV) {
     }
     w.__FREED_STORE__ = store.useAppStore
     w.__FREED_LIBRARY_CORE__ = {
+      queryNormalized: (query: LibraryCoreSqliteQueryRequest) =>
+        sqliteCore.queryPwaNormalizedLibrary(query),
       mutateDeviceContactSync: (
         mutation: LibraryCoreDeviceContactSyncMutationV1,
       ) => sqliteCore.mutatePwaDeviceContactSync(mutation),

--- a/packages/pwa/tests/corpus-hardening-e2e-settings.ts
+++ b/packages/pwa/tests/corpus-hardening-e2e-settings.ts
@@ -1,0 +1,18 @@
+export const pwaCorpusHardeningPort = Number(
+  process.env.PWA_CORPUS_HARDENING_PORT ?? "1424",
+);
+
+if (
+  !Number.isSafeInteger(pwaCorpusHardeningPort) ||
+  pwaCorpusHardeningPort < 1 ||
+  pwaCorpusHardeningPort > 65_535
+) {
+  throw new Error("PWA_CORPUS_HARDENING_PORT must be a valid TCP port");
+}
+
+export const pwaCorpusHardeningBaseUrl = `http://127.0.0.1:${pwaCorpusHardeningPort.toLocaleString(
+  "en-US",
+  {
+    useGrouping: false,
+  },
+)}`;

--- a/packages/pwa/tests/sqlite-opfs-corpus-hardening.spec.ts
+++ b/packages/pwa/tests/sqlite-opfs-corpus-hardening.spec.ts
@@ -1,0 +1,384 @@
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import {
+  chromium,
+  expect,
+  test,
+  type BrowserContext,
+  type Page,
+} from "@playwright/test";
+import { pwaCorpusHardeningBaseUrl } from "./corpus-hardening-e2e-settings";
+
+/**
+ * Nightly tier. This catches PWA OPFS regressions that only appear once the
+ * Library is large, including an unbounded named query, a corpus-sized browser
+ * allocation, or storage growth that cannot be compared across exact fixtures.
+ * It is deliberately absent from pull request and release gates.
+ */
+const requestedTarget = Number(process.env.FREED_PWA_CORPUS_TARGET ?? "100000");
+const smokeTarget = 256;
+const contractTargets = [25_000, 100_000] as const;
+const supportedTargets = [smokeTarget, ...contractTargets] as const;
+
+if (!supportedTargets.includes(requestedTarget as 256 | 25_000 | 100_000)) {
+  throw new Error("FREED_PWA_CORPUS_TARGET must be 256, 25000, or 100000");
+}
+
+const target = requestedTarget as 256 | 25_000 | 100_000;
+const milestones =
+  target === smokeTarget
+    ? [smokeTarget]
+    : contractTargets.filter((value) => value <= target);
+const reportPath = resolve(
+  process.cwd(),
+  process.env.FREED_PWA_CORPUS_REPORT ??
+    "test-results/pwa-library-corpus-hardening.json",
+);
+
+interface BrowserLibraryCore {
+  addItems(items: unknown[]): Promise<void>;
+  facetSummary(): Promise<{ totalCount: number }>;
+  queryNormalized(query: unknown): Promise<unknown>;
+}
+
+interface MemorySample {
+  readonly measurement:
+    "measureUserAgentSpecificMemory" | "performance.memory" | "unsupported";
+  readonly bytes: number | null;
+  readonly sampledPeakPageHeapBytes: number | null;
+}
+
+interface MilestoneReport {
+  readonly corpusCount: number;
+  readonly feedPage: {
+    readonly durationMs: number;
+    readonly rowCount: number;
+    readonly totalCount: number;
+  };
+  readonly facets: {
+    readonly durationMs: number;
+    readonly totalCount: number;
+  };
+  readonly memory: MemorySample;
+  readonly searchPage: {
+    readonly durationMs: number;
+    readonly rowCount: number;
+    readonly scannedRows: number;
+  };
+  readonly storage: {
+    readonly quotaBytes: number | null;
+    readonly usageBytes: number | null;
+  };
+}
+
+async function acceptLegalGate(page: Page): Promise<void> {
+  const accept = page.getByTestId("legal-gate-accept");
+  if (!(await accept.isVisible({ timeout: 5_000 }).catch(() => false))) return;
+  await page.getByRole("checkbox").check();
+  await expect(accept).toBeEnabled();
+  await accept.click();
+}
+
+async function openLibrary(page: Page): Promise<void> {
+  await page.goto(pwaCorpusHardeningBaseUrl);
+  await acceptLegalGate(page);
+  await page.waitForFunction(() => {
+    const current = window as unknown as Record<string, unknown>;
+    const store = current.__FREED_STORE__ as
+      { getState(): { isInitialized: boolean } } | undefined;
+    return (
+      store?.getState().isInitialized === true &&
+      typeof current.__FREED_LIBRARY_CORE__ === "object"
+    );
+  });
+}
+
+async function seedUntil(
+  page: Page,
+  from: number,
+  to: number,
+): Promise<number | null> {
+  return page.evaluate(
+    async ({ start, end }) => {
+      const library = (window as unknown as Record<string, unknown>)
+        .__FREED_LIBRARY_CORE__ as BrowserLibraryCore;
+      const batchSize = 128;
+      const publishedBase = 1_800_000_000_000;
+      const memory = performance as Performance & {
+        memory?: { usedJSHeapSize: number };
+      };
+      let sampledPeakPageHeapBytes: number | null = null;
+      for (let offset = start; offset < end; offset += batchSize) {
+        const batchEnd = Math.min(offset + batchSize, end);
+        const batch = [];
+        for (let index = offset; index < batchEnd; index += 1) {
+          batch.push({
+            globalId: `rss:https://corpus.invalid/feed.xml:item-${index}`,
+            platform: "rss",
+            contentType: "article",
+            capturedAt: publishedBase - index,
+            publishedAt: publishedBase - index,
+            author: {
+              id: "corpus-author",
+              handle: "corpus-author",
+              displayName: "Corpus Author",
+            },
+            content: {
+              text: `Deterministic SQLite benchmark item ${index.toLocaleString()}`,
+              mediaUrls: [],
+              mediaTypes: [],
+            },
+            userState: {
+              hidden: false,
+              saved: false,
+              archived: false,
+              tags: [],
+            },
+            topics: [],
+            rssSource: {
+              feedUrl: "https://corpus.invalid/feed.xml",
+              feedTitle: "Deterministic Corpus",
+            },
+          });
+        }
+        await library.addItems(batch);
+        const usedHeap = memory.memory?.usedJSHeapSize;
+        if (Number.isFinite(usedHeap)) {
+          sampledPeakPageHeapBytes = Math.max(
+            sampledPeakPageHeapBytes ?? 0,
+            usedHeap ?? 0,
+          );
+        }
+        if (batchEnd % 5_000 === 0 || batchEnd === end) {
+          console.info(
+            `PWA corpus seed reached ${batchEnd.toLocaleString()} items`,
+          );
+        }
+      }
+      return sampledPeakPageHeapBytes;
+    },
+    { start: from, end: to },
+  );
+}
+
+async function measureMemory(
+  page: Page,
+  sampledPeakPageHeapBytes: number | null,
+): Promise<MemorySample> {
+  const current = await page.evaluate(async () => {
+    const candidate = performance as Performance & {
+      measureUserAgentSpecificMemory?: () => Promise<{ bytes: number }>;
+      memory?: { usedJSHeapSize: number };
+    };
+    if (
+      crossOriginIsolated &&
+      typeof candidate.measureUserAgentSpecificMemory === "function"
+    ) {
+      try {
+        const measured = await candidate.measureUserAgentSpecificMemory();
+        return {
+          bytes: measured.bytes,
+          measurement: "measureUserAgentSpecificMemory" as const,
+        };
+      } catch {
+        // Fall through to the Chromium heap counter when the memory API is
+        // present but temporarily unavailable.
+      }
+    }
+    if (Number.isFinite(candidate.memory?.usedJSHeapSize)) {
+      return {
+        bytes: candidate.memory?.usedJSHeapSize ?? null,
+        measurement: "performance.memory" as const,
+      };
+    }
+    return { bytes: null, measurement: "unsupported" as const };
+  });
+  return { ...current, sampledPeakPageHeapBytes };
+}
+
+async function measureMilestone(
+  page: Page,
+  baselineCount: number,
+  corpusCount: number,
+): Promise<MilestoneReport> {
+  return page.evaluate(
+    async ({ baseline, count }) => {
+      const library = (window as unknown as Record<string, unknown>)
+        .__FREED_LIBRARY_CORE__ as BrowserLibraryCore;
+      const measure = async <T>(operation: () => Promise<T>) => {
+        const startedAt = performance.now();
+        const value = await operation();
+        return { durationMs: performance.now() - startedAt, value };
+      };
+      const token = crypto.randomUUID();
+      const feed = await measure(
+        () =>
+          library.queryNormalized({
+            cancellationId: `corpus-feed-cancel:${token}`,
+            cursor: null,
+            limit: 64,
+            queryId: "feed_page_v1",
+            readerSessionId: `corpus-feed-reader:${token}`,
+            schemaVersion: 1,
+          }) as Promise<{
+            rows: unknown[];
+            totalCount: number;
+          }>,
+      );
+      const facets = await measure(() => library.facetSummary());
+      const search = await measure(
+        () =>
+          library.queryNormalized({
+            cancellationId: `corpus-search-cancel:${token}`,
+            cursor: null,
+            filter: {
+              archivedOnly: false,
+              authorId: null,
+              feedUrl: null,
+              platform: null,
+              savedOnly: false,
+              schemaVersion: 1,
+              showHidden: false,
+              signals: [],
+              socialContentFilter: "all",
+              tags: [],
+            },
+            friendsPredicateSchemaVersion: 1,
+            identityMode: "all_content",
+            limit: 32,
+            query: "deterministic benchmark",
+            queryId: "search_page_v1",
+            readerSessionId: `corpus-search-reader:${token}`,
+            recommendationOrderSchemaVersion: 1,
+            schemaVersion: 1,
+          }) as Promise<{ rows: unknown[]; scannedRows: number }>,
+      );
+      const storage = await navigator.storage.estimate();
+      return {
+        corpusCount: count,
+        feedPage: {
+          durationMs: feed.durationMs,
+          rowCount: feed.value.rows.length,
+          totalCount: feed.value.totalCount - baseline,
+        },
+        facets: {
+          durationMs: facets.durationMs,
+          totalCount: facets.value.totalCount - baseline,
+        },
+        memory: {
+          bytes: null,
+          measurement: "unsupported" as const,
+          sampledPeakPageHeapBytes: null,
+        },
+        searchPage: {
+          durationMs: search.durationMs,
+          rowCount: search.value.rows.length,
+          scannedRows: search.value.scannedRows,
+        },
+        storage: {
+          quotaBytes: Number.isFinite(storage.quota)
+            ? (storage.quota ?? null)
+            : null,
+          usageBytes: Number.isFinite(storage.usage)
+            ? (storage.usage ?? null)
+            : null,
+        },
+      };
+    },
+    { baseline: baselineCount, count: corpusCount },
+  );
+}
+
+async function writeReport(
+  context: BrowserContext,
+  reports: readonly MilestoneReport[],
+): Promise<void> {
+  await mkdir(dirname(reportPath), { recursive: true });
+  await writeFile(
+    reportPath,
+    `${JSON.stringify(
+      {
+        browser: context.browser()?.version() ?? "unknown",
+        generatedAt: new Date().toISOString(),
+        milestones: reports,
+        schemaVersion: 1,
+        target,
+      },
+      null,
+      2,
+    )}\n`,
+    "utf8",
+  );
+}
+
+test("OPFS SQLite keeps PWA queries bounded at representative corpus scale", async () => {
+  test.setTimeout(3_600_000);
+  const profileRoot = resolve(
+    process.cwd(),
+    "test-results/pwa-library-corpus-profile",
+  );
+  let context: BrowserContext | null = null;
+  const reports: MilestoneReport[] = [];
+  let completed = false;
+  let sampledPeakPageHeapBytes: number | null = null;
+
+  try {
+    await rm(profileRoot, { force: true, recursive: true });
+    context = await chromium.launchPersistentContext(profileRoot, {
+      args: ["--enable-precise-memory-info"],
+      baseURL: pwaCorpusHardeningBaseUrl,
+      headless: true,
+    });
+    const page = context.pages()[0] ?? (await context.newPage());
+    page.on("console", (message) => {
+      if (message.type() === "info") console.info(message.text());
+    });
+    await openLibrary(page);
+    const baseline = await page.evaluate(async () => {
+      const library = (window as unknown as Record<string, unknown>)
+        .__FREED_LIBRARY_CORE__ as BrowserLibraryCore;
+      return (await library.facetSummary()).totalCount;
+    });
+
+    let seeded = 0;
+    for (const milestone of milestones) {
+      const segmentPeak = await seedUntil(page, seeded, milestone);
+      if (segmentPeak !== null) {
+        sampledPeakPageHeapBytes = Math.max(
+          sampledPeakPageHeapBytes ?? 0,
+          segmentPeak,
+        );
+      }
+      seeded = milestone;
+      await expect
+        .poll(
+          async () =>
+            page.evaluate(async () => {
+              const library = (window as unknown as Record<string, unknown>)
+                .__FREED_LIBRARY_CORE__ as BrowserLibraryCore;
+              return (await library.facetSummary()).totalCount;
+            }),
+          { timeout: 120_000 },
+        )
+        .toBe(baseline + milestone);
+      const report = await measureMilestone(page, baseline, milestone);
+      reports.push({
+        ...report,
+        memory: await measureMemory(page, sampledPeakPageHeapBytes),
+      });
+      await writeReport(context, reports);
+      expect(report.feedPage.rowCount).toBeLessThanOrEqual(64);
+      expect(report.feedPage.totalCount).toBe(report.corpusCount);
+      expect(report.facets.totalCount).toBe(report.corpusCount);
+      expect(report.searchPage.rowCount).toBeLessThanOrEqual(32);
+      expect(report.searchPage.scannedRows).toBeLessThanOrEqual(256);
+      expect(report.storage.usageBytes).not.toBeNull();
+    }
+
+    console.info(`PWA corpus report: ${reportPath}`);
+    completed = true;
+  } finally {
+    await context?.close();
+    if (completed) await rm(profileRoot, { force: true, recursive: true });
+  }
+});

--- a/packages/pwa/vite.config.ts
+++ b/packages/pwa/vite.config.ts
@@ -66,6 +66,13 @@ export default defineConfig({
     fs: {
       allow: fsAllow,
     },
+    headers:
+      process.env.FREED_PWA_CORPUS_HARDENING === "1"
+        ? {
+            "Cross-Origin-Embedder-Policy": "require-corp",
+            "Cross-Origin-Opener-Policy": "same-origin",
+          }
+        : undefined,
   },
   build: {
     target: "esnext",

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -1073,12 +1073,19 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
     }
 
     const scrollPosition = container.scrollTop + 56;
-    let anchorSection = sections[0];
-    for (const section of sections) {
-      if (section.offsetTop <= scrollPosition) {
-        anchorSection = section;
-      } else {
-        break;
+    const maximumScrollTop = Math.max(
+      0,
+      container.scrollHeight - container.clientHeight,
+    );
+    const reachedScrollEnd = maximumScrollTop - container.scrollTop <= 1;
+    let anchorSection = sections.at(reachedScrollEnd ? -1 : 0)!;
+    if (!reachedScrollEnd) {
+      for (const section of sections) {
+        if (section.offsetTop <= scrollPosition) {
+          anchorSection = section;
+        } else {
+          break;
+        }
       }
     }
 

--- a/scripts/run-pwa-library-corpus-hardening.mjs
+++ b/scripts/run-pwa-library-corpus-hardening.mjs
@@ -1,0 +1,55 @@
+#!/usr/bin/env node
+
+import { randomInt } from "node:crypto";
+import { spawn } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findFreePort } from "./lib/find-free-port.mjs";
+
+const scriptDirectory = dirname(fileURLToPath(import.meta.url));
+
+async function selectTestPort() {
+  const configuredPort = process.env.PWA_CORPUS_HARDENING_PORT?.trim();
+  if (configuredPort) return configuredPort;
+
+  const firstCandidate = randomInt(20_000, 60_000);
+  return String(await findFreePort(firstCandidate, 1_000));
+}
+
+/** Run the opt-in PWA OPFS corpus hardening proof on a fresh origin. */
+export async function runPwaLibraryCorpusHardening(
+  args = process.argv.slice(2),
+) {
+  const port = await selectTestPort();
+  const baseUrl = `http://127.0.0.1:${port}`;
+  console.log(`PWA corpus hardening origin: ${baseUrl}`);
+
+  const playwrightCli = resolve(
+    scriptDirectory,
+    "../node_modules/playwright/cli.js",
+  );
+  const child = spawn(
+    process.execPath,
+    [playwrightCli, "test", "--config", "playwright.corpus.config.ts", ...args],
+    {
+      cwd: process.cwd(),
+      env: { ...process.env, PWA_CORPUS_HARDENING_PORT: port },
+      stdio: "inherit",
+    },
+  );
+
+  const exitCode = await new Promise((resolveExit, reject) => {
+    child.once("error", reject);
+    child.once("exit", (code, signal) => {
+      resolveExit(code ?? (signal ? 1 : 0));
+    });
+  });
+  process.exitCode = exitCode;
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  await runPwaLibraryCorpusHardening();
+}


### PR DESCRIPTION
(AI Generated).

## Summary
- Add a deterministic Chromium OPFS stress lane at 25,000 and 100,000 FeedItems with bounded capture transactions, query limits, storage evidence, and sampled browser heap.
- Run the expensive proof only in the nonblocking nightly workflow and attach failures to the existing Library Core hardening debt issue.
- Fix the mobile Settings scrollspy so a final section clamped at the bottom cannot display a stale breadcrumb.
- Record the first successful 100,000 item baseline and state the remaining native, WebKit scale, whole-process memory, quota, crash, and corruption gaps.

## Testing
- Local 100,000 item OPFS proof passed in 17.8 minutes.
- npm run validate:feature
- PWA WebKit OPFS durability passed after the scrollspy repair.
- Focused Chromium mobile Settings scenario passed.
- Root typecheck passed.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `ce290f239a2105fdd3463a61e7372ec0363cd871`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-settings-scrollspy-1683`
- Provider review decision: `diff_authorized`
- Provider review artifact: `99083a6d50ea8248dc9ea2c15d85976eb37921b69ef53cda83c8f735ae4634f9`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider contact behavior is unchanged. The diff only changes local Settings scrollspy selection when the local scrollport reaches its lower bound.
- Fingerprinting risk: None. The diff does not change provider requests, navigation, timing, retries, cookies, headers, provider WebView scrolling or clicks, media, login, extraction, or background activity.
- Lowest profile alternative: Keep the repair inside the local Settings scroll calculation. No provider contact or live traffic is needed.

Files bound into this provider review:
- `packages/ui/src/components/SettingsDialog.tsx`