### PR TITLE
fix: backport snapshot publisher forwarding

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -45,6 +45,8 @@ export const PROMOTION_CONTROL_FILES = [
   "scripts/release-promotion.test.mjs",
   "scripts/release.sh",
   "scripts/validate-main-pr.mjs",
+  "scripts/trusted-worktree-publish.sh",
+  "scripts/worktree-publish.sh",
 ];
 
 export const PROMOTION_BRANCH_PATTERN =

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -157,6 +157,8 @@ test("the promotion control definition preserves itself", () => {
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release-promotion-shared.mjs"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/deploy-pwa-production-snapshot.sh"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release.sh"));
+  assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/worktree-publish.sh"));
+  assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/trusted-worktree-publish.sh"));
 });
 
 test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {

--- a/scripts/trusted-worktree-publish.sh
+++ b/scripts/trusted-worktree-publish.sh
@@ -253,10 +253,12 @@ if [[ "${BASE_BRANCH}" == "main" ]]; then
   fi
   (
     builtin cd "${CANDIDATE_ROOT}"
+    PROMOTION_SNAPSHOT_REF="$(/usr/bin/git show -s --format='%(trailers:key=Freed-Dev-Snapshot,valueonly)' "${SCOPE_HEAD_SHA}")"
     "${NODE_BIN}" scripts/validate-main-pr.mjs \
       --base-ref=origin/main \
       --head-ref="${SCOPE_HEAD_SHA}" \
-      --head-branch="${CANDIDATE_BRANCH}"
+      --head-branch="${CANDIDATE_BRANCH}" \
+      --snapshot-ref="${PROMOTION_SNAPSHOT_REF}"
   )
 elif [[ -n "${SCOPE_HEAD_SHA}" ]]; then
   echo "Error: only a governed main publish may receive a pre-bound head." >&2

--- a/scripts/worktree-publish.sh
+++ b/scripts/worktree-publish.sh
@@ -1112,11 +1112,13 @@ if [[ "${BASE_BRANCH}" == "main" ]]; then
     echo "Error: governed main head changed after broker validation." >&2
     exit 1
   fi
+  PROMOTION_SNAPSHOT_REF="$("${GIT_BIN}" show -s --format='%(trailers:key=Freed-Dev-Snapshot,valueonly)' "${PUBLISH_HEAD}")"
   "${NODE_BIN}" "${SCRIPT_DIR}/validate-main-pr.mjs" \
     --cwd="$("${GIT_BIN}" rev-parse --show-toplevel)" \
     --base-ref=origin/main \
     --head-ref="${PUBLISH_HEAD}" \
-    --head-branch="${BRANCH_NAME}"
+    --head-branch="${BRANCH_NAME}" \
+    --snapshot-ref="${PROMOTION_SNAPSHOT_REF}"
 elif ${TRUSTED_PUBLISH_MODE} && [[ -n "${SCOPE_HEAD_SHA}" ]]; then
   echo "Error: only governed main capabilities may pre-bind a publish head." >&2
   exit 1


### PR DESCRIPTION
(AI Generated).

## Summary
- Backport the normal and trusted publisher forwarding needed by immutable production snapshots.

## Testing
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=fix/main-governance-snapshot-publishers
- publisher suite passed 117 tests on the exact source diff