### PR TITLE
fix: bind production deploys to dev snapshots

### DIFF
--- a/.agents/skills/freed-ship-build/SKILL.md
+++ b/.agents/skills/freed-ship-build/SKILL.md
@@ -8,6 +8,12 @@ disable-model-invocation: true
 
 Publish from the correct release lane and prove which artifact was installed afterward.
 
+This skill governs versioned Freed Desktop releases. A production PWA snapshot
+does not create a version, tag, GitHub release, release-note artifact, or public
+release card. After its immutable dev snapshot is promoted to `main`, deploy it
+from an exact clean `origin/main` checkout with
+`./scripts/deploy-pwa-production-snapshot.sh <promoted-dev-sha>`.
+
 ## Run this end to end without stopping
 
 Once invoked, carry the release all the way to a tagged, verified build. Do not
@@ -45,8 +51,8 @@ through, not a reason to hand the release back.
 
 1. Confirm `dev` or `production` release mode. Production is the default for `./scripts/release.sh`. Dev release prep requires `--channel=dev`.
 2. Record the release task ID and granted authority. If the release repays tracked debt, also record each canonical GitHub issue. Preparing notes, pushing a tag, publishing, and deploying are distinct external actions.
-3. Fetch `origin/dev` and `origin/main`, require a clean tree, and record the source git SHA.
-4. For production, run `node scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=origin/main`. If it fails because main is behind approved product state, run `./scripts/promote-dev-to-main.sh <worktree-path>`, merge that reviewed PR, and fetch the new `origin/main` before release prep.
+3. Fetch `origin/dev` and `origin/main`, require a clean tree, and select one exact 40-character source dev commit SHA. That immutable SHA is the production snapshot. Later `dev` commits do not invalidate or expand it.
+4. For production, run `node scripts/validate-release-promotion.mjs --from-ref=<source-dev-sha> --to-ref=origin/main`. If it fails because main is behind the selected product snapshot, run `./scripts/promote-dev-to-main.sh <worktree-path> <branch-name> --snapshot-sha <source-dev-sha>`, merge that reviewed PR, and fetch the new `origin/main` before release prep. Never replace the selected SHA with a later live `origin/dev` tip unless the owner explicitly selects a new snapshot.
 5. If the release contains provider-visible work, confirm its artifact names the
    provider set, observable behavior, and decision state. A
    `behavior_approved` artifact must carry the owner approval reference for that
@@ -74,7 +80,7 @@ through, not a reason to hand the release back.
 
 ## Prepare and publish
 
-1. Create a fresh `chore/release-<version>` worktree with `./scripts/worktree-add.sh <worktree-path> -b chore/release-<version> origin/main --target shared` for production, or use `origin/dev` for dev. Run `./scripts/release.sh` for production or `./scripts/release.sh --channel=dev` for dev. The script accepts only numeric CalVer with the one exact `-dev` tag suffix, updates package versions, records the source product commit and fixed promoted dev snapshot in the production release artifact, generates release-note artifacts, commits the draft, and refuses a stale or incorrect base.
+1. Create a fresh `chore/release-<version>` worktree with `./scripts/worktree-add.sh <worktree-path> -b chore/release-<version> origin/main --target shared` for production, or use `origin/dev` for dev. Run `./scripts/release.sh --promoted-dev-sha=<source-dev-sha>` for production or `./scripts/release.sh --channel=dev` for dev. The script accepts only numeric CalVer with the one exact `-dev` tag suffix, updates package versions, records the source product commit and fixed promoted dev snapshot in the production release artifact, generates release-note artifacts, commits the draft, and refuses a stale or incorrect base. Production prep validates against the selected immutable SHA rather than the moving `origin/dev` branch.
    **Run the script. Do not bump versions by hand.** The tag carries `-dev`; the five version files carry plain CalVer with no suffix (v26.7.1501-dev shipped `26.7.1501` in `package.json`). Writing the tag string into the version files makes `validate-release-identity` reject the publish on all five, and hand-editing product files after the notes are generated makes it reject again for "product files changed after release notes were prepared". `release.sh` gets both right and leaves an already-approved release file untouched, so it is safe to re-run to repair a botched prep.
 2. Review `source.libraryCoreActivation` in the generated release JSON before
    approving the release. The generator selects the exact immutable

--- a/docs/PHASE-1-FOUNDATION.md
+++ b/docs/PHASE-1-FOUNDATION.md
@@ -223,7 +223,8 @@ Branch routing:
 - merges to `dev` redeploy `dev-app.freed.wtf` through native Vercel Git deploys
 - Vercel preview deployments handle PWA branch and PR previews
 - `main` remains the production app release branch
-- production release prep starts from exact current `origin/main` and refuses stale product state, so any required `dev` promotion lands before the release-only prep PR
+- production release prep starts from exact current `origin/main` and validates it against the immutable dev commit selected by the promotion PR, so later `dev` work can continue without invalidating the release snapshot
+- production PWA snapshots deploy from an exact promoted `main` commit without creating a version, tag, Desktop build, release-note artifact, or public release card
 - `main` no longer redeploys `freed.wtf` as a side effect
 
 Manual preview deploys for this monorepo now go through `./scripts/vercel-deploy-preview.sh website` and `./scripts/vercel-deploy-preview.sh pwa`. The helper stages a temporary monorepo slice with shared workspace packages before uploading to Vercel, which avoids the broken `npm install` failures caused by raw subdirectory deploys.

--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -455,7 +455,7 @@ Reward security researchers for responsible disclosure.
 | ----- | ---------------------------------------- | ---------- |
 | 10.19 | Discord server setup                     | Low        |
 | 10.20 | Bug bounty program                       | Medium     |
-| 10.21 | Release automation                       | Medium     | ✓ Complete (reviewed release prep, in-band current-task owner approval, protected branch promotion, dedicated release App provisioning, root-owned native tag publication, split tag rulesets, and fail-closed release identity checks) |
+| 10.21 | Release automation                       | Medium     | ✓ Complete (reviewed release prep, immutable dev snapshot promotion that permits ongoing development, release-card-free production PWA snapshot deployment, in-band current-task owner approval, protected branch promotion, dedicated release App provisioning, root-owned native tag publication, split tag rulesets, and fail-closed release identity checks) |
 | 10.22 | Documentation site                       | Medium     |
 | 10.28 | Primary automation host and task custody | Medium     | ✓ Complete (reviewed opaque host assignment, root-owned enrollment, nightly primary-host gate, one custodian heartbeat contract, and conservative external no-op archival)                                                              |
 | 10.29 | Task-scoped factory execution claims     | Medium     | ✓ Complete (single-manifest claims, exact retry receipts, conflict fencing, heartbeat custody, checkpoint-backed epoch transfer, exact release, and runtime-neutral draft-only pilot authority)                                         |

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -821,7 +821,8 @@ export async function captureDomFeed(
 - [x] Visible-scope archive read actions batch filtered read items through one bounded SQLite mutation, so large Instagram cleanup does not loop through one archive toggle per post
 - [x] macOS DMG is notarized in CI releases
 - [x] Checked-in release notes are reviewed before a release tag can publish
-- [x] Production release prep and publish refuse stale `main` snapshots until current `dev` has been promoted into `main`, and PRs targeting `main` reject direct product edits outside the promotion flow
+- [x] Production promotion captures one immutable dev commit, release prep validates and records that exact snapshot, later `dev` commits do not invalidate it, and PRs targeting `main` reject direct product edits outside the promotion flow
+- [x] Production PWA snapshot deployment validates the selected promoted dev commit against exact `origin/main` and publishes it without generating a versioned Desktop release or public release card
 - [x] Debug panel Health tab charts provider reliability plus daily and hourly pull volume across RSS, X, Facebook, Instagram, LinkedIn, Google Drive, and Dropbox
 - [x] Desktop Settings > Sync shows local item count, local document size, Drive stage, last download, last upload, remote bytes, uploaded bytes, cloud errors, pending upload explanations, a manual Drive `Sync now` action, and a recent activity timeline
 - [x] Desktop Settings > Sync warns when more than one Freed Desktop installation is registered with the library because parallel RSS or authenticated provider polling can duplicate request traffic. PWA clients do not trigger the warning.

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -363,8 +363,13 @@ After it merges, tag the exact updated `origin/dev` commit with
 `./scripts/release-publish.sh <version>-dev`.
 
 Production release prep requires an exact current `origin/main` base after any
-required product promotion. Dev release prep requires exact current
-`origin/dev`. Both return through branch protection. `release-publish.sh`
+required product promotion and the immutable source dev SHA recorded by that
+promotion, passed as `--promoted-dev-sha=<sha>`. Later commits on `dev` do not
+invalidate or expand the selected production snapshot. A production PWA-only
+snapshot uses `./scripts/deploy-pwa-production-snapshot.sh <promoted-dev-sha>`
+from exact `origin/main`; it creates no version, tag, Desktop build, release
+notes, or public release card. Dev release prep requires exact current
+`origin/dev`. Both versioned release lanes return through branch protection. `release-publish.sh`
 refuses to tag unless local `HEAD` exactly equals the target remote branch, so
 it cannot tag an unmerged local release commit. It also binds the requested tag,
 channel, Desktop, PWA, Tauri, and Cargo versions to the reviewed release

--- a/scripts/deploy-pwa-production-snapshot.sh
+++ b/scripts/deploy-pwa-production-snapshot.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <promoted-dev-sha>" >&2
+  exit 1
+fi
+
+SNAPSHOT_SHA_INPUT="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+use_resolved_node_path
+NODE_BIN="$(resolve_node_bin)"
+
+cd "${REPO_ROOT}"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: production snapshot deployment requires a clean worktree." >&2
+  exit 1
+fi
+
+if [[ ! "${SNAPSHOT_SHA_INPUT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Error: promoted dev snapshot must be one full 40-character commit SHA." >&2
+  exit 1
+fi
+
+git fetch origin main
+SNAPSHOT_SHA="$(git rev-parse "${SNAPSHOT_SHA_INPUT}^{commit}")"
+MAIN_SHA="$(git rev-parse origin/main)"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+if [[ "${SNAPSHOT_SHA}" != "${SNAPSHOT_SHA_INPUT}" ]]; then
+  echo "Error: promoted dev snapshot must name one exact commit without abbreviation." >&2
+  exit 1
+fi
+if [[ "${HEAD_SHA}" != "${MAIN_SHA}" ]]; then
+  echo "Error: production snapshot deployment must run from exact origin/main ${MAIN_SHA}; HEAD is ${HEAD_SHA}." >&2
+  exit 1
+fi
+
+"${NODE_BIN}" scripts/validate-release-promotion.mjs \
+  --from-ref="${SNAPSHOT_SHA}" \
+  --to-ref="${MAIN_SHA}"
+
+echo "Deploying production PWA snapshot from main ${MAIN_SHA}, selected from dev ${SNAPSHOT_SHA}."
+FREED_BUILD_KIND=snapshot \
+FREED_BUILD_CHANNEL=production \
+FREED_BUILD_COMMIT_SHA="${MAIN_SHA}" \
+FREED_BUILD_COMMIT_REF=main \
+  "${SCRIPT_DIR}/vercel-deploy-production.sh" pwa
+
+echo "Production PWA snapshot deployed."
+echo "Main SHA: ${MAIN_SHA}"
+echo "Promoted dev SHA: ${SNAPSHOT_SHA}"

--- a/scripts/promote-dev-to-main.sh
+++ b/scripts/promote-dev-to-main.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: ./scripts/promote-dev-to-main.sh <worktree-path> [<branch-name>] [--provider-risk-review-artifact <path> | --provider-risk-approval-file <path>]" >&2
+  echo "Usage: ./scripts/promote-dev-to-main.sh <worktree-path> [<branch-name>] [--snapshot-sha <40-hex-sha>] [--provider-risk-review-artifact <path> | --provider-risk-approval-file <path>]" >&2
   exit 1
 fi
 
@@ -12,6 +12,7 @@ shift
 BRANCH_NAME=""
 PROVIDER_RISK_APPROVAL_FILE=""
 PROVIDER_RISK_REVIEW_ARTIFACT=""
+SNAPSHOT_SHA_INPUT=""
 if [[ $# -gt 0 && "$1" != --* ]]; then
   BRANCH_NAME="$1"
   shift
@@ -19,6 +20,11 @@ fi
 BRANCH_NAME="${BRANCH_NAME:-chore/promote-dev-to-main-$(date +%Y%m%d-%H%M%S)}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --snapshot-sha)
+      [[ $# -ge 2 && -n "$2" ]] || { echo "Error: --snapshot-sha requires a 40-character commit SHA." >&2; exit 1; }
+      SNAPSHOT_SHA_INPUT="$2"
+      shift 2
+      ;;
     --provider-risk-review-artifact)
       [[ $# -ge 2 && -n "$2" ]] || { echo "Error: --provider-risk-review-artifact requires a path." >&2; exit 1; }
       PROVIDER_RISK_REVIEW_ARTIFACT="$2"
@@ -66,8 +72,22 @@ fi
 
 /usr/bin/git fetch origin dev main
 
-if "${NODE_BIN}" "${SCRIPT_DIR}/validate-release-promotion.mjs" --from-ref=origin/dev --to-ref=origin/main >/dev/null 2>&1; then
-  echo "origin/main already matches origin/dev on product-owned paths."
+if [[ -z "${SNAPSHOT_SHA_INPUT}" ]]; then
+  SNAPSHOT_SHA_INPUT="$(/usr/bin/git rev-parse origin/dev)"
+fi
+if [[ ! "${SNAPSHOT_SHA_INPUT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Error: --snapshot-sha must be one full 40-character commit SHA." >&2
+  exit 1
+fi
+SNAPSHOT_SHA="$(/usr/bin/git rev-parse "${SNAPSHOT_SHA_INPUT}^{commit}")"
+if [[ "${SNAPSHOT_SHA}" != "${SNAPSHOT_SHA_INPUT}" ]]; then
+  echo "Error: --snapshot-sha must name one exact commit without abbreviation." >&2
+  exit 1
+fi
+
+if "${NODE_BIN}" "${SCRIPT_DIR}/validate-release-promotion.mjs" --from-ref="${SNAPSHOT_SHA}" --to-ref=origin/main >/dev/null 2>&1; then
+  echo "origin/main already matches immutable dev snapshot ${SNAPSHOT_SHA} on product-owned paths."
+  echo "Prepare production with: ./scripts/release.sh --promoted-dev-sha=${SNAPSHOT_SHA}"
   exit 0
 fi
 
@@ -98,7 +118,7 @@ else
     /usr/bin/git fetch origin dev main
     "${NODE_BIN}" "${SCRIPT_DIR}/prepare-release-promotion.mjs" \
       --cwd="${WORKTREE_PATH}" \
-      --from-ref=origin/dev \
+      --from-ref="${SNAPSHOT_SHA}" \
       --base-ref=origin/main
 
     if /usr/bin/git diff --cached --quiet; then
@@ -127,18 +147,19 @@ fi
     --base-ref=origin/main \
     --head-ref=HEAD \
     --head-branch="${BRANCH_NAME}"
+  "${NODE_BIN}" scripts/validate-release-promotion.mjs \
+    --from-ref="${SNAPSHOT_SHA}" \
+    --to-ref=HEAD
 
   BODY_FILE="$(mktemp)"
   trap 'rm -f "${BODY_FILE}"' EXIT
-  DEV_SHA="$(/usr/bin/git rev-parse origin/dev)"
-
   cat > "${BODY_FILE}" <<EOF
 (AI Generated).
 
 ## Summary
-- Promote the current \`origin/dev\` product snapshot into \`main\` before a production release.
+- Promote one immutable dev product snapshot into \`main\` before a production release.
 - Base main SHA: \`${MAIN_SHA}\`
-- Source dev SHA: \`${DEV_SHA}\`
+- Source dev SHA: \`${SNAPSHOT_SHA}\`
 
 ## Testing
 - \`node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=${BRANCH_NAME}\`
@@ -161,3 +182,4 @@ EOF
 
 echo "Promotion PR created from ${BRANCH_NAME}."
 echo "After it merges, refresh origin/main. Create the production release-prep branch from that exact commit."
+echo "Prepare production with: ./scripts/release.sh --promoted-dev-sha=${SNAPSHOT_SHA}"

--- a/scripts/promote-dev-to-main.test.mjs
+++ b/scripts/promote-dev-to-main.test.mjs
@@ -65,7 +65,7 @@ async function existingPromotionFixture(t) {
   await fs.copyFile(path.join(sourceRoot, ".nvmrc"), path.join(repo, ".nvmrc"));
   await fs.writeFile(
     path.join(repo, "scripts/validate-release-promotion.mjs"),
-    "process.exit(1);\n",
+    'process.exit(process.argv.includes("--to-ref=origin/main") ? 1 : 0);\n',
   );
   await fs.writeFile(
     path.join(repo, "scripts/validate-main-pr.mjs"),

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -26,6 +26,10 @@ const promotion = readFileSync(
   path.join(scriptsDir, "promote-dev-to-main.sh"),
   "utf8",
 );
+const pwaProductionSnapshot = readFileSync(
+  path.join(scriptsDir, "deploy-pwa-production-snapshot.sh"),
+  "utf8",
+);
 const releaseWorkflow = readFileSync(
   path.join(scriptsDir, "..", ".github", "workflows", "release.yml"),
   "utf8",
@@ -67,7 +71,36 @@ test("release preparation uses the channel's protected branch as its exact base"
   assert.match(releasePrep, /--base \$\{EXPECTED_BRANCH\} --ready/);
   assert.match(releasePrep, /npm run validate:release/);
   assert.match(releasePrep, /npm run validate:feature/);
+  assert.match(releasePrep, /--promoted-dev-sha=<40-hex-sha>/);
+  assert.match(
+    releasePrep,
+    /--from-ref="\$\{PROMOTED_DEV_COMMIT_SHA\}"/,
+  );
+  assert.doesNotMatch(
+    releasePrep,
+    /validate-release-promotion\.mjs --from-ref=origin\/dev/,
+  );
   assert.doesNotMatch(releasePrep, /git push origin (?:dev|main)/);
+});
+
+test("PWA production snapshots bind one promoted dev SHA without generating a release", () => {
+  assert.match(pwaProductionSnapshot, /git fetch origin main/);
+  assert.match(
+    pwaProductionSnapshot,
+    /\$\{HEAD_SHA\}" != "\$\{MAIN_SHA\}"/,
+  );
+  assert.match(
+    pwaProductionSnapshot,
+    /validate-release-promotion\.mjs[\s\S]*--from-ref="\$\{SNAPSHOT_SHA\}"[\s\S]*--to-ref="\$\{MAIN_SHA\}"/,
+  );
+  assert.match(pwaProductionSnapshot, /FREED_BUILD_KIND=snapshot/);
+  assert.match(pwaProductionSnapshot, /FREED_BUILD_CHANNEL=production/);
+  assert.match(
+    pwaProductionSnapshot,
+    /vercel-deploy-production\.sh" pwa/,
+  );
+  assert.doesNotMatch(pwaProductionSnapshot, /release\.sh/);
+  assert.doesNotMatch(pwaProductionSnapshot, /release-notes/);
 });
 
 test("release publication delegates one exact tag to the trusted App publisher", () => {
@@ -131,6 +164,11 @@ test("release publication delegates one exact tag to the trusted App publisher",
   assert.match(
     releasePrep,
     /FREED_PROMOTED_DEV_COMMIT_SHA="\$\{PROMOTED_DEV_COMMIT_SHA\}"/,
+  );
+  assert.match(promotion, /--from-ref="\$\{SNAPSHOT_SHA\}"/);
+  assert.match(
+    promotion,
+    /\.\/scripts\/release\.sh --promoted-dev-sha=\$\{SNAPSHOT_SHA\}/,
   );
   assert.match(releaseWorkflow, /EXPECTED_BRANCH="main"/);
   assert.match(releaseWorkflow, /TAG" == \*-dev[\s\S]*EXPECTED_BRANCH="dev"/);

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -207,6 +207,52 @@ test("validate-release-promotion fails when main is stale on product files", (t)
   assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
 });
 
+test("an immutable promoted dev snapshot stays valid after dev advances", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'approved snapshot';\n",
+  );
+  commitAll(cwd, "approved snapshot");
+  const snapshotSha = git(cwd, ["rev-parse", "HEAD"]);
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'approved snapshot';\n",
+  );
+  commitAll(cwd, "promote approved snapshot");
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'later development';\n",
+  );
+  commitAll(cwd, "later dev change");
+  updateOriginRef(cwd, "dev");
+
+  const fixedSnapshot = runNode(VALIDATE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    `--from-ref=${snapshotSha}`,
+    "--to-ref=main",
+  ]);
+  assert.equal(fixedSnapshot.status, 0, fixedSnapshot.stderr);
+
+  const movingTip = runNode(VALIDATE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    "--from-ref=origin/dev",
+    "--to-ref=main",
+  ]);
+  assert.equal(movingTip.status, 1);
+  assert.match(movingTip.stderr, /packages\/pwa\/src\/app\.ts/);
+});
+
 test("prepare-release-promotion copies the dev product snapshot across squashed history", (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,10 +18,10 @@ use_resolved_node_path
 # Note: major version (YY) must be ≤255 for Windows MSI compatibility.
 #
 # Usage:
-#   ./scripts/release.sh                            # auto-compute a production release
-#   ./scripts/release.sh --channel=production       # explicit production release
+#   ./scripts/release.sh --promoted-dev-sha=<sha>   # auto-compute a production release
+#   ./scripts/release.sh --channel=production --promoted-dev-sha=<sha>
 #   ./scripts/release.sh --channel=dev              # auto-compute a dev release
-#   ./scripts/release.sh 26.3.105                   # manual production override
+#   ./scripts/release.sh 26.3.105 --promoted-dev-sha=<sha>
 #   ./scripts/release.sh 26.3.105-dev --channel=dev # manual dev override
 
 DESKTOP_DIR="packages/desktop"
@@ -32,6 +32,7 @@ DESKTOP_PKG="${DESKTOP_DIR}/package.json"
 PWA_PKG="packages/pwa/package.json"
 CHANNEL="production"
 VERSION_INPUT=""
+PROMOTED_DEV_SHA_INPUT=""
 
 # Ensure tracked and untracked worktree state is clean.
 if [[ -n "$(git status --porcelain)" ]]; then
@@ -44,14 +45,17 @@ for arg in "$@"; do
     --channel=production|--channel=dev)
       CHANNEL="${arg#*=}"
       ;;
+    --promoted-dev-sha=*)
+      PROMOTED_DEV_SHA_INPUT="${arg#*=}"
+      ;;
     -h|--help)
-      echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev]" >&2
+      echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev] [--promoted-dev-sha=<40-hex-sha>]" >&2
       exit 0
       ;;
     *)
       if [[ -n "$VERSION_INPUT" ]]; then
         echo "Error: too many positional arguments." >&2
-        echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev]" >&2
+        echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev] [--promoted-dev-sha=<40-hex-sha>]" >&2
         exit 1
       fi
       VERSION_INPUT="${arg#v}"
@@ -86,8 +90,22 @@ fi
 
 PROMOTED_DEV_COMMIT_SHA=""
 if [[ "$CHANNEL" == "production" ]]; then
-  "${NODE_BIN}" scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD
-  PROMOTED_DEV_COMMIT_SHA="$(git rev-parse origin/dev)"
+  if [[ ! "${PROMOTED_DEV_SHA_INPUT}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Error: production release prep requires --promoted-dev-sha=<40-hex-sha>." >&2
+    echo "Use the immutable source dev SHA recorded by the promotion PR, not the moving origin/dev branch." >&2
+    exit 1
+  fi
+  PROMOTED_DEV_COMMIT_SHA="$(git rev-parse "${PROMOTED_DEV_SHA_INPUT}^{commit}")"
+  if [[ "${PROMOTED_DEV_COMMIT_SHA}" != "${PROMOTED_DEV_SHA_INPUT}" ]]; then
+    echo "Error: --promoted-dev-sha must name one exact commit without abbreviation." >&2
+    exit 1
+  fi
+  "${NODE_BIN}" scripts/validate-release-promotion.mjs \
+    --from-ref="${PROMOTED_DEV_COMMIT_SHA}" \
+    --to-ref=HEAD
+elif [[ -n "${PROMOTED_DEV_SHA_INPUT}" ]]; then
+  echo "Error: --promoted-dev-sha is valid only for production releases." >&2
+  exit 1
 fi
 
 if [[ -n "$VERSION_INPUT" ]]; then


### PR DESCRIPTION
(AI Generated).

## Summary
- Bind production promotion, versioned release prep, and release-card-free PWA snapshot deployment to one immutable dev commit so dev can continue advancing.

## Testing
- npm run validate:feature