### PR TITLE
fix: preserve snapshot control definition

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -40,6 +40,7 @@ export const PROMOTION_CONTROL_FILES = [
   "scripts/promote-dev-to-main.sh",
   "scripts/promote-dev-to-main.test.mjs",
   "scripts/release-governance.test.mjs",
+  "scripts/release-promotion-shared.mjs",
   "scripts/release-promotion.test.mjs",
   "scripts/validate-main-pr.mjs",
 ];

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -14,6 +14,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  PROMOTION_CONTROL_FILES,
   listPromotionBranchDiffFiles,
   listPromotionDiffFiles,
 } from "./release-promotion-shared.mjs";
@@ -151,6 +152,10 @@ function runNode(scriptPath, args) {
     encoding: "utf8",
   });
 }
+
+test("the promotion control definition preserves itself", () => {
+  assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release-promotion-shared.mjs"));
+});
 
 test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {
   const cwd = makeTempRepo();


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the promotion control definition itself current when deploying an older product snapshot.

## Testing
- npm run validate:feature
- node --test scripts/release-promotion.test.mjs