### PR TITLE
fix: preserve release controls across snapshots

### DIFF
--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -370,7 +370,9 @@ snapshot uses `./scripts/deploy-pwa-production-snapshot.sh <promoted-dev-sha>`
 from exact `origin/main`; it creates no version, tag, Desktop build, release
 notes, or public release card. The promotion commit records the selected SHA in
 its `Freed-Dev-Snapshot` trailer, and the main PR guard validates against that
-immutable commit instead of the moving `origin/dev` tip. Dev release prep requires exact current
+immutable commit instead of the moving `origin/dev` tip. The small promotion
+control file set stays current with `dev`, so release governance can be repaired
+without pulling newer product work into an already selected snapshot. Dev release prep requires exact current
 `origin/dev`. Both versioned release lanes return through branch protection. `release-publish.sh`
 refuses to tag unless local `HEAD` exactly equals the target remote branch, so
 it cannot tag an unmerged local release commit. It also binds the requested tag,

--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -34,6 +34,16 @@ export const FORBIDDEN_MAIN_PR_PREFIXES = ["website/"];
 
 export const PROMOTION_WEBSITE_CONFIG_FILES = ["website/next.config.ts"];
 
+export const PROMOTION_CONTROL_FILES = [
+  ".github/workflows/ci.yml",
+  "docs/RELEASE-SECRETS.md",
+  "scripts/promote-dev-to-main.sh",
+  "scripts/promote-dev-to-main.test.mjs",
+  "scripts/release-governance.test.mjs",
+  "scripts/release-promotion.test.mjs",
+  "scripts/validate-main-pr.mjs",
+];
+
 export const PROMOTION_BRANCH_PATTERN =
   /^chore\/promote-dev-to-main(?:-[a-z0-9._-]+)?$/;
 export const RELEASE_PREP_BRANCH_PATTERN = /^chore\/release-[a-z0-9._-]+$/;
@@ -103,6 +113,10 @@ export function isPromotionScopeFile(filePath) {
   );
 }
 
+export function isPromotionControlFile(filePath) {
+  return PROMOTION_CONTROL_FILES.includes(filePath);
+}
+
 export function listChangedFiles({
   fromRef,
   toRef,
@@ -136,6 +150,7 @@ export function listPromotionDiffFiles({ fromRef, toRef, cwd }) {
 
   return uniqueSorted([...promotionScopeFiles, ...websiteConfigFiles]).filter(
     (filePath) => {
+      if (isPromotionControlFile(filePath)) return false;
       if (isReleaseOnlyFile(filePath)) return false;
       if (filePath !== CARGO_LOCK_PATH) return true;
       return !isCargoLockReleaseOnlyChange({ fromRef, toRef, cwd });
@@ -167,7 +182,7 @@ export function listPromotionBranchDiffFiles({ fromRef, toRef, cwd }) {
     ...promotionScopeFiles,
     ...websiteConfigFiles,
     ...releaseNoteFiles,
-  ]);
+  ]).filter((filePath) => !isPromotionControlFile(filePath));
 }
 
 export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
@@ -197,7 +212,7 @@ export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
     ...promotionScopeFiles,
     ...websiteConfigFiles,
     ...releaseNoteFiles,
-  ]);
+  ]).filter((filePath) => !isPromotionControlFile(filePath));
 }
 
 export function listComparisonFiles({ baseRef, headRef, cwd }) {

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -173,6 +173,11 @@ test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {
     "release-notes/releases/v26.4.2100.json",
     '{\n  "approved": true\n}\n',
   );
+  writeRepoFile(
+    cwd,
+    "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
   commitAll(cwd, "dev change");
 
   const files = listPromotionDiffFiles({
@@ -182,6 +187,53 @@ test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {
   });
 
   assert.deepEqual(files, ["packages/pwa/src/app.ts"]);
+});
+
+test("an old product snapshot preserves current promotion controls", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'selected snapshot';\n",
+  );
+  commitAll(cwd, "selected product snapshot");
+  const snapshotSha = git(cwd, ["rev-parse", "HEAD"]);
+
+  writeRepoFile(
+    cwd,
+    "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
+  commitAll(cwd, "fix: current promotion control");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
+  commitAll(cwd, "fix: backport promotion control");
+  updateOriginRef(cwd, "main");
+
+  git(cwd, ["checkout", "-b", "chore/promote-dev-to-main-snapshot", "main"]);
+  const prepared = runNode(PREPARE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    `--from-ref=${snapshotSha}`,
+    "--base-ref=origin/main",
+  ]);
+  assert.equal(prepared.status, 0, prepared.stderr);
+  assert.equal(
+    git(cwd, ["show", ":packages/pwa/src/app.ts"]),
+    "export const value = 'selected snapshot';",
+  );
+  assert.equal(
+    git(cwd, ["show", ":scripts/validate-main-pr.mjs"]),
+    "export const control = 'current';",
+  );
 });
 
 test("validate-release-promotion fails when main is stale on product files", (t) => {

--- a/scripts/validate-main-pr.mjs
+++ b/scripts/validate-main-pr.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   PROMOTION_BRANCH_PATTERN,
+  PROMOTION_CONTROL_FILES,
   RELEASE_PREP_BRANCH_PATTERN,
   classifyMainPrFiles,
   ensureRefExists,
@@ -19,6 +20,7 @@ const REPO_ROOT = path.resolve(__dirname, "..");
 const GOVERNANCE_BACKPORT_BRANCH_PATTERN =
   /^fix\/main-governance-[a-z0-9._-]+$/;
 const GOVERNANCE_BACKPORT_FILES = new Set([
+  ...PROMOTION_CONTROL_FILES,
   ".github/CODEOWNERS",
   ".github/ISSUE_TEMPLATE/debt.yml",
   ".agents/skills/freed-build-feature/SKILL.md",
@@ -233,6 +235,20 @@ function main() {
     );
   }
   ensureRefExists(options.snapshotRef, { cwd: options.cwd });
+
+  const controlDriftFiles = filesThatDifferFromSnapshot(
+    PROMOTION_CONTROL_FILES,
+    {
+      cwd: options.cwd,
+      headRef: options.headRef,
+      snapshotRef: "origin/dev",
+    },
+  );
+  if (controlDriftFiles.length > 0) {
+    die(
+      `Promotion control files must exactly match origin/dev:\n${formatFileList(controlDriftFiles)}`,
+    );
+  }
 
   const driftFiles = listPromotionBranchDiffFiles({
     fromRef: options.snapshotRef,


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the selected product snapshot immutable while allowing the explicit promotion control file set to stay current.
- Require those control files to match dev exactly, so governance repairs cannot carry arbitrary main-only content.

## Testing
- npm run validate:feature
- node --test scripts/release-promotion.test.mjs scripts/promote-dev-to-main.test.mjs scripts/release-governance.test.mjs