### PR TITLE
fix: reject unrelated Playwright servers

### DIFF
--- a/packages/desktop/playwright.config.ts
+++ b/packages/desktop/playwright.config.ts
@@ -1,14 +1,19 @@
 import { defineConfig, devices } from "@playwright/test";
 import { createHash } from "node:crypto";
+import { findFreePort } from "../../scripts/lib/find-free-port.mjs";
 
 const USE_LOCAL_SERVER = !process.env.BASE_URL;
 const DEFAULT_PORT = 1422;
 const WORKTREE_PORT_SPAN = 20_000;
 const configuredPort = Number.parseInt(process.env.PLAYWRIGHT_PORT ?? "", 10);
 const worktreePortOffset = createHash("sha1").update(process.cwd()).digest().readUInt16BE(0) % WORKTREE_PORT_SPAN;
-const defaultPort = Number.isFinite(configuredPort) && configuredPort > 0
+const hasConfiguredPort = Number.isInteger(configuredPort) && configuredPort > 0 && configuredPort <= 65_535;
+const defaultPort = hasConfiguredPort
   ? configuredPort
-  : DEFAULT_PORT + worktreePortOffset;
+  : await findFreePort(DEFAULT_PORT + worktreePortOffset);
+if (!hasConfiguredPort) {
+  process.env.PLAYWRIGHT_PORT = String(defaultPort);
+}
 const BASE_URL = process.env.BASE_URL ?? `http://127.0.0.1:${String(defaultPort)}`;
 
 export default defineConfig({
@@ -40,7 +45,7 @@ export default defineConfig({
     ? {
         command: `${process.execPath} ../../node_modules/vite/bin/vite.js --host 127.0.0.1 --port ${String(defaultPort)} --strictPort`,
         url: BASE_URL,
-        reuseExistingServer: !process.env.CI,
+        reuseExistingServer: false,
         timeout: 60_000,
         env: {
           VITE_TEST_TAURI: "1",

--- a/scripts/worktree-preview.test.mjs
+++ b/scripts/worktree-preview.test.mjs
@@ -56,6 +56,28 @@ test("findFreePort skips a port that is only occupied on IPv6", async (t) => {
   assert.notEqual(candidate, address.port);
 });
 
+test("Desktop Playwright skips unrelated listeners and never reuses a server", async (t) => {
+  const server = net.createServer((_socket) => {
+    // The listener deliberately is not a Freed Vite server.
+  });
+  t.after(async () => {
+    await close(server);
+  });
+
+  await listen(server, 0, "127.0.0.1");
+  const address = server.address();
+  assert.ok(address && typeof address === "object" && "port" in address);
+
+  const candidate = await findFreePort(address.port, 5);
+  assert.notEqual(candidate, address.port);
+
+  const config = readFileSync(path.join(repoRoot, "packages/desktop/playwright.config.ts"), "utf8");
+  assert.match(config, /await findFreePort\(DEFAULT_PORT \+ worktreePortOffset\)/);
+  assert.match(config, /process\.env\.PLAYWRIGHT_PORT = String\(defaultPort\)/);
+  assert.match(config, /reuseExistingServer: false/);
+  assert.doesNotMatch(config, /reuseExistingServer: !process\.env\.CI/);
+});
+
 test("worktree-preview help prints usage", () => {
   const result = spawnSync("bash", ["scripts/worktree-preview.sh", "--help"], {
     cwd: repoRoot,


### PR DESCRIPTION
(AI Generated).

## Summary
- Select a verified free worktree port and pin it across Playwright worker config loads.
- Reject an occupied explicit port instead of reusing an unrelated HTTP service.
- Closes #1691.

## Testing
- Pinned Node 24.14.1: node --test scripts/worktree-preview.test.mjs
- 403 collision reproduction rejected the unrelated listener before test execution.
- Pinned Node 24.14.1: npm run validate:feature