### PR TITLE
fix: run production OPFS checks on macOS

### DIFF
--- a/.github/workflows/main-release-validation.yml
+++ b/.github/workflows/main-release-validation.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install Playwright browsers
         run: |
-          npx playwright install --with-deps chromium webkit
+          npx playwright install --with-deps chromium
         working-directory: packages/desktop
 
       - name: Run production validation
@@ -73,6 +73,7 @@ jobs:
         env:
           CI: "true"
           GH_TOKEN: ${{ github.token }}
+          FREED_SKIP_PWA_OPFS_DURABILITY: "true"
 
       - name: Upload test artifacts on failure
         if: failure()
@@ -88,4 +89,37 @@ jobs:
         with:
           name: test-results
           path: packages/desktop/test-results/
+          retention-days: 7
+
+  pwa-opfs-acceptance:
+    name: PWA OPFS durability (macOS WebKit)
+    runs-on: macos-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install WebKit
+        run: npx playwright install webkit
+
+      - name: Prove persistent OPFS SQLite durability
+        run: npm run test:e2e:opfs
+        working-directory: packages/pwa
+
+      - name: Upload OPFS diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: production-pwa-opfs-test-results
+          path: packages/pwa/test-results/
           retention-days: 7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,7 +212,7 @@ jobs:
       - name: Install Playwright browsers
         if: needs.notes.outputs.release_channel != 'dev'
         run: |
-          npx playwright install --with-deps chromium webkit
+          npx playwright install --with-deps chromium
         working-directory: packages/desktop
 
       - name: Run channel validation
@@ -230,9 +230,48 @@ jobs:
         env:
           CI: "true"
           GITHUB_TOKEN: ${{ github.token }}
+          FREED_SKIP_PWA_OPFS_DURABILITY: "true"
+
+  pwa-opfs-acceptance:
+    name: PWA OPFS durability (macOS WebKit)
+    needs: notes
+    runs-on: macos-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        if: needs.notes.outputs.release_channel != 'dev'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+
+      - name: Setup Node.js
+        if: needs.notes.outputs.release_channel != 'dev'
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install dependencies
+        if: needs.notes.outputs.release_channel != 'dev'
+        run: npm ci
+
+      - name: Install WebKit
+        if: needs.notes.outputs.release_channel != 'dev'
+        run: npx playwright install webkit
+
+      - name: Prove persistent OPFS SQLite durability
+        if: needs.notes.outputs.release_channel != 'dev'
+        run: npm run test:e2e:opfs
+        working-directory: packages/pwa
+
+      - name: Upload OPFS diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: release-pwa-opfs-test-results
+          path: packages/pwa/test-results/
+          retention-days: 7
 
   create-release:
-    needs: [notes, validation]
+    needs: [notes, validation, pwa-opfs-acceptance]
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -277,19 +277,33 @@ test("dev tag validation inherits the exact successful dev integration receipt",
   assert.match(validationJob, /npm run validate:production/);
 });
 
-test("production validation installs WebKit before running OPFS durability", () => {
+test("production validation runs OPFS durability on macOS WebKit", () => {
   const releaseValidationJob = releaseWorkflow.slice(
     releaseWorkflow.indexOf("\n  validation:"),
+    releaseWorkflow.indexOf("\n  pwa-opfs-acceptance:"),
+  );
+  const releaseOpfsJob = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("\n  pwa-opfs-acceptance:"),
     releaseWorkflow.indexOf("\n  create-release:"),
   );
 
   assert.match(
     mainReleaseValidationWorkflow,
-    /playwright install --with-deps chromium webkit/,
+    /FREED_SKIP_PWA_OPFS_DURABILITY: "true"/,
   );
+  assert.match(mainReleaseValidationWorkflow, /runs-on: macos-latest/);
+  assert.match(mainReleaseValidationWorkflow, /playwright install webkit/);
+  assert.match(mainReleaseValidationWorkflow, /npm run test:e2e:opfs/);
   assert.match(
     releaseValidationJob,
-    /playwright install --with-deps chromium webkit/,
+    /FREED_SKIP_PWA_OPFS_DURABILITY: "true"/,
+  );
+  assert.match(releaseOpfsJob, /runs-on: macos-latest/);
+  assert.match(releaseOpfsJob, /playwright install webkit/);
+  assert.match(releaseOpfsJob, /npm run test:e2e:opfs/);
+  assert.match(
+    releaseWorkflow,
+    /needs: \[notes, validation, pwa-opfs-acceptance\]/,
   );
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the full Linux production validation lane, but exclude WebKit OPFS durability from that incompatible runner.
- Run the required OPFS durability acceptance separately on macOS WebKit for main promotions and production tags.

## Testing
- PATH=/Users/aubreyfalconer/.nvm/versions/node/v24.14.1/bin:$PATH npm run validate:feature