### PR TITLE
fix: reject corrupted PWA media ranges

### DIFF
--- a/packages/pwa/src/lib/library-core-opfs-content-vault.test.ts
+++ b/packages/pwa/src/lib/library-core-opfs-content-vault.test.ts
@@ -376,7 +376,7 @@ describe("PWA Library Core OPFS content vault", () => {
     ).toEqual([0]);
   });
 
-  it("refuses complete availability when a cached range changes after publication", async () => {
+  it("refuses full reads and complete availability when cached bytes change", async () => {
     const bytes = Uint8Array.from([7, 8, 9, 10]);
     const contentDigest = installRange(bytes);
     const storage = new MemoryRangeStorage();
@@ -402,10 +402,29 @@ describe("PWA Library Core OPFS content vault", () => {
     );
     storage.objects.set(storageKey, Uint8Array.from([7, 8, 9, 11]));
     await expect(
+      vault.read({
+        accessedAt: 21,
+        contentDigest,
+        maximumBytes: bytes.byteLength,
+        rangeIndex: 0,
+        rangeOffset: 0,
+        schemaVersion: 1,
+      }),
+    ).rejects.toThrow(/range digest is invalid/);
+    expect(
+      engine.readContentState({ contentDigest, schemaVersion: 1 }),
+    ).toMatchObject({
+      availability: {
+        completeDigestVerifiedAt: null,
+        hydrationState: "corrupt",
+      },
+      contentRevision: 2,
+    });
+    await expect(
       vault.verifyComplete({
         contentDigest,
         schemaVersion: 1,
-        verifiedAt: 21,
+        verifiedAt: 22,
       }),
     ).rejects.toThrow(/complete content digest is invalid/);
     expect(
@@ -415,7 +434,7 @@ describe("PWA Library Core OPFS content vault", () => {
         completeDigestVerifiedAt: null,
         hydrationState: "corrupt",
       },
-      contentRevision: 2,
+      contentRevision: 3,
     });
   });
 

--- a/packages/pwa/src/lib/library-core-opfs-content-vault.ts
+++ b/packages/pwa/src/lib/library-core-opfs-content-vault.ts
@@ -246,6 +246,20 @@ export class PwaLibraryCoreOpfsContentVault {
     if (bytes.byteLength !== expectedBytes) {
       throw new Error("verified content range object is truncated");
     }
+    if (
+      request.rangeOffset === 0 &&
+      bytes.byteLength === proof.byteLength
+    ) {
+      const hash = createLibraryCoreMediaBlobDigestStateV1();
+      hash.update(bytes);
+      if (hash.digestLowerHex() !== proof.rangeContentDigest) {
+        this.#engine.markContentCorrupt(
+          request.contentDigest,
+          request.accessedAt,
+        );
+        throw new Error("verified content range digest is invalid");
+      }
+    }
     this.#engine.markContentAccessed(request.contentDigest, request.accessedAt);
     const response = parseLibraryCoreContentRangeReadResponseV1({
       bytes,

--- a/packages/pwa/src/lib/library-core-sqlite-engine.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.ts
@@ -3313,7 +3313,11 @@ export class PwaLibraryCoreSqliteEngine {
   readVerifiedContentRangeReadProof(
     contentDigest: string,
     rangeIndex: number,
-  ): Readonly<{ byteLength: number; storageKey: string }> {
+  ): Readonly<{
+    byteLength: number;
+    rangeContentDigest: string;
+    storageKey: string;
+  }> {
     if (
       !isLibraryCoreLowercaseHex64(contentDigest) ||
       !Number.isSafeInteger(rangeIndex) ||
@@ -3322,7 +3326,8 @@ export class PwaLibraryCoreSqliteEngine {
       throw new TypeError("verified content range read identity is invalid");
     }
     const rows = this.#database.exec({
-      sql: `SELECT local.verified_byte_length, local.storage_key
+      sql: `SELECT local.verified_byte_length, local.storage_key,
+                   canonical.range_digest
             FROM library_device_content_ranges AS local
             JOIN library_content_ranges AS canonical
               ON canonical.content_digest = local.content_digest
@@ -3342,6 +3347,10 @@ export class PwaLibraryCoreSqliteEngine {
     }
     return Object.freeze({
       byteLength: safeInteger(rows[0]![0], "verified content range length"),
+      rangeContentDigest: text(
+        rows[0]![2],
+        "verified content range digest",
+      ),
       storageKey: text(rows[0]![1], "verified content range storage key"),
     });
   }


### PR DESCRIPTION
(AI Generated).

## Summary
- Recheck the canonical range digest whenever a complete verified OPFS range is read.
- Mark same-length mutated media as corrupt and refuse it before returning bytes.

## Testing
- npm run validate:feature
- Focused OPFS content-vault unit test, 5 tests passed in 1.62 seconds