### PR TITLE
fix: keep sync status control stable

### DIFF
--- a/packages/desktop/tests/e2e/google-contacts.spec.ts
+++ b/packages/desktop/tests/e2e/google-contacts.spec.ts
@@ -250,7 +250,8 @@ test("slow Google Contacts sync appears in the global background activity popove
 
   await popover.getByRole("button", { name: "Close" }).click();
   await expect(popover).toHaveCount(0);
-  await expect(trigger).toHaveCount(0);
+  await expect(trigger).toBeVisible();
+  await expect(trigger).toHaveAttribute("aria-label", "Background activity: Last activity succeeded");
 });
 
 test("People API failures surface reconnect state instead of failing silently", async ({ app }) => {

--- a/packages/desktop/tests/e2e/provider-health.spec.ts
+++ b/packages/desktop/tests/e2e/provider-health.spec.ts
@@ -1739,38 +1739,26 @@ test("settings sources nav shows provider status dots", async ({ app, page }) =>
   expect(Math.abs(sidebarIndicatorSizes!.settingsHeight - sidebarIndicatorSizes!.sourceHeight)).toBeLessThanOrEqual(1);
 });
 
-test("provider sync button shows a spinner while that provider is active", async ({ app, page }) => {
+test("toolbar activity status stays mounted across idle, syncing, and completed states", async ({ app, page }) => {
   await seedAcceptedDesktopConsent(page);
 
   await app.goto();
   await app.waitForReady();
 
   await page.evaluate(async ({ activityStorePath }) => {
-    const w = window as Record<string, unknown>;
-    const store = w.__FREED_STORE__ as {
-      getState: () => {
-        providerSyncCounts: Record<string, number>;
-      };
-      setState: (partial: Record<string, unknown>) => void;
-    };
-    const current = store.getState().providerSyncCounts;
-    store.setState({
-      xAuth: {
-        isAuthenticated: true,
-        cookies: { ct0: "ct0", authToken: "token" },
-      },
-      fbAuth: {
-        isAuthenticated: true,
-      },
-      providerSyncCounts: {
-        ...current,
-        x: 1,
-      },
-    });
+    const activity = await import(activityStorePath) as typeof import("../../../ui/src/lib/background-activity-store");
+    activity.useBackgroundActivityStore.getState().clearBackgroundActivity();
+  }, { activityStorePath: BACKGROUND_ACTIVITY_STORE_PATH });
 
-    window.__freed.debug?.()?.addEvent("change", "[X] sync started");
-    window.__freed.debug?.()?.addEvent("change", "[X] requesting home timeline");
-    window.__freed.debug?.()?.addEvent("change", "[X] response received: 12,345 bytes");
+  const activityTrigger = page.getByTestId("background-activity-trigger");
+  const activityStatus = page.getByTestId("background-activity-status");
+  await expect(activityTrigger).toBeVisible();
+  await expect(activityTrigger).toHaveAttribute("aria-label", "Background activity: No recent activity");
+  await expect(activityStatus).toHaveAttribute("title", "No recent activity");
+  const idleBounds = await activityTrigger.boundingBox();
+  expect(idleBounds).not.toBeNull();
+
+  await page.evaluate(async ({ activityStorePath }) => {
     const activity = await import(activityStorePath) as typeof import("../../../ui/src/lib/background-activity-store");
     activity.startBackgroundActivity({
       id: "channel:x",
@@ -1791,8 +1779,13 @@ test("provider sync button shows a spinner while that provider is active", async
     }
   }, { activityStorePath: BACKGROUND_ACTIVITY_STORE_PATH });
 
-  const activityTrigger = page.getByTestId("background-activity-trigger");
   await expect(activityTrigger).toBeVisible();
+  await expect(activityTrigger).toHaveAttribute("aria-label", "Background activity: Syncing");
+  await expect(activityStatus).toHaveAttribute("title", "Syncing");
+  const syncingBounds = await activityTrigger.boundingBox();
+  expect(syncingBounds).not.toBeNull();
+  expect(syncingBounds!.x).toBe(idleBounds!.x);
+  expect(syncingBounds!.width).toBe(idleBounds!.width);
   await activityTrigger.click();
   const activityPopover = page.getByTestId("background-activity-popover");
   await expect(activityPopover).toBeVisible();
@@ -1831,9 +1824,43 @@ test("provider sync button shows a spinner while that provider is active", async
   await expect(activityPopover).toBeVisible();
   await expect(activityPopover).toContainText("0 active");
   await expect(activityTrigger).toBeVisible();
+  await expect(activityTrigger).toHaveAttribute("aria-label", "Background activity: Last activity succeeded");
+  await expect(activityStatus).toHaveAttribute("title", "Last activity succeeded");
+  const completedBounds = await activityTrigger.boundingBox();
+  expect(completedBounds).not.toBeNull();
+  expect(completedBounds!.x).toBe(idleBounds!.x);
+  expect(completedBounds!.width).toBe(idleBounds!.width);
   await page.keyboard.press("Escape");
   await expect(activityPopover).toHaveCount(0);
-  await expect(activityTrigger).toHaveCount(0);
+  await expect(activityTrigger).toBeVisible();
+
+  await page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const store = w.__FREED_STORE__ as {
+      getState: () => {
+        providerSyncCounts: Record<string, number>;
+      };
+      setState: (partial: Record<string, unknown>) => void;
+    };
+    const current = store.getState().providerSyncCounts;
+    store.setState({
+      xAuth: {
+        isAuthenticated: true,
+        cookies: { ct0: "ct0", authToken: "token" },
+      },
+      fbAuth: {
+        isAuthenticated: true,
+      },
+      providerSyncCounts: {
+        ...current,
+        x: 1,
+      },
+    });
+
+    window.__freed.debug?.()?.addEvent("change", "[X] sync started");
+    window.__freed.debug?.()?.addEvent("change", "[X] requesting home timeline");
+    window.__freed.debug?.()?.addEvent("change", "[X] response received: 12,345 bytes");
+  });
 
   await openSettingsSection(page, "X");
   const sidebar = getDesktopSidebar(page);

--- a/packages/ui/src/components/BackgroundActivityPopover.tsx
+++ b/packages/ui/src/components/BackgroundActivityPopover.tsx
@@ -208,7 +208,7 @@ export function BackgroundActivityPopover({
       role="dialog"
       aria-label="Background activity"
       data-testid="background-activity-popover"
-      className="theme-dialog-shell theme-menu-shell fixed z-[330] flex w-[min(28rem,calc(100vw-1.5rem))] flex-col !overflow-y-hidden rounded-[var(--card-radius)] border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-0 shadow-2xl shadow-black/45"
+      className="theme-dialog-shell theme-menu-shell fixed z-[330] flex w-[min(28rem,calc(100vw-1.5rem))] flex-col rounded-[var(--card-radius)] border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-0 shadow-2xl shadow-black/45"
       style={position}
     >
       <div className="sticky top-0 z-10 flex items-start justify-between gap-3 border-b border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] px-3 pb-2.5 pt-3">

--- a/packages/ui/src/components/icons.tsx
+++ b/packages/ui/src/components/icons.tsx
@@ -43,6 +43,28 @@ export function AllIcon({ className = "w-4 h-4", style }: IconProps) {
   );
 }
 
+/** Two circular arrows for neutral sync status. */
+export function RefreshIcon({ className = "w-4 h-4", style }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      style={style}
+      aria-hidden="true"
+    >
+      <path d="M20 12a8 8 0 0 0-13.66-5.66L4 8" />
+      <path d="M20 7v5h-5" />
+      <path d="M4 12a8 8 0 0 0 13.66 5.66L20 16" />
+      <path d="M4 17v-5h5" />
+    </svg>
+  );
+}
+
 /** Bookmark shape – saved items. */
 export function BookmarkIcon({ className = "w-4 h-4", style }: IconProps) {
   return (

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -24,12 +24,14 @@ import { THEME_DEFINITIONS, type ThemeId } from "@freed/shared/themes";
 import { Tooltip } from "../Tooltip.js";
 import { toast } from "../Toast.js";
 import { BackgroundActivityPopover } from "../BackgroundActivityPopover.js";
+import { ProviderStatusIndicator } from "../ProviderStatusIndicator.js";
 import { ThemePreviewButton } from "../ThemePreviewButton.js";
 import {
   ArchiveIcon,
   CloseIcon,
   FilterIcon,
   MenuIcon,
+  RefreshIcon,
   ReaderRailHideIcon,
   ReaderRailShowIcon,
   SidebarCollapseIcon,
@@ -422,10 +424,19 @@ export function Header({
       ? "Item unavailable"
       : "Loading item...";
   const activeBackgroundActivityCount = useBackgroundActivityStore((s) => Object.keys(s.active).length);
+  const latestBackgroundActivityLevel = useBackgroundActivityStore((s) => s.log[0]?.level);
   const backgroundActivityActive = activeBackgroundActivityCount > 0;
   const [activityPopoverOpen, setActivityPopoverOpen] = useState(false);
   const activityButtonRef = useRef<HTMLButtonElement | null>(null);
-  const showBackgroundActivityControl = backgroundActivityActive || activityPopoverOpen;
+  const backgroundActivityStatus = backgroundActivityActive
+    ? { label: "Syncing", tone: "healthy" as const }
+    : latestBackgroundActivityLevel === "error"
+      ? { label: "Last activity failed", tone: "critical" as const }
+      : latestBackgroundActivityLevel === "warning"
+        ? { label: "Last activity needs attention", tone: "warning" as const }
+        : latestBackgroundActivityLevel === "success"
+          ? { label: "Last activity succeeded", tone: "healthy" as const }
+          : { label: "No recent activity", tone: "idle" as const };
 
   const scopeLabel = useMemo(() => {
     const staticLabel = getStaticFilterLabel(activeFilter);
@@ -508,8 +519,7 @@ export function Header({
   const collapsedReaderBaseActionWidthRem = selectedItem?.sourceUrl
     ? showInlineReaderBookmark ? 11 : 8.5
     : showInlineReaderBookmark ? 6.5 : 3.5;
-  const collapsedReaderActionWidthRem =
-    collapsedReaderBaseActionWidthRem + (showBackgroundActivityControl ? 2.75 : 0);
+  const collapsedReaderActionWidthRem = collapsedReaderBaseActionWidthRem + 2.75;
   const collapsedReaderTitleStyle = readerActive && isBelowLargeToolbar
     ? ({ paddingRight: `${collapsedReaderActionWidthRem}rem` } as CSSProperties)
     : undefined;
@@ -1672,36 +1682,46 @@ export function Header({
             style={collapsedReaderActionStyle}
           >
             <ToolbarAnimatedSlot
-              visible={showBackgroundActivityControl}
+              visible={true}
               width={TOOLBAR_ICON_BUTTON_SIZE}
             >
-              {showBackgroundActivityControl ? (
-                <Tooltip label="Background activity">
-                  <button
-                    ref={activityButtonRef}
-                    type="button"
-                    onClick={handleToggleBackgroundActivity}
-                    {...getToolbarControlProps()}
-                    data-testid="background-activity-trigger"
-                    className={`${TOOLBAR_ICON_BUTTON_CLASS} ${
-                      activityPopoverOpen
-                        ? "theme-toolbar-button-active"
-                        : isMobileDevice
-                          ? "theme-toolbar-button-ghost"
-                          : "theme-toolbar-button-neutral"
-                    } text-[var(--theme-accent-secondary)]`}
-                    aria-haspopup="dialog"
-                    aria-expanded={activityPopoverOpen}
-                    aria-label="Show background activity"
-                  >
+              <Tooltip label={`Background activity: ${backgroundActivityStatus.label}`}>
+                <button
+                  ref={activityButtonRef}
+                  type="button"
+                  onClick={handleToggleBackgroundActivity}
+                  {...getToolbarControlProps()}
+                  data-testid="background-activity-trigger"
+                  className={`${TOOLBAR_ICON_BUTTON_CLASS} ${
+                    activityPopoverOpen
+                      ? "theme-toolbar-button-active"
+                      : isMobileDevice
+                        ? "theme-toolbar-button-ghost"
+                        : "theme-toolbar-button-neutral"
+                  }`}
+                  aria-haspopup="dialog"
+                  aria-expanded={activityPopoverOpen}
+                  aria-label={`Background activity: ${backgroundActivityStatus.label}`}
+                >
+                  {backgroundActivityStatus.tone === "idle" ? (
                     <span
-                      className={`h-3.5 w-3.5 rounded-full border border-current border-t-transparent ${
-                        backgroundActivityActive ? "animate-spin" : ""
-                      }`}
+                      className="inline-flex h-4 w-4 items-center justify-center"
+                      data-testid="background-activity-status"
+                      aria-label={backgroundActivityStatus.label}
+                      title={backgroundActivityStatus.label}
+                    >
+                      <RefreshIcon />
+                    </span>
+                  ) : (
+                    <ProviderStatusIndicator
+                      tone={backgroundActivityStatus.tone}
+                      syncing={backgroundActivityActive}
+                      label={backgroundActivityStatus.label}
+                      testId="background-activity-status"
                     />
-                  </button>
-                </Tooltip>
-              ) : null}
+                  )}
+                </button>
+              </Tooltip>
             </ToolbarAnimatedSlot>
 
             {readerActive && !selectedItem ? (


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the global activity button mounted in a fixed toolbar slot across idle, syncing, and completed states.
- Show a classic two-arrow refresh icon while idle, the existing spinner during active work, and colored status indicators after completion.
- Keep the activity log inside viewport scroll bounds so it cannot shift the toolbar.

## Testing
- Focused provider-health toolbar activity test passed.
- Focused Google Contacts background activity test passed.
- npm run validate:feature passed.