### PR TITLE
fix: install WebKit for production validation

### DIFF
--- a/.github/workflows/main-release-validation.yml
+++ b/.github/workflows/main-release-validation.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          npx playwright install --with-deps chromium
+          npx playwright install --with-deps chromium webkit
         working-directory: packages/desktop
 
       - name: Run production validation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install Playwright browsers
         if: needs.notes.outputs.release_channel != 'dev'
         run: |
-          npx playwright install --with-deps chromium
+          npx playwright install --with-deps chromium webkit
         working-directory: packages/desktop
 
       - name: Run channel validation

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -277,6 +277,22 @@ test("dev tag validation inherits the exact successful dev integration receipt",
   assert.match(validationJob, /npm run validate:production/);
 });
 
+test("production validation installs WebKit before running OPFS durability", () => {
+  const releaseValidationJob = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("\n  validation:"),
+    releaseWorkflow.indexOf("\n  create-release:"),
+  );
+
+  assert.match(
+    mainReleaseValidationWorkflow,
+    /playwright install --with-deps chromium webkit/,
+  );
+  assert.match(
+    releaseValidationJob,
+    /playwright install --with-deps chromium webkit/,
+  );
+});
+
 test("draft release assets and publication use the exact release ID", () => {
   const updaterJob = releaseWorkflow.slice(
     releaseWorkflow.indexOf("\n  updater-manifest:"),


### PR DESCRIPTION
(AI Generated).

## Summary
- Install Chromium and WebKit in both production validation workflows before the PWA OPFS durability suite runs.

## Testing
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH npm run validate:feature