### PR TITLE
chore: prepare v26.8.3102-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.3101",
+  "version": "26.8.3102",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.3101"
+version = "26.8.3102"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.3101"
+version = "26.8.3102"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.3101",
+  "version": "26.8.3102",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.3101",
+  "version": "26.8.3102",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.8.31.json
+++ b/release-notes/daily/dev/26.8.31.json
@@ -16,5 +16,5 @@
   "editorialNotes": [
     "Carry the complete v26.8.3100-dev story forward and add the Drive retry plus orphaned sample Library recovery."
   ],
-  "updatedAt": "2026-08-31T19:37:29.200Z"
+  "updatedAt": "2026-08-31T22:06:44.670Z"
 }

--- a/release-notes/daily/dev/26.8.31.json
+++ b/release-notes/daily/dev/26.8.31.json
@@ -2,7 +2,7 @@
   "channel": "dev",
   "dayKey": "26.8.31",
   "date": "2026-08-31",
-  "preferredDeck": "Reliable PWA recovery and Google Drive authentication",
+  "preferredDeck": "Atomic Google Drive checkpoints and resilient PWA sample data",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
@@ -10,11 +10,11 @@
   ],
   "pinnedHighlights": [
     "Physical iPhone PWA acceptance",
-    "Refresh a rejected Google Drive access token and retry the exact failed Library request once",
-    "Recover an interrupted local sample Library without touching a connected Library"
+    "Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload",
+    "Show progress while importing or clearing sample data"
   ],
   "editorialNotes": [
-    "Carry the complete v26.8.3100-dev story forward and add the Drive retry plus orphaned sample Library recovery."
+    "Lead with the atomic Drive checkpoint fix and PWA sample-data recovery. Keep the remaining signed Drive verification explicit."
   ],
   "updatedAt": "2026-08-31T22:06:44.670Z"
 }

--- a/release-notes/releases/v26.8.3102-dev.json
+++ b/release-notes/releases/v26.8.3102-dev.json
@@ -106,21 +106,36 @@
   "release": {
     "deck": "Atomic Google Drive checkpoints and resilient PWA sample data",
     "features": [
-      "Anonymous release demo experience",
-      "Keep PWA feeds and search bounded across 100,000 locally stored items"
+      "Open Map and Friends on demand while keeping return visits available offline",
+      "Keep PWA feeds and search bounded across 100,000 locally stored items",
+      "Page large Friends directories with stable SQLite keyset cursors"
     ],
     "fixes": [
+      "Add an anonymous release demo experience",
       "Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload",
       "Refresh a rejected Google Drive access token and retry the exact failed Library request once",
-      "Show progress while importing or clearing sample data",
+      "Show live progress while a sample Library is being populated",
+      "Show progress while clearing sample data",
       "Recover an interrupted local sample Library without touching a connected Library",
+      "Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite",
       "Reject corrupted PWA media ranges before they become available offline",
-      "Keep PWA browser fixtures from writing synchronized device preferences"
+      "Publish accurate location counts in Map",
+      "Preserve the original storage-full error and retry safely after PWA SQLite quota failures",
+      "Restore durable sample Library context across reloads and WebKit process exits",
+      "Expose normal manual Google Drive sync to the installed verification trigger",
+      "Clear stale Friends recovery errors after WebGPU falls back to healthy WebGL2",
+      "Keep PWA browser fixtures from writing synchronized device preferences",
+      "Make feed performance checks report inconclusive evidence instead of synthetic success",
+      "Keep mobile Settings breadcrumbs aligned with the final section at the bottom of the page",
+      "Make clean PWA preview deployments include their required guards and project binding",
+      "Keep PWA previews on the requested local port"
     ],
     "followUps": [
       "Physical iPhone PWA acceptance",
+      "Run installed build verification in an isolated profile",
+      "Extend large-library proof to WebKit and whole-process memory",
       "Verify the first signed Google Drive publication against the real local Library"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3102-dev\n\nAtomic Google Drive checkpoints and resilient PWA sample data\n\n### Features\n\n- Anonymous release demo experience\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n\n### Fixes\n\n- Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload\n- Refresh a rejected Google Drive access token and retry the exact failed Library request once\n- Show progress while importing or clearing sample data\n- Recover an interrupted local sample Library without touching a connected Library\n- Reject corrupted PWA media ranges before they become available offline\n- Keep PWA browser fixtures from writing synchronized device preferences\n\n### Follow-ups\n\n- Physical iPhone PWA acceptance\n- Verify the first signed Google Drive publication against the real local Library\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3102-dev\n\nAtomic Google Drive checkpoints and resilient PWA sample data\n\n### Features\n\n- Open Map and Friends on demand while keeping return visits available offline\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n- Page large Friends directories with stable SQLite keyset cursors\n\n### Fixes\n\n- Add an anonymous release demo experience\n- Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload\n- Refresh a rejected Google Drive access token and retry the exact failed Library request once\n- Show live progress while a sample Library is being populated\n- Show progress while clearing sample data\n- Recover an interrupted local sample Library without touching a connected Library\n- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite\n- Reject corrupted PWA media ranges before they become available offline\n- Publish accurate location counts in Map\n- Preserve the original storage-full error and retry safely after PWA SQLite quota failures\n- Restore durable sample Library context across reloads and WebKit process exits\n- Expose normal manual Google Drive sync to the installed verification trigger\n- Clear stale Friends recovery errors after WebGPU falls back to healthy WebGL2\n- Keep PWA browser fixtures from writing synchronized device preferences\n- Make feed performance checks report inconclusive evidence instead of synthetic success\n- Keep mobile Settings breadcrumbs aligned with the final section at the bottom of the page\n- Make clean PWA preview deployments include their required guards and project binding\n- Keep PWA previews on the requested local port\n\n### Follow-ups\n\n- Physical iPhone PWA acceptance\n- Run installed build verification in an isolated profile\n- Extend large-library proof to WebKit and whole-process memory\n- Verify the first signed Google Drive publication against the real local Library\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.3102-dev.json
+++ b/release-notes/releases/v26.8.3102-dev.json
@@ -3,7 +3,7 @@
   "version": "26.8.3102-dev",
   "channel": "dev",
   "dayKey": "26.8.31",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-08-31T22:06:44.666Z",
   "model": "heuristic",
@@ -104,36 +104,23 @@
     ]
   },
   "release": {
-    "deck": "Reliable PWA recovery and Google Drive authentication",
+    "deck": "Atomic Google Drive checkpoints and resilient PWA sample data",
     "features": [
       "Anonymous release demo experience",
-      "Open Map and Friends on demand while keeping return visits available offline",
       "Keep PWA feeds and search bounded across 100,000 locally stored items"
     ],
     "fixes": [
-      "Release build and type-safety cleanup",
-      "Reader, feed, and header polish",
-      "Admit Google Drive installed sync trigger",
-      "Capture and scraper reliability fixes",
-      "Keep PWA browser fixtures from writing synchronized device preferences",
-      "Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite",
-      "Reject corrupted PWA media ranges before they become available offline",
+      "Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload",
       "Refresh a rejected Google Drive access token and retry the exact failed Library request once",
-      "Recover an interrupted local sample Library without touching a connected Library"
+      "Show progress while importing or clearing sample data",
+      "Recover an interrupted local sample Library without touching a connected Library",
+      "Reject corrupted PWA media ranges before they become available offline",
+      "Keep PWA browser fixtures from writing synchronized device preferences"
     ],
     "followUps": [
-      "Refresh v26.8.3101-dev identity",
-      "WebKit PWA corpus hardening",
-      "Prepare v26.8.3100-dev",
-      "Friends offset pagination with keysets",
-      "Reduce PWA install bundle",
-      "Page large Friends directories with stable SQLite keyset cursors",
-      "Smaller PWA installs, stronger local storage recovery, and faster large Libraries",
-      "Run installed build verification in an isolated profile",
       "Physical iPhone PWA acceptance",
-      "Extend large-library proof to WebKit and whole-process memory",
-      "Verify the first Google Drive publication and exact retry against the real local Library"
+      "Verify the first signed Google Drive publication against the real local Library"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3102-dev\n\nReliable PWA recovery and Google Drive authentication\n\n### Features\n\n- Anonymous release demo experience\n- Open Map and Friends on demand while keeping return visits available offline\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n\n### Fixes\n\n- Release build and type-safety cleanup\n- Reader, feed, and header polish\n- Admit Google Drive installed sync trigger\n- Capture and scraper reliability fixes\n- Keep PWA browser fixtures from writing synchronized device preferences\n- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite\n- Reject corrupted PWA media ranges before they become available offline\n- Refresh a rejected Google Drive access token and retry the exact failed Library request once\n- Recover an interrupted local sample Library without touching a connected Library\n\n### Follow-ups\n\n- Refresh v26.8.3101-dev identity\n- WebKit PWA corpus hardening\n- Prepare v26.8.3100-dev\n- Friends offset pagination with keysets\n- Reduce PWA install bundle\n- Page large Friends directories with stable SQLite keyset cursors\n- Smaller PWA installs, stronger local storage recovery, and faster large Libraries\n- Run installed build verification in an isolated profile\n- Physical iPhone PWA acceptance\n- Extend large-library proof to WebKit and whole-process memory\n- Verify the first Google Drive publication and exact retry against the real local Library\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3102-dev\n\nAtomic Google Drive checkpoints and resilient PWA sample data\n\n### Features\n\n- Anonymous release demo experience\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n\n### Fixes\n\n- Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload\n- Refresh a rejected Google Drive access token and retry the exact failed Library request once\n- Show progress while importing or clearing sample data\n- Recover an interrupted local sample Library without touching a connected Library\n- Reject corrupted PWA media ranges before they become available offline\n- Keep PWA browser fixtures from writing synchronized device preferences\n\n### Follow-ups\n\n- Physical iPhone PWA acceptance\n- Verify the first signed Google Drive publication against the real local Library\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.3102-dev.json
+++ b/release-notes/releases/v26.8.3102-dev.json
@@ -1,0 +1,139 @@
+{
+  "tag": "v26.8.3102-dev",
+  "version": "26.8.3102-dev",
+  "channel": "dev",
+  "dayKey": "26.8.31",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-08-31T22:06:44.666Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.3101-dev",
+    "previousPublishedDayTag": "v26.8.3006-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "5924b55b9d785d1f1c62737f8012007837731238",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.3101-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "bd9ddb312a6eaea9044e368096eb523ac3771a9a",
+        "toInclusiveProductCommitSha": "5924b55b9d785d1f1c62737f8012007837731238"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:251a9d31983ffc1700ccdfd1870a2b586b08d508dba50def936dc2e365d3ede7",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.8.3100-dev",
+      "v26.8.3101-dev",
+      "v26.8.3102-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.8.3100-dev",
+      "v26.8.3101-dev",
+      "v26.8.3102-dev"
+    ],
+    "prNumbers": [
+      1673,
+      1677,
+      1678,
+      1679,
+      1680,
+      1681,
+      1682,
+      1683,
+      1684,
+      1685,
+      1686,
+      1687,
+      1688,
+      1690,
+      1692,
+      1694,
+      1695,
+      1696,
+      1697,
+      1698,
+      1699,
+      1702,
+      1703
+    ],
+    "commitSubjects": [
+      "fix: pin checkpoint before Drive export (#1702)",
+      "fix: reject unrelated Playwright servers (#1703)",
+      "fix: show sample Library clear progress (#1698)",
+      "docs: codify release economy (#1700)",
+      "feat: add anonymous release demo experience (#1697)",
+      "chore: refresh v26.8.3101-dev identity (#1699)",
+      "fix: admit Google Drive installed sync trigger (#1696)",
+      "fix: keep PWA previews on the reported port (#1695)",
+      "release: v26.8.3101-dev (#1693)",
+      "perf: show sample Library import progress (#1694)",
+      "fix: recover orphaned PWA preview checkpoints (#1692)",
+      "fix: reject corrupted PWA media ranges (#1690)",
+      "chore: add WebKit PWA corpus hardening (#1688)",
+      "fix: publish accurate map location counts (#1687)",
+      "chore: prepare v26.8.3100-dev (#1686)",
+      "fix: make feed performance probes honest (#1685)",
+      "fix: preserve PWA SQLite quota failures (#1684)",
+      "perf: add PWA OPFS corpus hardening (#1683)",
+      "fix: clear retained Friends recovery errors (#1682)",
+      "perf: replace Friends offset pagination with keysets (#1681)",
+      "fix: bootstrap clean Vercel deployments (#1680)",
+      "fix: package PWA deployment guards (#1679)",
+      "perf: reduce PWA install bundle (#1678)",
+      "fix: recover Google Drive sync authentication (#1677)",
+      "test: repair PWA browser fixture preferences (#1676)",
+      "fix: restore PWA sample library context (#1673)"
+    ]
+  },
+  "release": {
+    "deck": "Reliable PWA recovery and Google Drive authentication",
+    "features": [
+      "Anonymous release demo experience",
+      "Open Map and Friends on demand while keeping return visits available offline",
+      "Keep PWA feeds and search bounded across 100,000 locally stored items"
+    ],
+    "fixes": [
+      "Release build and type-safety cleanup",
+      "Reader, feed, and header polish",
+      "Admit Google Drive installed sync trigger",
+      "Capture and scraper reliability fixes",
+      "Keep PWA browser fixtures from writing synchronized device preferences",
+      "Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite",
+      "Reject corrupted PWA media ranges before they become available offline",
+      "Refresh a rejected Google Drive access token and retry the exact failed Library request once",
+      "Recover an interrupted local sample Library without touching a connected Library"
+    ],
+    "followUps": [
+      "Refresh v26.8.3101-dev identity",
+      "WebKit PWA corpus hardening",
+      "Prepare v26.8.3100-dev",
+      "Friends offset pagination with keysets",
+      "Reduce PWA install bundle",
+      "Page large Friends directories with stable SQLite keyset cursors",
+      "Smaller PWA installs, stronger local storage recovery, and faster large Libraries",
+      "Run installed build verification in an isolated profile",
+      "Physical iPhone PWA acceptance",
+      "Extend large-library proof to WebKit and whole-process memory",
+      "Verify the first Google Drive publication and exact retry against the real local Library"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3102-dev\n\nReliable PWA recovery and Google Drive authentication\n\n### Features\n\n- Anonymous release demo experience\n- Open Map and Friends on demand while keeping return visits available offline\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n\n### Fixes\n\n- Release build and type-safety cleanup\n- Reader, feed, and header polish\n- Admit Google Drive installed sync trigger\n- Capture and scraper reliability fixes\n- Keep PWA browser fixtures from writing synchronized device preferences\n- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite\n- Reject corrupted PWA media ranges before they become available offline\n- Refresh a rejected Google Drive access token and retry the exact failed Library request once\n- Recover an interrupted local sample Library without touching a connected Library\n\n### Follow-ups\n\n- Refresh v26.8.3101-dev identity\n- WebKit PWA corpus hardening\n- Prepare v26.8.3100-dev\n- Friends offset pagination with keysets\n- Reduce PWA install bundle\n- Page large Friends directories with stable SQLite keyset cursors\n- Smaller PWA installs, stronger local storage recovery, and faster large Libraries\n- Run installed build verification in an isolated profile\n- Physical iPhone PWA acceptance\n- Extend large-library proof to WebKit and whole-process memory\n- Verify the first Google Drive publication and exact retry against the real local Library\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.8.3102-dev.md
+++ b/release-notes/releases/v26.8.3102-dev.md
@@ -1,0 +1,45 @@
+(AI Generated).
+
+## Freed v26.8.3102-dev
+
+Reliable PWA recovery and Google Drive authentication
+
+### Features
+
+- Anonymous release demo experience
+- Open Map and Friends on demand while keeping return visits available offline
+- Keep PWA feeds and search bounded across 100,000 locally stored items
+
+### Fixes
+
+- Release build and type-safety cleanup
+- Reader, feed, and header polish
+- Admit Google Drive installed sync trigger
+- Capture and scraper reliability fixes
+- Keep PWA browser fixtures from writing synchronized device preferences
+- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite
+- Reject corrupted PWA media ranges before they become available offline
+- Refresh a rejected Google Drive access token and retry the exact failed Library request once
+- Recover an interrupted local sample Library without touching a connected Library
+
+### Follow-ups
+
+- Refresh v26.8.3101-dev identity
+- WebKit PWA corpus hardening
+- Prepare v26.8.3100-dev
+- Friends offset pagination with keysets
+- Reduce PWA install bundle
+- Page large Friends directories with stable SQLite keyset cursors
+- Smaller PWA installs, stronger local storage recovery, and faster large Libraries
+- Run installed build verification in an isolated profile
+- Physical iPhone PWA acceptance
+- Extend large-library proof to WebKit and whole-process memory
+- Verify the first Google Drive publication and exact retry against the real local Library
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.8.3102-dev.md
+++ b/release-notes/releases/v26.8.3102-dev.md
@@ -6,21 +6,36 @@ Atomic Google Drive checkpoints and resilient PWA sample data
 
 ### Features
 
-- Anonymous release demo experience
+- Open Map and Friends on demand while keeping return visits available offline
 - Keep PWA feeds and search bounded across 100,000 locally stored items
+- Page large Friends directories with stable SQLite keyset cursors
 
 ### Fixes
 
+- Add an anonymous release demo experience
 - Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload
 - Refresh a rejected Google Drive access token and retry the exact failed Library request once
-- Show progress while importing or clearing sample data
+- Show live progress while a sample Library is being populated
+- Show progress while clearing sample data
 - Recover an interrupted local sample Library without touching a connected Library
+- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite
 - Reject corrupted PWA media ranges before they become available offline
+- Publish accurate location counts in Map
+- Preserve the original storage-full error and retry safely after PWA SQLite quota failures
+- Restore durable sample Library context across reloads and WebKit process exits
+- Expose normal manual Google Drive sync to the installed verification trigger
+- Clear stale Friends recovery errors after WebGPU falls back to healthy WebGL2
 - Keep PWA browser fixtures from writing synchronized device preferences
+- Make feed performance checks report inconclusive evidence instead of synthetic success
+- Keep mobile Settings breadcrumbs aligned with the final section at the bottom of the page
+- Make clean PWA preview deployments include their required guards and project binding
+- Keep PWA previews on the requested local port
 
 ### Follow-ups
 
 - Physical iPhone PWA acceptance
+- Run installed build verification in an isolated profile
+- Extend large-library proof to WebKit and whole-process memory
 - Verify the first signed Google Drive publication against the real local Library
 
 ### Downloads

--- a/release-notes/releases/v26.8.3102-dev.md
+++ b/release-notes/releases/v26.8.3102-dev.md
@@ -2,39 +2,26 @@
 
 ## Freed v26.8.3102-dev
 
-Reliable PWA recovery and Google Drive authentication
+Atomic Google Drive checkpoints and resilient PWA sample data
 
 ### Features
 
 - Anonymous release demo experience
-- Open Map and Friends on demand while keeping return visits available offline
 - Keep PWA feeds and search bounded across 100,000 locally stored items
 
 ### Fixes
 
-- Release build and type-safety cleanup
-- Reader, feed, and header polish
-- Admit Google Drive installed sync trigger
-- Capture and scraper reliability fixes
-- Keep PWA browser fixtures from writing synchronized device preferences
-- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite
-- Reject corrupted PWA media ranges before they become available offline
+- Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload
 - Refresh a rejected Google Drive access token and retry the exact failed Library request once
+- Show progress while importing or clearing sample data
 - Recover an interrupted local sample Library without touching a connected Library
+- Reject corrupted PWA media ranges before they become available offline
+- Keep PWA browser fixtures from writing synchronized device preferences
 
 ### Follow-ups
 
-- Refresh v26.8.3101-dev identity
-- WebKit PWA corpus hardening
-- Prepare v26.8.3100-dev
-- Friends offset pagination with keysets
-- Reduce PWA install bundle
-- Page large Friends directories with stable SQLite keyset cursors
-- Smaller PWA installs, stronger local storage recovery, and faster large Libraries
-- Run installed build verification in an isolated profile
 - Physical iPhone PWA acceptance
-- Extend large-library proof to WebKit and whole-process memory
-- Verify the first Google Drive publication and exact retry against the real local Library
+- Verify the first signed Google Drive publication against the real local Library
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Bump Freed Desktop and PWA to 26.8.3102.
- Approve cumulative dev release notes led by atomic Drive checkpoint export and resilient PWA sample data.

## Testing
- npm run validate:feature product checks passed; release-note validation initially rejected omitted cumulative same-day items
- validate-release-notes.mjs passed after carrying forward required same-day items
- validate-release-identity.mjs passed for v26.8.3102-dev at aa347945