### PR TITLE
fix: backport immutable snapshot controls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -273,11 +273,16 @@ jobs:
         run: git fetch origin dev main
 
       - name: Validate main PR scope
+        env:
+          PROMOTION_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          PROMOTION_HEAD_BRANCH: ${{ github.head_ref }}
         run: |
+          snapshot_ref="$(git show -s --format='%(trailers:key=Freed-Dev-Snapshot,valueonly)' "${PROMOTION_HEAD_SHA}")"
           node scripts/validate-main-pr.mjs \
             --base-ref="origin/${{ github.base_ref }}" \
-            --head-ref="${{ github.event.pull_request.head.sha }}" \
-            --head-branch="${{ github.head_ref }}"
+            --head-ref="${PROMOTION_HEAD_SHA}" \
+            --head-branch="${PROMOTION_HEAD_BRANCH}" \
+            --snapshot-ref="${snapshot_ref}"
 
   feature:
     name: Feature validation

--- a/docs/RELEASE-SECRETS.md
+++ b/docs/RELEASE-SECRETS.md
@@ -363,8 +363,17 @@ After it merges, tag the exact updated `origin/dev` commit with
 `./scripts/release-publish.sh <version>-dev`.
 
 Production release prep requires an exact current `origin/main` base after any
-required product promotion. Dev release prep requires exact current
-`origin/dev`. Both return through branch protection. `release-publish.sh`
+required product promotion and the immutable source dev SHA recorded by that
+promotion, passed as `--promoted-dev-sha=<sha>`. Later commits on `dev` do not
+invalidate or expand the selected production snapshot. A production PWA-only
+snapshot uses `./scripts/deploy-pwa-production-snapshot.sh <promoted-dev-sha>`
+from exact `origin/main`; it creates no version, tag, Desktop build, release
+notes, or public release card. The promotion commit records the selected SHA in
+its `Freed-Dev-Snapshot` trailer, and the main PR guard validates against that
+immutable commit instead of the moving `origin/dev` tip. The small promotion
+control file set stays current with `dev`, so release governance can be repaired
+without pulling newer product work into an already selected snapshot. Dev release prep requires exact current
+`origin/dev`. Both versioned release lanes return through branch protection. `release-publish.sh`
 refuses to tag unless local `HEAD` exactly equals the target remote branch, so
 it cannot tag an unmerged local release commit. It also binds the requested tag,
 channel, Desktop, PWA, Tauri, and Cargo versions to the reviewed release

--- a/scripts/deploy-pwa-production-snapshot.sh
+++ b/scripts/deploy-pwa-production-snapshot.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+  echo "Usage: $0 <promoted-dev-sha>" >&2
+  exit 1
+fi
+
+SNAPSHOT_SHA_INPUT="$1"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# shellcheck source=./lib/node-tooling.sh
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+use_resolved_node_path
+NODE_BIN="$(resolve_node_bin)"
+
+cd "${REPO_ROOT}"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Error: production snapshot deployment requires a clean worktree." >&2
+  exit 1
+fi
+
+if [[ ! "${SNAPSHOT_SHA_INPUT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Error: promoted dev snapshot must be one full 40-character commit SHA." >&2
+  exit 1
+fi
+
+git fetch origin main
+SNAPSHOT_SHA="$(git rev-parse "${SNAPSHOT_SHA_INPUT}^{commit}")"
+MAIN_SHA="$(git rev-parse origin/main)"
+HEAD_SHA="$(git rev-parse HEAD)"
+
+if [[ "${SNAPSHOT_SHA}" != "${SNAPSHOT_SHA_INPUT}" ]]; then
+  echo "Error: promoted dev snapshot must name one exact commit without abbreviation." >&2
+  exit 1
+fi
+if [[ "${HEAD_SHA}" != "${MAIN_SHA}" ]]; then
+  echo "Error: production snapshot deployment must run from exact origin/main ${MAIN_SHA}; HEAD is ${HEAD_SHA}." >&2
+  exit 1
+fi
+
+"${NODE_BIN}" scripts/validate-release-promotion.mjs \
+  --from-ref="${SNAPSHOT_SHA}" \
+  --to-ref="${MAIN_SHA}"
+
+echo "Deploying production PWA snapshot from main ${MAIN_SHA}, selected from dev ${SNAPSHOT_SHA}."
+FREED_BUILD_KIND=snapshot \
+FREED_BUILD_CHANNEL=production \
+FREED_BUILD_COMMIT_SHA="${MAIN_SHA}" \
+FREED_BUILD_COMMIT_REF=main \
+  "${SCRIPT_DIR}/vercel-deploy-production.sh" pwa
+
+echo "Production PWA snapshot deployed."
+echo "Main SHA: ${MAIN_SHA}"
+echo "Promoted dev SHA: ${SNAPSHOT_SHA}"

--- a/scripts/promote-dev-to-main.sh
+++ b/scripts/promote-dev-to-main.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 if [[ $# -lt 1 ]]; then
-  echo "Usage: ./scripts/promote-dev-to-main.sh <worktree-path> [<branch-name>] [--provider-risk-review-artifact <path> | --provider-risk-approval-file <path>]" >&2
+  echo "Usage: ./scripts/promote-dev-to-main.sh <worktree-path> [<branch-name>] [--snapshot-sha <40-hex-sha>] [--provider-risk-review-artifact <path> | --provider-risk-approval-file <path>]" >&2
   exit 1
 fi
 
@@ -12,6 +12,7 @@ shift
 BRANCH_NAME=""
 PROVIDER_RISK_APPROVAL_FILE=""
 PROVIDER_RISK_REVIEW_ARTIFACT=""
+SNAPSHOT_SHA_INPUT=""
 if [[ $# -gt 0 && "$1" != --* ]]; then
   BRANCH_NAME="$1"
   shift
@@ -19,6 +20,11 @@ fi
 BRANCH_NAME="${BRANCH_NAME:-chore/promote-dev-to-main-$(date +%Y%m%d-%H%M%S)}"
 while [[ $# -gt 0 ]]; do
   case "$1" in
+    --snapshot-sha)
+      [[ $# -ge 2 && -n "$2" ]] || { echo "Error: --snapshot-sha requires a 40-character commit SHA." >&2; exit 1; }
+      SNAPSHOT_SHA_INPUT="$2"
+      shift 2
+      ;;
     --provider-risk-review-artifact)
       [[ $# -ge 2 && -n "$2" ]] || { echo "Error: --provider-risk-review-artifact requires a path." >&2; exit 1; }
       PROVIDER_RISK_REVIEW_ARTIFACT="$2"
@@ -66,8 +72,22 @@ fi
 
 /usr/bin/git fetch origin dev main
 
-if "${NODE_BIN}" "${SCRIPT_DIR}/validate-release-promotion.mjs" --from-ref=origin/dev --to-ref=origin/main >/dev/null 2>&1; then
-  echo "origin/main already matches origin/dev on product-owned paths."
+if [[ -z "${SNAPSHOT_SHA_INPUT}" ]]; then
+  SNAPSHOT_SHA_INPUT="$(/usr/bin/git rev-parse origin/dev)"
+fi
+if [[ ! "${SNAPSHOT_SHA_INPUT}" =~ ^[0-9a-f]{40}$ ]]; then
+  echo "Error: --snapshot-sha must be one full 40-character commit SHA." >&2
+  exit 1
+fi
+SNAPSHOT_SHA="$(/usr/bin/git rev-parse "${SNAPSHOT_SHA_INPUT}^{commit}")"
+if [[ "${SNAPSHOT_SHA}" != "${SNAPSHOT_SHA_INPUT}" ]]; then
+  echo "Error: --snapshot-sha must name one exact commit without abbreviation." >&2
+  exit 1
+fi
+
+if "${NODE_BIN}" "${SCRIPT_DIR}/validate-release-promotion.mjs" --from-ref="${SNAPSHOT_SHA}" --to-ref=origin/main >/dev/null 2>&1; then
+  echo "origin/main already matches immutable dev snapshot ${SNAPSHOT_SHA} on product-owned paths."
+  echo "Prepare production with: ./scripts/release.sh --promoted-dev-sha=${SNAPSHOT_SHA}"
   exit 0
 fi
 
@@ -98,7 +118,7 @@ else
     /usr/bin/git fetch origin dev main
     "${NODE_BIN}" "${SCRIPT_DIR}/prepare-release-promotion.mjs" \
       --cwd="${WORKTREE_PATH}" \
-      --from-ref=origin/dev \
+      --from-ref="${SNAPSHOT_SHA}" \
       --base-ref=origin/main
 
     if /usr/bin/git diff --cached --quiet; then
@@ -106,13 +126,20 @@ else
       exit 1
     fi
 
-    /usr/bin/git commit -m "${TITLE}"
+    /usr/bin/git commit -m "${TITLE}" -m "Freed-Dev-Snapshot: ${SNAPSHOT_SHA}"
   )
 fi
 
 (
   cd "${WORKTREE_PATH}"
   /usr/bin/git fetch origin dev main
+  RECORDED_SNAPSHOT="$(/usr/bin/git show -s --format='%(trailers:key=Freed-Dev-Snapshot,valueonly)' HEAD)"
+  if [[ -z "${RECORDED_SNAPSHOT}" ]]; then
+    /usr/bin/git commit --amend --no-edit --trailer "Freed-Dev-Snapshot: ${SNAPSHOT_SHA}"
+  elif [[ "${RECORDED_SNAPSHOT}" != "${SNAPSHOT_SHA}" ]]; then
+    echo "Error: promotion commit records immutable dev snapshot ${RECORDED_SNAPSHOT}, not requested snapshot ${SNAPSHOT_SHA}." >&2
+    exit 1
+  fi
   MAIN_SHA="$(/usr/bin/git rev-parse origin/main)"
   HEAD_PARENT="$(/usr/bin/git rev-parse HEAD^)"
   if [[ "${HEAD_PARENT}" != "${MAIN_SHA}" ]]; then
@@ -126,22 +153,24 @@ fi
   "${NODE_BIN}" scripts/validate-main-pr.mjs \
     --base-ref=origin/main \
     --head-ref=HEAD \
-    --head-branch="${BRANCH_NAME}"
+    --head-branch="${BRANCH_NAME}" \
+    --snapshot-ref="${SNAPSHOT_SHA}"
+  "${NODE_BIN}" scripts/validate-release-promotion.mjs \
+    --from-ref="${SNAPSHOT_SHA}" \
+    --to-ref=HEAD
 
   BODY_FILE="$(mktemp)"
   trap 'rm -f "${BODY_FILE}"' EXIT
-  DEV_SHA="$(/usr/bin/git rev-parse origin/dev)"
-
   cat > "${BODY_FILE}" <<EOF
 (AI Generated).
 
 ## Summary
-- Promote the current \`origin/dev\` product snapshot into \`main\` before a production release.
+- Promote one immutable dev product snapshot into \`main\` before a production release.
 - Base main SHA: \`${MAIN_SHA}\`
-- Source dev SHA: \`${DEV_SHA}\`
+- Source dev SHA: \`${SNAPSHOT_SHA}\`
 
 ## Testing
-- \`node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=${BRANCH_NAME}\`
+- \`node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=${BRANCH_NAME} --snapshot-ref=${SNAPSHOT_SHA}\`
 - CI
 EOF
 
@@ -161,3 +190,4 @@ EOF
 
 echo "Promotion PR created from ${BRANCH_NAME}."
 echo "After it merges, refresh origin/main. Create the production release-prep branch from that exact commit."
+echo "Prepare production with: ./scripts/release.sh --promoted-dev-sha=${SNAPSHOT_SHA}"

--- a/scripts/promote-dev-to-main.test.mjs
+++ b/scripts/promote-dev-to-main.test.mjs
@@ -65,7 +65,7 @@ async function existingPromotionFixture(t) {
   await fs.copyFile(path.join(sourceRoot, ".nvmrc"), path.join(repo, ".nvmrc"));
   await fs.writeFile(
     path.join(repo, "scripts/validate-release-promotion.mjs"),
-    "process.exit(1);\n",
+    'process.exit(process.argv.includes("--to-ref=origin/main") ? 1 : 0);\n',
   );
   await fs.writeFile(
     path.join(repo, "scripts/validate-main-pr.mjs"),
@@ -254,7 +254,14 @@ test("promotion forwards one provider review artifact to draft publication", asy
       "--base-ref=origin/main",
       "--head-ref=HEAD",
       `--head-branch=${fixture.branch}`,
+      `--snapshot-ref=${mustRun("git", ["rev-parse", "origin/dev"], { cwd: fixture.repo }).stdout.trim()}`,
     ],
+  );
+  assert.match(
+    mustRun("git", ["show", "-s", "--format=%B", "HEAD"], {
+      cwd: fixture.worktree,
+    }).stdout,
+    /Freed-Dev-Snapshot: [0-9a-f]{40}/,
   );
 });
 

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -26,6 +26,10 @@ const promotion = readFileSync(
   path.join(scriptsDir, "promote-dev-to-main.sh"),
   "utf8",
 );
+const pwaProductionSnapshot = readFileSync(
+  path.join(scriptsDir, "deploy-pwa-production-snapshot.sh"),
+  "utf8",
+);
 const releaseWorkflow = readFileSync(
   path.join(scriptsDir, "..", ".github", "workflows", "release.yml"),
   "utf8",
@@ -67,7 +71,36 @@ test("release preparation uses the channel's protected branch as its exact base"
   assert.match(releasePrep, /--base \$\{EXPECTED_BRANCH\} --ready/);
   assert.match(releasePrep, /npm run validate:release/);
   assert.match(releasePrep, /npm run validate:feature/);
+  assert.match(releasePrep, /--promoted-dev-sha=<40-hex-sha>/);
+  assert.match(
+    releasePrep,
+    /--from-ref="\$\{PROMOTED_DEV_COMMIT_SHA\}"/,
+  );
+  assert.doesNotMatch(
+    releasePrep,
+    /validate-release-promotion\.mjs --from-ref=origin\/dev/,
+  );
   assert.doesNotMatch(releasePrep, /git push origin (?:dev|main)/);
+});
+
+test("PWA production snapshots bind one promoted dev SHA without generating a release", () => {
+  assert.match(pwaProductionSnapshot, /git fetch origin main/);
+  assert.match(
+    pwaProductionSnapshot,
+    /\$\{HEAD_SHA\}" != "\$\{MAIN_SHA\}"/,
+  );
+  assert.match(
+    pwaProductionSnapshot,
+    /validate-release-promotion\.mjs[\s\S]*--from-ref="\$\{SNAPSHOT_SHA\}"[\s\S]*--to-ref="\$\{MAIN_SHA\}"/,
+  );
+  assert.match(pwaProductionSnapshot, /FREED_BUILD_KIND=snapshot/);
+  assert.match(pwaProductionSnapshot, /FREED_BUILD_CHANNEL=production/);
+  assert.match(
+    pwaProductionSnapshot,
+    /vercel-deploy-production\.sh" pwa/,
+  );
+  assert.doesNotMatch(pwaProductionSnapshot, /release\.sh/);
+  assert.doesNotMatch(pwaProductionSnapshot, /release-notes/);
 });
 
 test("release publication delegates one exact tag to the trusted App publisher", () => {
@@ -131,6 +164,11 @@ test("release publication delegates one exact tag to the trusted App publisher",
   assert.match(
     releasePrep,
     /FREED_PROMOTED_DEV_COMMIT_SHA="\$\{PROMOTED_DEV_COMMIT_SHA\}"/,
+  );
+  assert.match(promotion, /--from-ref="\$\{SNAPSHOT_SHA\}"/);
+  assert.match(
+    promotion,
+    /\.\/scripts\/release\.sh --promoted-dev-sha=\$\{SNAPSHOT_SHA\}/,
   );
   assert.match(releaseWorkflow, /EXPECTED_BRANCH="main"/);
   assert.match(releaseWorkflow, /TAG" == \*-dev[\s\S]*EXPECTED_BRANCH="dev"/);
@@ -406,12 +444,18 @@ test("feature and dev validation route OPFS durability to macOS WebKit", () => {
 test("main PR validation inspects the actual PR head instead of the synthetic merge", () => {
   assert.match(
     ciWorkflow,
-    /--head-ref="\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/,
+    /PROMOTION_HEAD_SHA: \$\{\{ github\.event\.pull_request\.head\.sha \}\}/,
   );
+  assert.match(ciWorkflow, /--head-ref="\$\{PROMOTION_HEAD_SHA\}"/);
   assert.doesNotMatch(
     ciWorkflow,
     /validate-main-pr\.mjs[\s\S]*--head-ref=HEAD/,
   );
+  assert.match(
+    ciWorkflow,
+    /trailers:key=Freed-Dev-Snapshot,valueonly/,
+  );
+  assert.match(ciWorkflow, /--snapshot-ref="\$\{snapshot_ref\}"/);
 });
 
 test("release preparation validates canonical CalVer before mutating version files", () => {

--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -34,6 +34,19 @@ export const FORBIDDEN_MAIN_PR_PREFIXES = ["website/"];
 
 export const PROMOTION_WEBSITE_CONFIG_FILES = ["website/next.config.ts"];
 
+export const PROMOTION_CONTROL_FILES = [
+  ".github/workflows/ci.yml",
+  "docs/RELEASE-SECRETS.md",
+  "scripts/deploy-pwa-production-snapshot.sh",
+  "scripts/promote-dev-to-main.sh",
+  "scripts/promote-dev-to-main.test.mjs",
+  "scripts/release-governance.test.mjs",
+  "scripts/release-promotion-shared.mjs",
+  "scripts/release-promotion.test.mjs",
+  "scripts/release.sh",
+  "scripts/validate-main-pr.mjs",
+];
+
 export const PROMOTION_BRANCH_PATTERN =
   /^chore\/promote-dev-to-main(?:-[a-z0-9._-]+)?$/;
 export const RELEASE_PREP_BRANCH_PATTERN = /^chore\/release-[a-z0-9._-]+$/;
@@ -103,6 +116,10 @@ export function isPromotionScopeFile(filePath) {
   );
 }
 
+export function isPromotionControlFile(filePath) {
+  return PROMOTION_CONTROL_FILES.includes(filePath);
+}
+
 export function listChangedFiles({
   fromRef,
   toRef,
@@ -136,6 +153,7 @@ export function listPromotionDiffFiles({ fromRef, toRef, cwd }) {
 
   return uniqueSorted([...promotionScopeFiles, ...websiteConfigFiles]).filter(
     (filePath) => {
+      if (isPromotionControlFile(filePath)) return false;
       if (isReleaseOnlyFile(filePath)) return false;
       if (filePath !== CARGO_LOCK_PATH) return true;
       return !isCargoLockReleaseOnlyChange({ fromRef, toRef, cwd });
@@ -167,7 +185,7 @@ export function listPromotionBranchDiffFiles({ fromRef, toRef, cwd }) {
     ...promotionScopeFiles,
     ...websiteConfigFiles,
     ...releaseNoteFiles,
-  ]);
+  ]).filter((filePath) => !isPromotionControlFile(filePath));
 }
 
 export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
@@ -197,7 +215,7 @@ export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
     ...promotionScopeFiles,
     ...websiteConfigFiles,
     ...releaseNoteFiles,
-  ]);
+  ]).filter((filePath) => !isPromotionControlFile(filePath));
 }
 
 export function listComparisonFiles({ baseRef, headRef, cwd }) {

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -14,6 +14,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  PROMOTION_CONTROL_FILES,
   listPromotionBranchDiffFiles,
   listPromotionDiffFiles,
 } from "./release-promotion-shared.mjs";
@@ -152,6 +153,12 @@ function runNode(scriptPath, args) {
   });
 }
 
+test("the promotion control definition preserves itself", () => {
+  assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release-promotion-shared.mjs"));
+  assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/deploy-pwa-production-snapshot.sh"));
+  assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release.sh"));
+});
+
 test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));
@@ -173,6 +180,11 @@ test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {
     "release-notes/releases/v26.4.2100.json",
     '{\n  "approved": true\n}\n',
   );
+  writeRepoFile(
+    cwd,
+    "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
   commitAll(cwd, "dev change");
 
   const files = listPromotionDiffFiles({
@@ -182,6 +194,53 @@ test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {
   });
 
   assert.deepEqual(files, ["packages/pwa/src/app.ts"]);
+});
+
+test("an old product snapshot preserves current promotion controls", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'selected snapshot';\n",
+  );
+  commitAll(cwd, "selected product snapshot");
+  const snapshotSha = git(cwd, ["rev-parse", "HEAD"]);
+
+  writeRepoFile(
+    cwd,
+    "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
+  commitAll(cwd, "fix: current promotion control");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
+  commitAll(cwd, "fix: backport promotion control");
+  updateOriginRef(cwd, "main");
+
+  git(cwd, ["checkout", "-b", "chore/promote-dev-to-main-snapshot", "main"]);
+  const prepared = runNode(PREPARE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    `--from-ref=${snapshotSha}`,
+    "--base-ref=origin/main",
+  ]);
+  assert.equal(prepared.status, 0, prepared.stderr);
+  assert.equal(
+    git(cwd, ["show", ":packages/pwa/src/app.ts"]),
+    "export const value = 'selected snapshot';",
+  );
+  assert.equal(
+    git(cwd, ["show", ":scripts/validate-main-pr.mjs"]),
+    "export const control = 'current';",
+  );
 });
 
 test("validate-release-promotion fails when main is stale on product files", (t) => {
@@ -205,6 +264,52 @@ test("validate-release-promotion fails when main is stale on product files", (t)
   assert.equal(result.status, 1);
   assert.match(result.stderr, /Production release blocked/);
   assert.match(result.stderr, /packages\/pwa\/src\/app\.ts/);
+});
+
+test("an immutable promoted dev snapshot stays valid after dev advances", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'approved snapshot';\n",
+  );
+  commitAll(cwd, "approved snapshot");
+  const snapshotSha = git(cwd, ["rev-parse", "HEAD"]);
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'approved snapshot';\n",
+  );
+  commitAll(cwd, "promote approved snapshot");
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "packages/pwa/src/app.ts",
+    "export const value = 'later development';\n",
+  );
+  commitAll(cwd, "later dev change");
+  updateOriginRef(cwd, "dev");
+
+  const fixedSnapshot = runNode(VALIDATE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    `--from-ref=${snapshotSha}`,
+    "--to-ref=main",
+  ]);
+  assert.equal(fixedSnapshot.status, 0, fixedSnapshot.stderr);
+
+  const movingTip = runNode(VALIDATE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    "--from-ref=origin/dev",
+    "--to-ref=main",
+  ]);
+  assert.equal(movingTip.status, 1);
+  assert.match(movingTip.stderr, /packages\/pwa\/src\/app\.ts/);
 });
 
 test("prepare-release-promotion copies the dev product snapshot across squashed history", (t) => {
@@ -282,6 +387,11 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
   commitAll(cwd, "dev advances after promotion");
   updateOriginRef(cwd, "dev");
 
+  git(cwd, ["checkout", "main"]);
+  chmodSync(path.join(cwd, "scripts/release.sh"), 0o755);
+  commitAll(cwd, "fix: backport current release controls");
+  updateOriginRef(cwd, "main");
+
   git(cwd, [
     "checkout",
     "-b",
@@ -304,7 +414,7 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
   ]);
 
   assert.equal(prepared.status, 0, prepared.stderr);
-  assert.match(prepared.stdout, /Prepared 10 product paths for promotion/);
+  assert.match(prepared.stdout, /Prepared 9 product paths for promotion/);
   assert.equal(
     git(cwd, ["show", ":packages/pwa/src/app.ts"]),
     "export const value = 'next dev snapshot';",
@@ -353,6 +463,7 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260722",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
   assert.equal(validated.status, 0, validated.stderr);
 });
@@ -1034,6 +1145,7 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
   );
   commitAll(cwd, "dev change");
   updateOriginRef(cwd, "dev");
+  const snapshotSha = git(cwd, ["rev-parse", "origin/dev"]);
 
   git(cwd, ["checkout", "-b", "chore/promote-dev-to-main-20260421", "main"]);
   git(cwd, ["merge", "--squash", "--no-commit", "dev"]);
@@ -1043,6 +1155,10 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
     "chore: promote dev into main for production release",
   ]);
   const promotionHead = git(cwd, ["rev-parse", "HEAD"]);
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(cwd, "packages/pwa/src/later.ts", "export const later = true;\n");
+  commitAll(cwd, "later dev change");
+  updateOriginRef(cwd, "dev");
   git(cwd, ["checkout", "main"]);
   git(cwd, ["merge", "--no-ff", "--no-edit", promotionHead]);
   assert.equal(
@@ -1057,10 +1173,11 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
     "--base-ref=origin/main",
     `--head-ref=${promotionHead}`,
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${snapshotSha}`,
   ]);
 
   assert.equal(result.status, 0);
-  assert.match(result.stdout, /Promotion branch matches origin\/dev/);
+  assert.match(result.stdout, /Promotion branch matches selected dev snapshot/);
 });
 
 test("validate-main-pr rejects a promotion whose parent is no longer current main", (t) => {
@@ -1092,6 +1209,7 @@ test("validate-main-pr rejects a promotion whose parent is no longer current mai
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     `--head-branch=${promotionBranch}`,
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 1);
@@ -1145,10 +1263,11 @@ test("validate-main-pr rejects third-content release metadata on a promotion bra
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /Promotion PR is stale/);
+  assert.match(result.stderr, /does not match selected dev snapshot/);
   assert.match(result.stderr, /packages\/desktop\/src-tauri\/Cargo\.toml/);
 });
 
@@ -1198,10 +1317,11 @@ test("validate-main-pr rejects third-content release notes on a promotion branch
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 1);
-  assert.match(result.stderr, /Promotion PR is stale/);
+  assert.match(result.stderr, /does not match selected dev snapshot/);
   assert.match(result.stderr, /release-notes\/releases\/v26\.4\.2100\.json/);
 });
 
@@ -1236,10 +1356,11 @@ test("validate-main-pr allows website build config in promotion branches", (t) =
     "--base-ref=origin/main",
     "--head-ref=HEAD",
     "--head-branch=chore/promote-dev-to-main-20260421",
+    `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
 
   assert.equal(result.status, 0);
-  assert.match(result.stdout, /Promotion branch matches origin\/dev/);
+  assert.match(result.stdout, /Promotion branch matches selected dev snapshot/);
 });
 
 test("validate-main-pr rejects product changes on a non-promotion branch", (t) => {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -18,10 +18,10 @@ use_resolved_node_path
 # Note: major version (YY) must be ≤255 for Windows MSI compatibility.
 #
 # Usage:
-#   ./scripts/release.sh                            # auto-compute a production release
-#   ./scripts/release.sh --channel=production       # explicit production release
+#   ./scripts/release.sh --promoted-dev-sha=<sha>   # auto-compute a production release
+#   ./scripts/release.sh --channel=production --promoted-dev-sha=<sha>
 #   ./scripts/release.sh --channel=dev              # auto-compute a dev release
-#   ./scripts/release.sh 26.3.105                   # manual production override
+#   ./scripts/release.sh 26.3.105 --promoted-dev-sha=<sha>
 #   ./scripts/release.sh 26.3.105-dev --channel=dev # manual dev override
 
 DESKTOP_DIR="packages/desktop"
@@ -32,6 +32,7 @@ DESKTOP_PKG="${DESKTOP_DIR}/package.json"
 PWA_PKG="packages/pwa/package.json"
 CHANNEL="production"
 VERSION_INPUT=""
+PROMOTED_DEV_SHA_INPUT=""
 
 # Ensure tracked and untracked worktree state is clean.
 if [[ -n "$(git status --porcelain)" ]]; then
@@ -44,14 +45,17 @@ for arg in "$@"; do
     --channel=production|--channel=dev)
       CHANNEL="${arg#*=}"
       ;;
+    --promoted-dev-sha=*)
+      PROMOTED_DEV_SHA_INPUT="${arg#*=}"
+      ;;
     -h|--help)
-      echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev]" >&2
+      echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev] [--promoted-dev-sha=<40-hex-sha>]" >&2
       exit 0
       ;;
     *)
       if [[ -n "$VERSION_INPUT" ]]; then
         echo "Error: too many positional arguments." >&2
-        echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev]" >&2
+        echo "Usage: ./scripts/release.sh [<version>] [--channel=production|dev] [--promoted-dev-sha=<40-hex-sha>]" >&2
         exit 1
       fi
       VERSION_INPUT="${arg#v}"
@@ -86,8 +90,22 @@ fi
 
 PROMOTED_DEV_COMMIT_SHA=""
 if [[ "$CHANNEL" == "production" ]]; then
-  "${NODE_BIN}" scripts/validate-release-promotion.mjs --from-ref=origin/dev --to-ref=HEAD
-  PROMOTED_DEV_COMMIT_SHA="$(git rev-parse origin/dev)"
+  if [[ ! "${PROMOTED_DEV_SHA_INPUT}" =~ ^[0-9a-f]{40}$ ]]; then
+    echo "Error: production release prep requires --promoted-dev-sha=<40-hex-sha>." >&2
+    echo "Use the immutable source dev SHA recorded by the promotion PR, not the moving origin/dev branch." >&2
+    exit 1
+  fi
+  PROMOTED_DEV_COMMIT_SHA="$(git rev-parse "${PROMOTED_DEV_SHA_INPUT}^{commit}")"
+  if [[ "${PROMOTED_DEV_COMMIT_SHA}" != "${PROMOTED_DEV_SHA_INPUT}" ]]; then
+    echo "Error: --promoted-dev-sha must name one exact commit without abbreviation." >&2
+    exit 1
+  fi
+  "${NODE_BIN}" scripts/validate-release-promotion.mjs \
+    --from-ref="${PROMOTED_DEV_COMMIT_SHA}" \
+    --to-ref=HEAD
+elif [[ -n "${PROMOTED_DEV_SHA_INPUT}" ]]; then
+  echo "Error: --promoted-dev-sha is valid only for production releases." >&2
+  exit 1
 fi
 
 if [[ -n "$VERSION_INPUT" ]]; then

--- a/scripts/validate-main-pr.mjs
+++ b/scripts/validate-main-pr.mjs
@@ -5,6 +5,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
   PROMOTION_BRANCH_PATTERN,
+  PROMOTION_CONTROL_FILES,
   RELEASE_PREP_BRANCH_PATTERN,
   classifyMainPrFiles,
   ensureRefExists,
@@ -19,6 +20,7 @@ const REPO_ROOT = path.resolve(__dirname, "..");
 const GOVERNANCE_BACKPORT_BRANCH_PATTERN =
   /^fix\/main-governance-[a-z0-9._-]+$/;
 const GOVERNANCE_BACKPORT_FILES = new Set([
+  ...PROMOTION_CONTROL_FILES,
   ".github/CODEOWNERS",
   ".github/ISSUE_TEMPLATE/debt.yml",
   ".agents/skills/freed-build-feature/SKILL.md",
@@ -51,21 +53,21 @@ function die(message) {
 
 function usage() {
   console.error(
-    "Usage: node scripts/validate-main-pr.mjs [--cwd=<path>] --base-ref=<ref> --head-ref=<ref> --head-branch=<branch>",
+    "Usage: node scripts/validate-main-pr.mjs [--cwd=<path>] --base-ref=<ref> --head-ref=<ref> --head-branch=<branch> [--snapshot-ref=<40-hex-sha>]",
   );
 }
 
-function filesThatDifferFromDev(files, { cwd, headRef }) {
+function filesThatDifferFromSnapshot(files, { cwd, headRef, snapshotRef }) {
   return files.filter((filePath) => {
     const result = spawnSync(
       "git",
-      ["diff", "--quiet", "origin/dev", headRef, "--", filePath],
+      ["diff", "--quiet", snapshotRef, headRef, "--", filePath],
       { cwd, encoding: "utf8" },
     );
     if (result.status === 0) return false;
     if (result.status === 1) return true;
     die(
-      `Unable to compare ${filePath} with origin/dev: ${result.stderr || result.error?.message || "git diff failed"}`,
+      `Unable to compare ${filePath} with ${snapshotRef}: ${result.stderr || result.error?.message || "git diff failed"}`,
     );
   });
 }
@@ -108,6 +110,7 @@ function parseArgs(argv) {
     baseRef: "",
     headRef: "HEAD",
     headBranch: "",
+    snapshotRef: "",
   };
 
   for (const arg of argv) {
@@ -129,6 +132,10 @@ function parseArgs(argv) {
     }
     if (arg.startsWith("--head-branch=")) {
       options.headBranch = arg.slice("--head-branch=".length);
+      continue;
+    }
+    if (arg.startsWith("--snapshot-ref=")) {
+      options.snapshotRef = arg.slice("--snapshot-ref=".length);
       continue;
     }
     die(`Unsupported argument: ${arg}`);
@@ -168,9 +175,10 @@ function main() {
         `Governance backports to main contain unsupported files:\n${formatFileList(unsupported)}`,
       );
     }
-    const driftFiles = filesThatDifferFromDev(changedFiles, {
+    const driftFiles = filesThatDifferFromSnapshot(changedFiles, {
       cwd: options.cwd,
       headRef: options.headRef,
+      snapshotRef: "origin/dev",
     });
     if (driftFiles.length > 0) {
       die(
@@ -221,15 +229,36 @@ function main() {
     );
   }
 
+  if (!/^[0-9a-f]{40}$/.test(options.snapshotRef)) {
+    die(
+      "Promotion PR validation requires --snapshot-ref with the immutable 40-character dev commit selected when the promotion was created.",
+    );
+  }
+  ensureRefExists(options.snapshotRef, { cwd: options.cwd });
+
+  const controlDriftFiles = filesThatDifferFromSnapshot(
+    PROMOTION_CONTROL_FILES,
+    {
+      cwd: options.cwd,
+      headRef: options.headRef,
+      snapshotRef: "origin/dev",
+    },
+  );
+  if (controlDriftFiles.length > 0) {
+    die(
+      `Promotion control files must exactly match origin/dev:\n${formatFileList(controlDriftFiles)}`,
+    );
+  }
+
   const driftFiles = listPromotionBranchDiffFiles({
-    fromRef: "origin/dev",
+    fromRef: options.snapshotRef,
     toRef: options.headRef,
     cwd: options.cwd,
   });
 
   if (driftFiles.length > 0) {
     die(
-      `Promotion PR is stale. ${options.headRef} does not match origin/dev on product-owned paths:\n${formatFileList(driftFiles)}`,
+      `Promotion PR does not match selected dev snapshot ${options.snapshotRef} on product-owned paths:\n${formatFileList(driftFiles)}`,
     );
   }
 
@@ -239,7 +268,9 @@ function main() {
     headRef: options.headRef,
   });
 
-  console.log("Main PR guard passed. Promotion branch matches origin/dev.");
+  console.log(
+    `Main PR guard passed. Promotion branch matches selected dev snapshot ${options.snapshotRef}.`,
+  );
 }
 
 main();


### PR DESCRIPTION
(AI Generated).

## Summary
- Backport only the current production promotion control closure to main.
- Leave every PWA, Desktop, provider, and showcase product file unchanged.

## Testing
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=fix/main-governance-snapshot-controls
- node --test scripts/release-promotion.test.mjs scripts/promote-dev-to-main.test.mjs scripts/release-governance.test.mjs