### PR TITLE
fix: publish accurate map location counts

### DIFF
--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -283,6 +283,7 @@ interface AppState {
   archivableCountByPlatform: Record<string, number>;
   mapFriendLocationCount: number;
   mapAllContentLocationCount: number;
+  setMapLocationCounts: (friendCount: number, allContentCount: number) => void;
   visibleFeedTotalCount: number;
 
   // X auth state
@@ -655,6 +656,17 @@ export const useAppStore = create<AppState>((set, get) => ({
   archivableCountByPlatform: {},
   mapFriendLocationCount: 0,
   mapAllContentLocationCount: 0,
+  setMapLocationCounts: (friendCount, allContentCount) => {
+    set((state) =>
+      state.mapFriendLocationCount === friendCount &&
+      state.mapAllContentLocationCount === allContentCount
+        ? state
+        : {
+            mapFriendLocationCount: friendCount,
+            mapAllContentLocationCount: allContentCount,
+          },
+    );
+  },
   visibleFeedTotalCount: 0,
   xAuth: { isAuthenticated: false },
   fbAuth: { isAuthenticated: false },

--- a/packages/pwa/src/lib/command-palette.test.ts
+++ b/packages/pwa/src/lib/command-palette.test.ts
@@ -116,6 +116,7 @@ function createTestStore(overrides: Partial<BaseAppState> = {}) {
     visibleFeedTotalCount: overrides.visibleFeedTotalCount ?? 0,
     mapFriendLocationCount: overrides.mapFriendLocationCount ?? 0,
     mapAllContentLocationCount: overrides.mapAllContentLocationCount ?? 0,
+    setMapLocationCounts: overrides.setMapLocationCounts ?? (() => {}),
     isLoading: false,
     isSyncing: false,
     isInitialized: true,

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -270,6 +270,17 @@ export const useAppStore = create<AppState>((set, get) => ({
   archivableCountByPlatform: {},
   mapFriendLocationCount: 0,
   mapAllContentLocationCount: 0,
+  setMapLocationCounts: (friendCount, allContentCount) => {
+    set((state) =>
+      state.mapFriendLocationCount === friendCount &&
+      state.mapAllContentLocationCount === allContentCount
+        ? state
+        : {
+            mapFriendLocationCount: friendCount,
+            mapAllContentLocationCount: allContentCount,
+          },
+    );
+  },
   visibleFeedTotalCount: 0,
   syncConnected: false,
   isLoading: true,

--- a/packages/shared/src/store-types.ts
+++ b/packages/shared/src/store-types.ts
@@ -119,6 +119,8 @@ export interface BaseAppState {
   mapFriendLocationCount: number;
   /** Authors with recent mapped content. Derived off the render path. */
   mapAllContentLocationCount: number;
+  /** Publish the exact derived marker counts for shared map navigation chrome. */
+  setMapLocationCounts: (friendCount: number, allContentCount: number) => void;
   /** Exact SQLite count for the active bounded feed query. */
   visibleFeedTotalCount: number;
 

--- a/packages/ui/src/components/map/MapView.test.tsx
+++ b/packages/ui/src/components/map/MapView.test.tsx
@@ -1,0 +1,134 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import type { BaseAppState, FeedItem, Friend, ResolvedLocationItem } from "@freed/shared";
+
+const setMapLocationCounts = vi.hoisted(() => vi.fn());
+const resolvedItems = vi.hoisted(() => [] as ResolvedLocationItem[]);
+
+const appState = {
+  searchCorpusVersion: 1,
+  selectedPersonId: null,
+  setSelectedPerson: vi.fn(),
+  setSelectedAccount: vi.fn(),
+  setSelectedItem: vi.fn(),
+  setActiveView: vi.fn(),
+  setFilter: vi.fn(),
+  setSearchQuery: vi.fn(),
+  setMapLocationCounts,
+} as unknown as BaseAppState;
+
+vi.mock("../../context/PlatformContext.js", () => ({
+  useAppStore: <T,>(selector: (state: BaseAppState) => T) => selector(appState),
+}));
+
+vi.mock("../../hooks/useLibrarySurfaceItems.js", () => ({
+  useLibraryMapCandidates: () => [],
+}));
+
+vi.mock("../../hooks/useResolvedLocations.js", () => ({
+  useResolvedLocationCandidates: () => ({ resolvedItems }),
+}));
+
+vi.mock("../../lib/device-display-preferences.js", () => ({
+  useDeviceDisplayPreferences: () => [{ mapMode: "friends" }, vi.fn()],
+}));
+
+vi.mock("../../lib/theme.js", () => ({
+  useAppliedThemeId: () => "system",
+}));
+
+vi.mock("./MapSurface.js", () => ({
+  MapSurface: () => null,
+}));
+
+import { MapView } from "./MapView";
+
+function item(globalId: string, authorId: string, publishedAt: number): FeedItem {
+  return {
+    globalId,
+    platform: "instagram",
+    contentType: "post",
+    capturedAt: publishedAt,
+    publishedAt,
+    author: {
+      id: authorId,
+      handle: authorId,
+      displayName: authorId,
+    },
+    content: {
+      text: "Mapped update",
+      mediaUrls: [],
+      mediaTypes: [],
+    },
+    userState: {
+      hidden: false,
+      saved: false,
+      archived: false,
+      tags: [],
+    },
+    topics: [],
+  };
+}
+
+describe("MapView location counts", () => {
+  let container: HTMLDivElement | null = null;
+  let root: Root | null = null;
+
+  beforeAll(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container?.remove();
+    container = null;
+    root = null;
+    resolvedItems.splice(0);
+    setMapLocationCounts.mockReset();
+  });
+
+  it("publishes the rendered Friend and all-content marker counts", async () => {
+    const now = Date.now();
+    const friend: Friend = {
+      id: "friend-ada",
+      name: "Ada Lovelace",
+      relationshipStatus: "friend",
+      sources: [],
+      careLevel: 4,
+      createdAt: now,
+      updatedAt: now,
+    };
+    resolvedItems.push(
+      {
+        accountId: null,
+        friend,
+        item: item("instagram:ada", "ada", now),
+        lat: 48.8566,
+        lng: 2.3522,
+        label: "Paris",
+      },
+      {
+        accountId: null,
+        friend: null,
+        item: item("instagram:grace", "grace", now - 1_000),
+        lat: 51.5072,
+        lng: -0.1276,
+        label: "London",
+      },
+    );
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+
+    await act(async () => {
+      root!.render(<MapView />);
+    });
+
+    expect(setMapLocationCounts).toHaveBeenLastCalledWith(1, 2);
+  });
+});

--- a/packages/ui/src/components/map/MapView.tsx
+++ b/packages/ui/src/components/map/MapView.tsx
@@ -149,6 +149,7 @@ export function MapView({ viewportInsets }: MapViewProps) {
   const setActiveView = useAppStore((state) => state.setActiveView);
   const setFilter = useAppStore((state) => state.setFilter);
   const setSearchQuery = useAppStore((state) => state.setSearchQuery);
+  const setMapLocationCounts = useAppStore((state) => state.setMapLocationCounts);
   const [deviceDisplay] = useDeviceDisplayPreferences();
   const themeId = useAppliedThemeId();
   const [rangeSelection, setRangeSelection] = useState<LocationTimeRange | null>(null);
@@ -182,6 +183,11 @@ export function MapView({ viewportInsets }: MapViewProps) {
       }),
     [effectiveTimeRange, resolvedItems],
   );
+
+  useEffect(() => {
+    setMapLocationCounts(friendMarkers.length, allContentMarkers.length);
+  }, [allContentMarkers.length, friendMarkers.length, setMapLocationCounts]);
+
   const effectiveMode = resolveMapMode(
     deviceDisplay.mapMode,
     friendMarkers.length,


### PR DESCRIPTION
(AI Generated).

## Summary
- Publish exact Friend and all-content marker counts to the shared header and sidebar state
- Avoid redundant store updates when the derived counts are unchanged

## Testing
- npm run validate:feature
- Live PWA preview shows 41 friends and 52 all-content accounts on the map

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `c805f3011bfd392e69da39213b9a695d99db2a47`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-map-location-count-20260831`
- Provider review decision: `diff_authorized`
- Provider review artifact: `4f7eb245de72e836a7c71b521aba13ed5c0326f862cf141cc49c14e70cea8ff6`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider-observable behavior is unchanged. The classified platform store files only receive an in-memory map marker count action used by shared navigation chrome.
- Fingerprinting risk: None added. This diff does not change provider requests, navigation, timing, cookies, headers, extraction, authentication, retries, or traffic cadence.
- Lowest profile alternative: Keep all provider traffic disabled while validating the map count against isolated local sample data.

Files bound into this provider review:
- `packages/desktop/src/lib/store.ts`
- `packages/pwa/src/lib/store.ts`