### PR TITLE
fix: remove legacy theme attribution

### DIFF
--- a/packages/desktop/tests/e2e/theme-switching.spec.ts
+++ b/packages/desktop/tests/e2e/theme-switching.spec.ts
@@ -17,7 +17,7 @@ async function dismissCloudSyncNudgeIfPresent(page: Page) {
   }
 }
 
-test("switching to both AubOS themes applies the selected theme immediately", async ({ app, page }) => {
+test("switching between Starship and Dark Star applies the selected theme immediately", async ({ app, page }) => {
   await app.goto();
   await app.waitForReady();
 

--- a/packages/shared/src/themes.ts
+++ b/packages/shared/src/themes.ts
@@ -416,7 +416,7 @@ export const THEME_DEFINITIONS: readonly ThemeDefinition[] = [
     name: "Starship",
     tagline: "Bright command deck",
     description:
-      "The original AubOS command interface in its daylight palette.",
+      "Cool silver surfaces, deep indigo controls, and crisp condensed type tuned for daylight.",
     previewGradient:
       "radial-gradient(circle at 71% 22%, #faffff 0 7%, rgb(139 234 255 / 0.34) 8% 13%, transparent 14%), radial-gradient(ellipse 82% 58% at 50% 112%, #77f1ff 0%, #3a8ee8 30%, #3644b8 68%, #211c72 100%), linear-gradient(180deg, #fbffff 0%, #e9f8ff 35%, #c9e6ff 68%, #aabcf6 100%)",
     previewDisplayFont: '"Barlow Condensed", "Arial Narrow", sans-serif',


### PR DESCRIPTION
(AI Generated).

## Summary

- Describe Starship through its visual design instead of product ancestry.
- Name Starship and Dark Star directly in the theme switching test.

## Validation

- Shared package TypeScript check passed.
- Playwright discovered all 9 theme switching tests.
- Diff whitespace check passed.