### PR TITLE
fix: recover completed actor lease cleanup

### DIFF
--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -13621,9 +13621,9 @@ test("a new exact-token release finishes completed acquisition cleanup after res
       }),
     (error) =>
       isAutomationControlError(error) &&
-      error.code === "lease_transaction_pending",
+      error.code === "lease_token_mismatch",
   );
-  assert.equal(existsSync(acquirePaths.active), true);
+  assert.equal(existsSync(acquirePaths.active), false);
   assert.equal(existsSync(acquirePaths.receipt), true);
 
   const released = releaseLeaseMutation({
@@ -13648,6 +13648,91 @@ test("a new exact-token release finishes completed acquisition cleanup after res
   assert.equal(
     readControlEvents(stateRoot).filter(
       (event) => event.eventId === `lease:${releaseOperationId}`,
+    ).length,
+    1,
+  );
+});
+
+test("a fresh trusted acquisition finishes completed release cleanup after process loss", () => {
+  const stateRoot = temporaryStateRoot();
+  const actor = "freed-release-verifier";
+  const name = AUTOMATION_ACTOR_POLICIES[actor].leaseName;
+  const firstCredentialToken = writeActorCredential(stateRoot, actor);
+  const firstToken = `completed-release-cleanup-${"x".repeat(40)}`;
+  const nowMs = Date.now();
+
+  acquireLeaseMutation({
+    stateRoot,
+    name,
+    owner: actor,
+    operationId: nextLeaseOperationId("completed-release-cleanup-acquire"),
+    ttlMs: 60_000,
+    nowMs,
+    token: firstToken,
+    actorCredentialToken: firstCredentialToken,
+  });
+  const releaseOperationId = nextLeaseOperationId(
+    "completed-release-cleanup-release",
+  );
+  assert.throws(
+    () =>
+      releaseLeaseMutation({
+        stateRoot,
+        name,
+        operationId: releaseOperationId,
+        token: firstToken,
+        nowMs: nowMs + 1_000,
+        checkpoint: throwAtLeaseCheckpoint("lease-receipt-written"),
+      }),
+    /lease checkpoint lease-receipt-written/,
+  );
+  const releasePaths = leaseTransactionPaths(
+    stateRoot,
+    name,
+    "release",
+    releaseOperationId,
+  );
+  assert.equal(existsSync(releasePaths.active), true);
+  assert.equal(existsSync(releasePaths.receipt), true);
+  assert.equal(
+    existsSync(
+      path.join(
+        automationControlPaths(stateRoot).leases,
+        `${name}.lease`,
+        "lease.json",
+      ),
+    ),
+    false,
+  );
+
+  const secondCredentialToken = writeActorCredential(stateRoot, actor);
+  const secondToken = `fresh-acquisition-${"y".repeat(40)}`;
+  const secondOperationId = nextLeaseOperationId(
+    "completed-release-cleanup-fresh-acquire",
+  );
+  const acquired = acquireLeaseMutation({
+    stateRoot,
+    name,
+    owner: actor,
+    operationId: secondOperationId,
+    ttlMs: 60_000,
+    nowMs: nowMs + 2_000,
+    token: secondToken,
+    actorCredentialToken: secondCredentialToken,
+  });
+
+  assert.equal(acquired.lease.token, secondToken);
+  assert.equal(existsSync(releasePaths.active), false);
+  assert.equal(existsSync(releasePaths.receipt), true);
+  assert.equal(
+    readControlEvents(stateRoot).filter(
+      (event) => event.eventId === `lease:${releaseOperationId}`,
+    ).length,
+    1,
+  );
+  assert.equal(
+    readControlEvents(stateRoot).filter(
+      (event) => event.eventId === `lease:${secondOperationId}`,
     ).length,
     1,
   );

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -32495,12 +32495,14 @@ function requireCurrentLeaseOperationRecoveryMatch(
       transaction.operation !== operation ||
       transaction.operationId !== operationId
     ) {
-      // A retained general-actor token may finish durable cleanup after the
-      // original response is lost. Owner governance remains exact-plan fenced.
+      // A later trusted general-actor operation may finish durable cleanup
+      // after the original process and its short-lived token are lost. The
+      // recovery path validates exact state, audit history, receipt, and WAL
+      // lineage before removing anything. Owner governance remains exact-plan
+      // fenced.
       if (
         transaction.phase === "complete" &&
-        transaction.resultReceipt.lease.owner !== "freed-owner" &&
-        transaction.tokenDigest === tokenDigest
+        transaction.resultReceipt.lease.owner !== "freed-owner"
       ) {
         recoverLeaseTransactionUnlocked(paths, name, Date.now(), eventsGuard);
         return;


### PR DESCRIPTION
(AI Generated).

## Summary

- allow a later trusted general-actor operation to finish cleanup for a fully completed lease transaction after the original process and short-lived token are lost
- retain exact state, audit event, receipt, and WAL-lineage validation before cleanup
- keep owner-governance transactions exact-plan fenced
- add regression coverage for a completed release followed by a fresh trusted acquisition

Refs #1708.

## Validation

- `npm run validate:feature`
- focused authority tests for completed acquisition cleanup, completed release cleanup, retained-state validation, and owner-governance fencing: 4 passed in 86 seconds
- full `scripts/automation-control.test.mjs` run: 25 passed and 0 failed before one existing long-running case exceeded the repository's 5-minute per-test blocking limit; the run was stopped at 8 minutes 33 seconds and is not claimed green

## Publication boundary

Draft PR only. This does not authorize merge, installation, deployment, direct authority-state edits, provider traffic, or issue closure.