### PR TITLE
fix: recover orphaned PWA preview checkpoints

### DIFF
--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -33,6 +33,11 @@
       idempotent replay after each restart. This deterministic browser gate
       does not replace the physical iPhone suspension, quota, and playback
       evidence above.
+- [x] Recover an interrupted local sample-library bootstrap only when the
+      selected checkpoint carries the complete synthetic preview receipt.
+      Native and browser checkpoint replacement clear the retired follower
+      enrollment singleton before creating the new actor. A real connected
+      Library with missing or mismatched local authority still fails closed.
 - [x] Run official SQLite WebAssembly through one dedicated Library worker over
       the high-performance `opfs-sahpool` VFS, with one bounded protocol, one
       connection generation, one cross-window Library lock, exact schema

--- a/packages/library-core-native/src/normalized_import.rs
+++ b/packages/library-core-native/src/normalized_import.rs
@@ -610,6 +610,7 @@ fn clear_checkpoint_replacement_target(
          DELETE FROM library_transactions;
          DELETE FROM library_invalidations;
          DELETE FROM library_follower_checkpoint_receipt;
+         DELETE FROM library_follower_actor_request;
          DELETE FROM library_device_scope_action_members;
          DELETE FROM library_device_scope_actions;
          DELETE FROM library_device_person_graph_layout;

--- a/packages/pwa/src/lib/library-core-preview-bootstrap.ts
+++ b/packages/pwa/src/lib/library-core-preview-bootstrap.ts
@@ -80,6 +80,7 @@ function digest(
 
 async function createPreviewLibrary(): Promise<void> {
   const selected = await readPwaNormalizedCheckpointReceipt();
+  let replaceExistingCheckpoint = false;
   let authority: PwaLibraryCoreLocalSampleAuthority | null;
   try {
     authority = await readPwaLibraryCoreLocalSampleAuthority();
@@ -97,11 +98,27 @@ async function createPreviewLibrary(): Promise<void> {
   }
   if (selected.receipt) {
     if (!authority || authority.libraryId !== selected.receipt.libraryId) {
-      throw new Error(
-        "Sample data is available only in an unconnected local Library",
-      );
+      const isOrphanedPreviewCheckpoint =
+        selected.receipt.checkpointGeneration === 0 &&
+        selected.receipt.sourceRevision === 0 &&
+        selected.receipt.controlRevision.startsWith("preview:") &&
+        selected.receipt.manifestObjectKey ===
+          `preview/checkpoint/${selected.receipt.libraryId}` &&
+        selected.receipt.manifestTransportObjectId.startsWith("preview:");
+      if (!isOrphanedPreviewCheckpoint) {
+        throw new Error(
+          "Sample data is available only in an unconnected local Library",
+        );
+      }
+      // OPFS and IndexedDB do not share a transaction. WebKit can therefore
+      // preserve the activated preview checkpoint while losing its browser key
+      // record after an interrupted launch. Only our fully identified preview
+      // receipt is safe to rebuild. A connected Library still fails closed.
+      await deletePwaLibraryCoreLocalSampleAuthority();
+      authority = null;
+      replaceExistingCheckpoint = true;
     }
-    if (authority.status === "ready") {
+    if (authority?.status === "ready") {
       if (authority.preparedResult) {
         const receipt = await applyPwaFollowerResult({
           canonicalResultBytes: authority.preparedResult.canonicalResultBytes,
@@ -132,9 +149,11 @@ async function createPreviewLibrary(): Promise<void> {
       }
       return;
     }
-    await resetPwaNormalizedLibrary();
-    await deletePwaLibraryCoreLocalSampleAuthority();
-    authority = null;
+    if (authority) {
+      await resetPwaNormalizedLibrary();
+      await deletePwaLibraryCoreLocalSampleAuthority();
+      authority = null;
+    }
   } else if (authority) {
     await resetPwaNormalizedLibrary();
     await deletePwaLibraryCoreLocalSampleAuthority();
@@ -250,7 +269,7 @@ async function createPreviewLibrary(): Promise<void> {
       manifestTransportObjectId: `preview:${randomHex64()}`,
       writerActorId,
     },
-    replaceExisting: false,
+    replaceExisting: replaceExistingCheckpoint,
     stageId,
   });
 

--- a/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
@@ -5710,7 +5710,13 @@ describe("PWA Library Core SQLite engine", () => {
     engine.initialize();
     database.exec(
       `INSERT INTO library_preferences (path, value_type, updated_at)
-       VALUES ('v:$.old', 'null', 1);`,
+       VALUES ('v:$.old', 'null', 1);
+       INSERT INTO library_follower_actor_request
+         (singleton_id, library_id, authority_epoch_id, actor_id,
+          actor_public_key, enrollment_request_digest,
+          canonical_enrollment_request, created_at)
+       VALUES (1, 'old-library', 'old-epoch', '${"a".repeat(64)}',
+               '${"b".repeat(64)}', '${"c".repeat(64)}', '{}', 1);`,
     );
     const records = [checkpointHeader(), ...authorityRecords()];
     stageRecords(engine, records, "replacement");
@@ -5730,6 +5736,13 @@ describe("PWA Library Core SQLite engine", () => {
     expect(
       database.exec({
         sql: "SELECT count(*) FROM library_preferences;",
+        rowMode: 0,
+        returnValue: "resultRows",
+      }),
+    ).toEqual([0]);
+    expect(
+      database.exec({
+        sql: "SELECT count(*) FROM library_follower_actor_request;",
         rowMode: 0,
         returnValue: "resultRows",
       }),

--- a/packages/pwa/src/lib/library-core-sqlite-engine.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.ts
@@ -1522,6 +1522,7 @@ export class PwaLibraryCoreSqliteEngine {
           DELETE FROM library_transactions;
           DELETE FROM library_invalidations;
           DELETE FROM library_follower_checkpoint_receipt;
+          DELETE FROM library_follower_actor_request;
           DELETE FROM library_device_scope_action_members;
           DELETE FROM library_device_scope_actions;
           DELETE FROM library_device_person_graph_layout;


### PR DESCRIPTION
(AI Generated).

## Summary
- Rebuild only fully identified synthetic preview checkpoints when WebKit preserves OPFS without the matching browser authority record.
- Clear the retired follower enrollment singleton during checkpoint replacement in both browser and native SQLite.

## Testing
- npm run validate:feature
- PWA WebKit OPFS durability: 1 passed
- PWA unit tests: 311 passed
- Library Core native tests: 182 passed