### PR TITLE
fix: keep PWA previews on the reported port

### DIFF
--- a/scripts/worktree-preview.sh
+++ b/scripts/worktree-preview.sh
@@ -148,8 +148,8 @@ case "${TARGET}" in
         "VITE_FREED_FEATURE_PREVIEW=1"
         "VITE_FREED_PREVIEW_LABEL=${PREVIEW_LABEL}"
       )
-      RUN_ARGS=("${NPM_BIN}" "run" "dev" "--" "--port" "${PORT}")
-      COMMAND_DISPLAY="cd packages/desktop && PATH=${ROOT_BIN_DIR}:\$PATH VITE_TEST_TAURI=1 VITE_FREED_FEATURE_PREVIEW=1 VITE_FREED_PREVIEW_LABEL=${PREVIEW_LABEL} npm run dev -- --port ${PORT}"
+      RUN_ARGS=("${NPM_BIN}" "run" "dev" "--" "--port" "${PORT}" "--strictPort")
+      COMMAND_DISPLAY="cd packages/desktop && PATH=${ROOT_BIN_DIR}:\$PATH VITE_TEST_TAURI=1 VITE_FREED_FEATURE_PREVIEW=1 VITE_FREED_PREVIEW_LABEL=${PREVIEW_LABEL} npm run dev -- --port ${PORT} --strictPort"
       URL="http://localhost:${PORT}"
     fi
     ;;
@@ -163,8 +163,8 @@ case "${TARGET}" in
       "VITE_FREED_FEATURE_PREVIEW=1"
       "VITE_FREED_PREVIEW_LABEL=${PREVIEW_LABEL}"
     )
-    RUN_ARGS=("${NPM_BIN}" "run" "dev" "--" "--port" "${PORT}")
-    COMMAND_DISPLAY="cd packages/pwa && PATH=${ROOT_BIN_DIR}:\$PATH VITE_FREED_FEATURE_PREVIEW=1 VITE_FREED_PREVIEW_LABEL=${PREVIEW_LABEL} npm run dev -- --port ${PORT}"
+    RUN_ARGS=("${NPM_BIN}" "run" "dev" "--" "--port" "${PORT}" "--strictPort")
+    COMMAND_DISPLAY="cd packages/pwa && PATH=${ROOT_BIN_DIR}:\$PATH VITE_FREED_FEATURE_PREVIEW=1 VITE_FREED_PREVIEW_LABEL=${PREVIEW_LABEL} npm run dev -- --port ${PORT} --strictPort"
     URL="http://localhost:${PORT}"
     ;;
   website)

--- a/scripts/worktree-preview.test.mjs
+++ b/scripts/worktree-preview.test.mjs
@@ -84,6 +84,23 @@ test("worktree-preview marks product previews as feature previews", () => {
   );
 });
 
+test("Vite worktree previews fail instead of moving to an untracked port", () => {
+  const script = readFileSync(path.join(repoRoot, "scripts/worktree-preview.sh"), "utf8");
+
+  assert.equal(
+    (script.match(/RUN_ARGS=.*"--strictPort"/g) ?? []).length,
+    2,
+  );
+  assert.match(
+    script,
+    /cd packages\/desktop .*npm run dev -- --port \$\{PORT\} --strictPort/,
+  );
+  assert.match(
+    script,
+    /cd packages\/pwa .*npm run dev -- --port \$\{PORT\} --strictPort/,
+  );
+});
+
 test("native worktree previews cannot reuse the production bundle identifier", () => {
   const script = readFileSync(path.join(repoRoot, "scripts/worktree-preview.sh"), "utf8");
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Make Vite reject an occupied preview port instead of silently moving to another port.
- Apply the same fail-closed behavior to mocked Freed Desktop previews.

## Testing
- Pinned Node 24.14.1 feature validation.
- Focused worktree preview tests, 5 passed.
- Live IPv6 port collision exited immediately without starting an untracked preview.