### PR TITLE
fix: bind main promotion guard to snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,11 +273,16 @@ jobs:
         run: git fetch origin dev main
 
       - name: Validate main PR scope
+        env:
+          PROMOTION_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PROMOTION_HEAD_BRANCH: ${{ github.head_ref }}
         run: |
+          snapshot_ref="$(git show -s --format='%(trailers:key=Freed-Dev-Snapshot,valueonly)' "${PROMOTION_HEAD_SHA}")"
           node scripts/validate-main-pr.mjs \
             --base-ref="origin/${{ github.base_ref }}" \
-            --head-ref="${{ github.event.pull_request.head.sha }}" \
-            --head-branch="${{ github.head_ref }}"
+            --head-ref="${PROMOTION_HEAD_SHA}" \
+            --head-branch="${PROMOTION_HEAD_BRANCH}" \
+            --snapshot-ref="${snapshot_ref}"
 
   feature:
     name: Feature validation

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -368,7 +368,9 @@ promotion, passed as `--promoted-dev-sha=<sha>`. Later commits on `dev` do not
 invalidate or expand the selected production snapshot. A production PWA-only
 snapshot uses `./scripts/deploy-pwa-production-snapshot.sh <promoted-dev-sha>`
 from exact `origin/main`; it creates no version, tag, Desktop build, release
-notes, or public release card. Dev release prep requires exact current
+notes, or public release card. The promotion commit records the selected SHA in
+its `Freed-Dev-Snapshot` trailer, and the main PR guard validates against that
+immutable commit instead of the moving `origin/dev` tip. Dev release prep requires exact current
 `origin/dev`. Both versioned release lanes return through branch protection. `release-publish.sh`
 refuses to tag unless local `HEAD` exactly equals the target remote branch, so
 it cannot tag an unmerged local release commit. It also binds the requested tag,

--- a/scripts/promote-dev-to-main.sh
+++ b/scripts/promote-dev-to-main.sh
@@ -126,13 +126,20 @@ else
       exit 1
     fi
 
-    /usr/bin/git commit -m "${TITLE}"
+    /usr/bin/git commit -m "${TITLE}" -m "Freed-Dev-Snapshot: ${SNAPSHOT_SHA}"
   )
 fi
 
 (
   cd "${WORKTREE_PATH}"
   /usr/bin/git fetch origin dev main
+  RECORDED_SNAPSHOT="$(/usr/bin/git show -s --format='%(trailers:key=Freed-Dev-Snapshot,valueonly)' HEAD)"
+  if [[ -z "${RECORDED_SNAPSHOT}" ]]; then
+    /usr/bin/git commit --amend --no-edit --trailer "Freed-Dev-Snapshot: ${SNAPSHOT_SHA}"
+  elif [[ "${RECORDED_SNAPSHOT}" != "${SNAPSHOT_SHA}" ]]; then
+    echo "Error: promotion commit records immutable dev snapshot ${RECORDED_SNAPSHOT}, not requested snapshot ${SNAPSHOT_SHA}." >&2
+    exit 1
+  fi
   MAIN_SHA="$(/usr/bin/git rev-parse origin/main)"
   HEAD_PARENT="$(/usr/bin/git rev-parse HEAD^)"
   if [[ "${HEAD_PARENT}" != "${MAIN_SHA}" ]]; then
@@ -146,7 +153,8 @@ fi
   "${NODE_BIN}" scripts/validate-main-pr.mjs \
     --base-ref=origin/main \
     --head-ref=HEAD \
-    --head-branch="${BRANCH_NAME}"
+    --head-branch="${BRANCH_NAME}" \
+    --snapshot-ref="${SNAPSHOT_SHA}"
   "${NODE_BIN}" scripts/validate-release-promotion.mjs \
     --from-ref="${SNAPSHOT_SHA}" \
     --to-ref=HEAD
@@ -162,7 +170,7 @@ fi
 - Source dev SHA: \`${SNAPSHOT_SHA}\`
 
 ## Testing
-- \`node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=${BRANCH_NAME}\`
+- \`node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=${BRANCH_NAME} --snapshot-ref=${SNAPSHOT_SHA}\`
 - CI
 EOF
 

--- a/scripts/promote-dev-to-main.test.mjs
+++ b/scripts/promote-dev-to-main.test.mjs
@@ -254,7 +254,14 @@ test("promotion forwards one provider review artifact to draft publication", asy
       "--base-ref=origin/main",
       "--head-ref=HEAD",
       `--head-branch=${fixture.branch}`,
+      `--snapshot-ref=${mustRun("git", ["rev-parse", "origin/dev"], { cwd: fixture.repo }).stdout.trim()}`,
     ],
+  );
+  assert.match(
+    mustRun("git", ["show", "-s", "--format=%B", "HEAD"], {
+      cwd: fixture.worktree,
+    }).stdout,
+    /Freed-Dev-Snapshot: [0-9a-f]{40}/,
   );
 });
 

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -444,12 +444,18 @@ test("feature and dev validation route OPFS durability to macOS WebKit", () => {
 test("main PR validation inspects the actual PR head instead of the synthetic merge", () => {
   assert.match(
     ciWorkflow,
-    /--head-ref="\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/,
+    /PROMOTION_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
   );
+  assert.match(ciWorkflow, /--head-ref="\$\{PROMOTION_HEAD_SHA\}"/);
   assert.doesNotMatch(
     ciWorkflow,
     /validate-main-pr\.mjs[\s\S]*--head-ref=HEAD/,
   );
+  assert.match(
+    ciWorkflow,
+    /trailers:key=Freed-Dev-Snapshot,valueonly/,
+  );
+  assert.match(ciWorkflow, /--snapshot-ref="\$\{snapshot_ref\}"/);
 });
 
 test("release preparation validates canonical CalVer before mutating version files", () => {

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -399,6 +399,7 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260722",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
   assert.equal(validated.status, 0, validated.stderr);
 });
@@ -1080,6 +1081,7 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
   );
   commitAll(cwd, "dev change");
   updateOriginRef(cwd, "dev");
+  const snapshotSha = git(cwd, ["rev-parse", "origin/dev"]);
 
   git(cwd, ["checkout", "-b", "chore/promote-dev-to-main-20260421", "main"]);
   git(cwd, ["merge", "--squash", "--no-commit", "dev"]);
@@ -1089,6 +1091,10 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
     "chore: promote dev into main for production release",
   ]);
   const promotionHead = git(cwd, ["rev-parse", "HEAD"]);
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(cwd, "packages/pwa/src/later.ts", "export const later = true;\n");
+  commitAll(cwd, "later dev change");
+  updateOriginRef(cwd, "dev");
   git(cwd, ["checkout", "main"]);
   git(cwd, ["merge", "--no-ff", "--no-edit", promotionHead]);
   assert.equal(
@@ -1103,10 +1109,11 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
     "--base-ref=origin/main",
     `--head-ref=${promotionHead}`,
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${snapshotSha}`,
   ]);
 
   assert.equal(result.status, 0);
-  assert.match(result.stdout, /Promotion branch matches origin\/dev/);
+  assert.match(result.stdout, /Promotion branch matches selected dev snapshot/);
 });
 
 test("validate-main-pr rejects a promotion whose parent is no longer current main", (t) => {
@@ -1138,6 +1145,7 @@ test("validate-main-pr rejects a promotion whose parent is no longer current mai
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     `--head-branch=${promotionBranch}`,
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 1);
@@ -1191,10 +1199,11 @@ test("validate-main-pr rejects third-content release metadata on a promotion bra
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /Promotion PR is stale/);
+  assert.match(result.stderr, /does not match selected dev snapshot/);
   assert.match(result.stderr, /packages\/desktop\/src-tauri\/Cargo\.toml/);
 });
 
@@ -1244,10 +1253,11 @@ test("validate-main-pr rejects third-content release notes on a promotion branch
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /Promotion PR is stale/);
+  assert.match(result.stderr, /does not match selected dev snapshot/);
   assert.match(result.stderr, /release-notes\/releases\/v26\.4\.2100\.json/);
 });
 
@@ -1282,10 +1292,11 @@ test("validate-main-pr allows website build config in promotion branches", (t) =
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 0);
-  assert.match(result.stdout, /Promotion branch matches origin\/dev/);
+  assert.match(result.stdout, /Promotion branch matches selected dev snapshot/);
 });
 
 test("validate-main-pr rejects product changes on a non-promotion branch", (t) => {

--- a/scripts/validate-main-pr.mjs
+++ b/scripts/validate-main-pr.mjs
@@ -51,21 +51,21 @@ function die(message) {
 
 function usage() {
   console.error(
-    "Usage: node scripts/validate-main-pr.mjs [--cwd=<path>] --base-ref=<ref> --head-ref=<ref> --head-branch=<branch>",
+    "Usage: node scripts/validate-main-pr.mjs [--cwd=<path>] --base-ref=<ref> --head-ref=<ref> --head-branch=<branch> [--snapshot-ref=<40-hex-sha>]",
   );
 }
 
-function filesThatDifferFromDev(files, { cwd, headRef }) {
+function filesThatDifferFromSnapshot(files, { cwd, headRef, snapshotRef }) {
   return files.filter((filePath) => {
     const result = spawnSync(
       "git",
-      ["diff", "--quiet", "origin/dev", headRef, "--", filePath],
+      ["diff", "--quiet", snapshotRef, headRef, "--", filePath],
       { cwd, encoding: "utf8" },
     );
     if (result.status === 0) return false;
     if (result.status === 1) return true;
     die(
-      `Unable to compare ${filePath} with origin/dev: ${result.stderr || result.error?.message || "git diff failed"}`,
+      `Unable to compare ${filePath} with ${snapshotRef}: ${result.stderr || result.error?.message || "git diff failed"}`,
     );
   });
 }
@@ -108,6 +108,7 @@ function parseArgs(argv) {
     baseRef: "",
     headRef: "HEAD",
     headBranch: "",
+    snapshotRef: "",
   };
 
   for (const arg of argv) {
@@ -129,6 +130,10 @@ function parseArgs(argv) {
     }
     if (arg.startsWith("--head-branch=")) {
       options.headBranch = arg.slice("--head-branch=".length);
+      continue;
+    }
+    if (arg.startsWith("--snapshot-ref=")) {
+      options.snapshotRef = arg.slice("--snapshot-ref=".length);
       continue;
     }
     die(`Unsupported argument: ${arg}`);
@@ -168,9 +173,10 @@ function main() {
         `Governance backports to main contain unsupported files:\n${formatFileList(unsupported)}`,
       );
     }
-    const driftFiles = filesThatDifferFromDev(changedFiles, {
+    const driftFiles = filesThatDifferFromSnapshot(changedFiles, {
       cwd: options.cwd,
       headRef: options.headRef,
+      snapshotRef: "origin/dev",
     });
     if (driftFiles.length > 0) {
       die(
@@ -221,15 +227,22 @@ function main() {
     );
   }
 
+  if (!/^[0-9a-f]{40}$/.test(options.snapshotRef)) {
+    die(
+      "Promotion PR validation requires --snapshot-ref with the immutable 40-character dev commit selected when the promotion was created.",
+    );
+  }
+  ensureRefExists(options.snapshotRef, { cwd: options.cwd });
+
   const driftFiles = listPromotionBranchDiffFiles({
-    fromRef: "origin/dev",
+    fromRef: options.snapshotRef,
     toRef: options.headRef,
     cwd: options.cwd,
   });
 
   if (driftFiles.length > 0) {
     die(
-      `Promotion PR is stale. ${options.headRef} does not match origin/dev on product-owned paths:\n${formatFileList(driftFiles)}`,
+      `Promotion PR does not match selected dev snapshot ${options.snapshotRef} on product-owned paths:\n${formatFileList(driftFiles)}`,
     );
   }
 
@@ -239,7 +252,9 @@ function main() {
     headRef: options.headRef,
   });
 
-  console.log("Main PR guard passed. Promotion branch matches origin/dev.");
+  console.log(
+    `Main PR guard passed. Promotion branch matches selected dev snapshot ${options.snapshotRef}.`,
+  );
 }
 
 main();


### PR DESCRIPTION
(AI Generated).

## Summary
- Validate production promotions against the immutable dev commit selected at creation time.
- Record that source commit in a promotion commit trailer so later dev work cannot invalidate or expand the candidate.

## Testing
- npm run validate:feature
- node --test scripts/release-promotion.test.mjs scripts/promote-dev-to-main.test.mjs scripts/release-governance.test.mjs