### PR TITLE
fix: preserve PWA SQLite quota failures

### DIFF
--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -635,6 +635,7 @@ never sorts, filters, or ranks a Library collection.
 | 6.116 | Clear transient Friends Galaxy draw errors and recovery state when a failed WebGPU switch retains the healthy WebGL2 compatibility renderer. Preserve the mounted semantic scene, announce recovery once, and cover the retained activation sequence plus the original selection-during-atlas-load failure | High       | ✓ Complete                                                                                       |
 | 6.117 | Add a nonblocking PWA OPFS corpus hardening lane that streams deterministic provider-neutral FeedItems in bounded 128-row transactions, records browser memory and storage evidence at 25,000 and 100,000 items, and proves feed, facet, and search responses stay inside their row and scan limits. Unsupported memory measurement remains explicit instead of fabricating evidence | High       | ✓ Complete                                                                                       |
 | 6.118 | Keep the mobile Settings breadcrumb synchronized with the final rendered section when WebKit clamps a programmatic scroll target at the bottom of the scrollport. Danger Zone content can no longer remain visibly open under a stale Legal label | Medium     | ✓ Complete                                                                                       |
+| 6.119 | Preserve the original PWA SQLite failure when SQLite has already ended a transaction before cleanup, including storage-full refusal. Prove a quota-bound large operation cannot advance accepted state or leak a partial member, retains its durable transaction stage, and succeeds on exact retry after capacity returns | High       | ✓ Complete                                                                                       |
 
 ---
 
@@ -700,6 +701,7 @@ Build chain: `@freed/shared` → `@freed/sync` → `vite build` (configured in `
 - [x] Saved reader content uses the permanent pinned cache tier by default, with local cache modes for Saved Only, Everything Opened, Recent Feed, and Manual Only
 - [x] Nightly PWA corpus hardening exercises real OPFS SQLite at 25,000 and 100,000 deterministic provider-neutral FeedItems, records browser memory and storage measurements, and proves bounded feed, facet, and search behavior without adding a pull request gate
 - [x] Mobile Settings identifies the final rendered section when the scrollport reaches its lower bound, so a clamped Danger Zone jump cannot leave the breadcrumb labeled as Legal
+- [x] PWA SQLite transaction cleanup preserves the original storage-full failure when SQLite has already ended the transaction, and deterministic quota proof preserves accepted state before exact retry
 
 ---
 

--- a/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
@@ -1461,6 +1461,44 @@ describe("PWA Library Core SQLite engine", () => {
       finalizedMember.envelope.transaction_id,
       finalized.transaction_digest,
     );
+    const pageCountRows = database.exec({
+      sql: "PRAGMA page_count;",
+      rowMode: "array",
+      returnValue: "resultRows",
+    }) as number[][];
+    const pageCount = pageCountRows[0]?.[0];
+    expect(pageCount).toBeGreaterThan(0);
+    expect(
+      database.exec({
+        sql: "PRAGMA freelist_count;",
+        rowMode: "array",
+        returnValue: "resultRows",
+      }),
+    ).toEqual([[0]]);
+    database.exec(`PRAGMA max_page_count = ${pageCount};`);
+    await expect(
+      engine.importNormalizedOperationPage({
+        page: page(operationRecord, true),
+        receivedAt: 2_600,
+        snapshot: descriptor,
+      }),
+    ).rejects.toThrow(/database or disk is full/);
+    expect(
+      database.exec({
+        sql: `SELECT m.source_revision,
+                     (SELECT count(*) FROM library_feed_items),
+                     (SELECT count(*) FROM library_operations),
+                     (SELECT count(*) FROM library_operation_replication_stages
+                       WHERE source_revision = 1),
+                     (SELECT count(*) FROM library_operation_replication_stage_members
+                       WHERE source_revision = 1)
+              FROM library_meta AS m WHERE m.singleton_id = 1;`,
+        rowMode: "array",
+        returnValue: "resultRows",
+      }),
+    ).toEqual([[0, 0, 0, 1, 0]]);
+    database.exec("PRAGMA max_page_count = 1073741823;");
+
     database.exec(`CREATE TEMP TRIGGER fail_operation_replication_receipt
       BEFORE INSERT ON library_operation_replication_results
       BEGIN SELECT RAISE(ABORT, 'injected operation replication fault'); END;`);

--- a/packages/pwa/src/lib/library-core-sqlite-engine.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.ts
@@ -462,6 +462,18 @@ function sameBytes(left: Uint8Array, right: Uint8Array): boolean {
   );
 }
 
+function rollbackPreservingOriginalError(
+  database: Database,
+  error: unknown,
+): never {
+  try {
+    database.exec("ROLLBACK;");
+  } catch {
+    // SQLITE_FULL can end the transaction before the explicit rollback runs.
+  }
+  throw error;
+}
+
 function nullableText(
   value: SqlValue | undefined,
   label: string,
@@ -1160,8 +1172,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#database.exec("COMMIT;");
       return result;
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -1312,8 +1323,7 @@ export class PwaLibraryCoreSqliteEngine {
       });
       this.#database.exec("COMMIT;");
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
     return this.#checkpointStageStatus(page.stageId);
   }
@@ -1823,8 +1833,7 @@ export class PwaLibraryCoreSqliteEngine {
         stageId,
       });
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -1991,8 +2000,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#database.exec("COMMIT;");
       return result.value;
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -2937,8 +2945,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#database.exec("COMMIT;");
       return receipt;
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -3052,8 +3059,7 @@ export class PwaLibraryCoreSqliteEngine {
       if (!receipt.ok) throw new TypeError(receipt.error);
       return receipt.value;
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -3536,8 +3542,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#database.exec("COMMIT;");
       return receipt.value;
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -3589,8 +3594,7 @@ export class PwaLibraryCoreSqliteEngine {
       }
       this.#database.exec("COMMIT;");
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -3742,8 +3746,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#database.exec("COMMIT;");
       return receipt.value;
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -3900,8 +3903,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#reconcileLocalContentState(changed);
       this.#database.exec("COMMIT;");
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -4324,8 +4326,7 @@ export class PwaLibraryCoreSqliteEngine {
       });
       this.#database.exec("COMMIT;");
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
     return Object.freeze({
       actorChainGenesis: verified.actor_chain_genesis,
@@ -4877,8 +4878,7 @@ export class PwaLibraryCoreSqliteEngine {
         transactionId: verified.transaction_body.transaction_id,
       });
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -5072,8 +5072,7 @@ export class PwaLibraryCoreSqliteEngine {
         transactionId: publication.transactionId,
       });
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -5326,8 +5325,7 @@ export class PwaLibraryCoreSqliteEngine {
         storedSegmentDigest: reference.descriptor.contentDigest,
       });
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -6135,8 +6133,7 @@ export class PwaLibraryCoreSqliteEngine {
       }
       this.#database.exec("COMMIT;");
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
 
     let appliedTransactionCount = 0;
@@ -6666,8 +6663,7 @@ export class PwaLibraryCoreSqliteEngine {
         this.#database.exec("COMMIT;");
         appliedTransactionCount += 1;
       } catch (error) {
-        this.#database.exec("ROLLBACK;");
-        throw error;
+        rollbackPreservingOriginalError(this.#database, error);
       }
     }
 
@@ -7085,8 +7081,7 @@ export class PwaLibraryCoreSqliteEngine {
         });
       }
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
     for (const verified of verifiedResults) {
       await this.#applyAcceptedFollowerResultThroughOperationImport(
@@ -7587,8 +7582,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#database.exec("COMMIT;");
       return Object.freeze({ memberCount, stageId, state: "ready" });
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 
@@ -7634,8 +7628,7 @@ export class PwaLibraryCoreSqliteEngine {
       this.#database.exec("COMMIT;");
       return Object.freeze({ memberCount, stageId, state: "staging" });
     } catch (error) {
-      this.#database.exec("ROLLBACK;");
-      throw error;
+      rollbackPreservingOriginalError(this.#database, error);
     }
   }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the original SQLite failure when SQLite has already ended a transaction before cleanup.
- Apply the rollback-safe error path to every PWA Library Core transaction boundary.
- Prove a storage-full large operation preserves accepted state and succeeds on exact retry.

## Testing
- npm run validate:feature