### PR TITLE
chore: prepare v26.8.3101-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.3100",
+  "version": "26.8.3101",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.3100"
+version = "26.8.3101"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.3100"
+version = "26.8.3101"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.3100",
+  "version": "26.8.3101",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.3100",
+  "version": "26.8.3101",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.31.json
+++ b/release-notes/daily/dev/26.8.31.json
@@ -2,13 +2,19 @@
   "channel": "dev",
   "dayKey": "26.8.31",
   "date": "2026-08-31",
-  "preferredDeck": null,
+  "preferredDeck": "Reliable PWA recovery and Google Drive authentication",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
-  "pinnedHighlights": [],
-  "editorialNotes": [],
-  "updatedAt": "2026-08-31T13:58:55.021Z"
+  "pinnedHighlights": [
+    "Physical iPhone PWA acceptance",
+    "Refresh a rejected Google Drive access token and retry the exact failed Library request once",
+    "Recover an interrupted local sample Library without touching a connected Library"
+  ],
+  "editorialNotes": [
+    "Carry the complete v26.8.3100-dev story forward and add the Drive retry plus orphaned sample Library recovery."
+  ],
+  "updatedAt": "2026-08-31T18:19:25.439Z"
 }

--- a/release-notes/releases/v26.8.3101-dev.json
+++ b/release-notes/releases/v26.8.3101-dev.json
@@ -1,0 +1,118 @@
+{
+  "tag": "v26.8.3101-dev",
+  "version": "26.8.3101-dev",
+  "channel": "dev",
+  "dayKey": "26.8.31",
+  "approved": true,
+  "editorialNotes": [
+    "Carry the complete v26.8.3100-dev story forward and lead with the safe PWA preview recovery plus Google Drive authentication repair."
+  ],
+  "generatedAt": "2026-08-31T18:19:25.437Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.3100-dev",
+    "previousPublishedDayTag": "v26.8.3006-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "497d05684928461d9efe9a42281cde098cdbfecd",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.3100-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "588249d423749ad08509cad671c7708a54d46166",
+        "toInclusiveProductCommitSha": "497d05684928461d9efe9a42281cde098cdbfecd"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:4d7c2db521ba065c6a7247dab856a2228bdf3ecb42d9b0022f3d8131200c46a8",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.3100-dev",
+      "v26.8.3101-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.3100-dev",
+      "v26.8.3101-dev"
+    ],
+    "prNumbers": [
+      1673,
+      1677,
+      1678,
+      1679,
+      1680,
+      1681,
+      1682,
+      1683,
+      1684,
+      1685,
+      1686,
+      1687,
+      1688,
+      1690,
+      1692
+    ],
+    "commitSubjects": [
+      "fix: recover orphaned PWA preview checkpoints (#1692)",
+      "fix: reject corrupted PWA media ranges (#1690)",
+      "chore: add WebKit PWA corpus hardening (#1688)",
+      "fix: publish accurate map location counts (#1687)",
+      "chore: prepare v26.8.3100-dev (#1686)",
+      "fix: make feed performance probes honest (#1685)",
+      "fix: preserve PWA SQLite quota failures (#1684)",
+      "perf: add PWA OPFS corpus hardening (#1683)",
+      "fix: clear retained Friends recovery errors (#1682)",
+      "perf: replace Friends offset pagination with keysets (#1681)",
+      "fix: bootstrap clean Vercel deployments (#1680)",
+      "fix: package PWA deployment guards (#1679)",
+      "perf: reduce PWA install bundle (#1678)",
+      "fix: recover Google Drive sync authentication (#1677)",
+      "test: repair PWA browser fixture preferences (#1676)",
+      "fix: restore PWA sample library context (#1673)"
+    ]
+  },
+  "release": {
+    "deck": "Reliable PWA recovery and Google Drive authentication",
+    "features": [
+      "Open Map and Friends on demand while keeping return visits available offline",
+      "Keep PWA feeds and search bounded across 100,000 locally stored items",
+      "Page large Friends directories with stable SQLite keyset cursors"
+    ],
+    "fixes": [
+      "Recover an interrupted local sample Library without touching a connected Library",
+      "Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite",
+      "Reject corrupted PWA media ranges before they become available offline",
+      "Publish accurate location counts in Map",
+      "Preserve the original storage-full error and retry safely after PWA SQLite quota failures",
+      "Restore durable sample Library context across reloads and WebKit process exits",
+      "Refresh Google Drive authentication once and retry the exact failed request after a 401",
+      "Expose normal manual Google Drive sync to the installed verification trigger",
+      "Clear stale Friends recovery errors after WebGPU falls back to healthy WebGL2",
+      "Keep PWA browser fixtures from writing synchronized device preferences",
+      "Make feed performance checks report inconclusive evidence instead of synthetic success",
+      "Keep mobile Settings breadcrumbs aligned with the final section at the bottom of the page",
+      "Make clean PWA preview deployments include their required guards and project binding"
+    ],
+    "followUps": [
+      "Run installed build verification in an isolated profile",
+      "Complete physical iPhone PWA acceptance",
+      "Extend large-library proof to WebKit and whole-process memory",
+      "Verify the first Google Drive publication and exact retry against the real local Library"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3101-dev\n\nReliable PWA recovery and Google Drive authentication\n\n### Features\n\n- Open Map and Friends on demand while keeping return visits available offline\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n- Page large Friends directories with stable SQLite keyset cursors\n\n### Fixes\n\n- Recover an interrupted local sample Library without touching a connected Library\n- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite\n- Reject corrupted PWA media ranges before they become available offline\n- Publish accurate location counts in Map\n- Preserve the original storage-full error and retry safely after PWA SQLite quota failures\n- Restore durable sample Library context across reloads and WebKit process exits\n- Refresh Google Drive authentication once and retry the exact failed request after a 401\n- Expose normal manual Google Drive sync to the installed verification trigger\n- Clear stale Friends recovery errors after WebGPU falls back to healthy WebGL2\n- Keep PWA browser fixtures from writing synchronized device preferences\n- Make feed performance checks report inconclusive evidence instead of synthetic success\n- Keep mobile Settings breadcrumbs aligned with the final section at the bottom of the page\n- Make clean PWA preview deployments include their required guards and project binding\n\n### Follow-ups\n\n- Run installed build verification in an isolated profile\n- Complete physical iPhone PWA acceptance\n- Extend large-library proof to WebKit and whole-process memory\n- Verify the first Google Drive publication and exact retry against the real local Library\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.3101-dev.md
+++ b/release-notes/releases/v26.8.3101-dev.md
@@ -1,0 +1,42 @@
+(AI Generated).
+
+## Freed v26.8.3101-dev
+
+Reliable PWA recovery and Google Drive authentication
+
+### Features
+
+- Open Map and Friends on demand while keeping return visits available offline
+- Keep PWA feeds and search bounded across 100,000 locally stored items
+- Page large Friends directories with stable SQLite keyset cursors
+
+### Fixes
+
+- Recover an interrupted local sample Library without touching a connected Library
+- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite
+- Reject corrupted PWA media ranges before they become available offline
+- Publish accurate location counts in Map
+- Preserve the original storage-full error and retry safely after PWA SQLite quota failures
+- Restore durable sample Library context across reloads and WebKit process exits
+- Refresh Google Drive authentication once and retry the exact failed request after a 401
+- Expose normal manual Google Drive sync to the installed verification trigger
+- Clear stale Friends recovery errors after WebGPU falls back to healthy WebGL2
+- Keep PWA browser fixtures from writing synchronized device preferences
+- Make feed performance checks report inconclusive evidence instead of synthetic success
+- Keep mobile Settings breadcrumbs aligned with the final section at the bottom of the page
+- Make clean PWA preview deployments include their required guards and project binding
+
+### Follow-ups
+
+- Run installed build verification in an isolated profile
+- Complete physical iPhone PWA acceptance
+- Extend large-library proof to WebKit and whole-process memory
+- Verify the first Google Drive publication and exact retry against the real local Library
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the cumulative August 31 dev release with interrupted PWA sample Library recovery and follower-enrollment cleanup.
- Carry forward the Google Drive OAuth 401 refresh-and-retry fix and current large-library PWA improvements.

## Testing
- PLAYWRIGHT_PORT=1422 npm run validate:feature
- PWA WebKit OPFS durability lifecycle
- Desktop native and Library Core native test suites