### PR TITLE
docs: refresh v26.8.3103-dev identity

### DIFF
--- a/release-notes/daily/dev/26.8.31.json
+++ b/release-notes/daily/dev/26.8.31.json
@@ -16,5 +16,5 @@
   "editorialNotes": [
     "Lead with the atomic Drive checkpoint fix and PWA sample-data recovery. Keep the remaining signed Drive verification explicit."
   ],
-  "updatedAt": "2026-09-01T03:57:07.918Z"
+  "updatedAt": "2026-09-01T04:29:57.288Z"
 }

--- a/release-notes/releases/v26.8.3103-dev.json
+++ b/release-notes/releases/v26.8.3103-dev.json
@@ -5,14 +5,14 @@
   "dayKey": "26.8.31",
   "approved": true,
   "editorialNotes": [],
-  "generatedAt": "2026-09-01T03:57:07.916Z",
+  "generatedAt": "2026-09-01T04:29:57.286Z",
   "model": "heuristic",
   "source": {
     "channel": "dev",
     "previousPublishedTag": "v26.8.3102-dev",
     "previousPublishedDayTag": "v26.8.3006-dev",
     "compareRef": "HEAD",
-    "productCommitSha": "111fafdaa805b7f0f04e378503d37d25fcfaa010",
+    "productCommitSha": "51bbe4592811d4cb986d11fdd89a1353eb114bf9",
     "promotedDevCommitSha": null,
     "libraryCoreActivation": {
       "schemaVersion": 1,
@@ -21,7 +21,7 @@
         "previousPublishedTag": "v26.8.3102-dev",
         "startMode": "previous_product_commit",
         "fromExclusiveCommitSha": "ee4472f93b23b53d2066925fc667c81bc8b113ad",
-        "toInclusiveProductCommitSha": "111fafdaa805b7f0f04e378503d37d25fcfaa010"
+        "toInclusiveProductCommitSha": "51bbe4592811d4cb986d11fdd89a1353eb114bf9"
       },
       "manifest": {
         "path": "docs/library-core-activation-manifest.json",
@@ -30,7 +30,7 @@
         "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
       },
       "transitions": [],
-      "inspectionDigest": "sha256:9b1b0c606a4afda04907db8d1e8b8610ba079bd11737b4c0decb882a1a54e3c2",
+      "inspectionDigest": "sha256:b65883182a40f020e639dd96e3e2c361e7845d617125b23f580aa85ce2ce874d",
       "decision": {
         "state": "no_activation_declared",
         "ownerApprovalReference": null,
@@ -96,9 +96,12 @@
       1744,
       1745,
       1747,
-      1750
+      1750,
+      1754
     ],
     "commitSubjects": [
+      "fix: prevent stale PWA OAuth credential writes (#1754)",
+      "release: v26.8.3103-dev (#1753)",
       "fix: forward snapshot identity during publication (#1750)",
       "fix: restore manual PWA contact entry (#1747)",
       "fix: preserve snapshot release control closure (#1745)",
@@ -161,11 +164,13 @@
       "Keep PWA feeds and search bounded across 100,000 locally stored items"
     ],
     "fixes": [
+      "Prevent stale PWA OAuth credential writes",
       "Reader, feed, and header polish",
       "Release build and type-safety cleanup",
       "Sync and update reliability fixes",
       "Admit Google Drive installed sync trigger",
       "Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite",
+      "Refresh Google Drive authentication once and retry the exact failed request after a 401",
       "Reject corrupted PWA media ranges before they become available offline",
       "Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload",
       "Show progress while importing or clearing sample data",
@@ -194,5 +199,5 @@
       "Soak the verified build before production promotion"
     ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3103-dev\n\nAtomic Google Drive checkpoints and resilient PWA sample data\n\n### Features\n\n- Anonymous release demo experience\n- Open Map and Friends on demand while keeping return visits available offline\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n\n### Fixes\n\n- Reader, feed, and header polish\n- Release build and type-safety cleanup\n- Sync and update reliability fixes\n- Admit Google Drive installed sync trigger\n- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite\n- Reject corrupted PWA media ranges before they become available offline\n- Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload\n- Show progress while importing or clearing sample data\n- Recover the PWA SQLite Library after its worker process is replaced\n- Preserve one durable PWA signing identity across concurrent tabs and WebKit restarts, with fail-closed teardown handling\n- Retain complete PWA articles within the bounded offline cache\n- Publish normalized Google Drive checkpoint pages with up to 4,096 records while retaining the 2 MiB byte limit\n- Create one durable local PWA sample authority when multiple tabs initialize together\n- Bind production PWA deployments and main promotion checks to the exact reviewed dev snapshot while keeping promotion controls current\n- Show the manual Phone, Email, and Address form when the browser does not support contact selection\n\n### Follow-ups\n\n- Prepare v26.8.3102-dev\n- Refresh v26.8.3101-dev identity\n- WebKit PWA corpus hardening\n- Friends offset pagination with keysets\n- Reduce PWA install bundle\n- Page large Friends directories with stable SQLite keyset cursors\n- Smaller PWA installs, stronger local storage recovery, and faster large Libraries\n- Run installed build verification in an isolated profile\n- Physical iPhone PWA acceptance\n- Extend large-library proof to WebKit and whole-process memory\n- Reliable PWA recovery and Google Drive authentication\n- Verify the first Google Drive publication and exact retry against the real local Library\n- Prove released Freed Desktop and PWA edits synchronize in both directions\n- Soak the verified build before production promotion\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.8.3103-dev\n\nAtomic Google Drive checkpoints and resilient PWA sample data\n\n### Features\n\n- Anonymous release demo experience\n- Open Map and Friends on demand while keeping return visits available offline\n- Keep PWA feeds and search bounded across 100,000 locally stored items\n\n### Fixes\n\n- Prevent stale PWA OAuth credential writes\n- Reader, feed, and header polish\n- Release build and type-safety cleanup\n- Sync and update reliability fixes\n- Admit Google Drive installed sync trigger\n- Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite\n- Refresh Google Drive authentication once and retry the exact failed request after a 401\n- Reject corrupted PWA media ranges before they become available offline\n- Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload\n- Show progress while importing or clearing sample data\n- Recover the PWA SQLite Library after its worker process is replaced\n- Preserve one durable PWA signing identity across concurrent tabs and WebKit restarts, with fail-closed teardown handling\n- Retain complete PWA articles within the bounded offline cache\n- Publish normalized Google Drive checkpoint pages with up to 4,096 records while retaining the 2 MiB byte limit\n- Create one durable local PWA sample authority when multiple tabs initialize together\n- Bind production PWA deployments and main promotion checks to the exact reviewed dev snapshot while keeping promotion controls current\n- Show the manual Phone, Email, and Address form when the browser does not support contact selection\n\n### Follow-ups\n\n- Prepare v26.8.3102-dev\n- Refresh v26.8.3101-dev identity\n- WebKit PWA corpus hardening\n- Friends offset pagination with keysets\n- Reduce PWA install bundle\n- Page large Friends directories with stable SQLite keyset cursors\n- Smaller PWA installs, stronger local storage recovery, and faster large Libraries\n- Run installed build verification in an isolated profile\n- Physical iPhone PWA acceptance\n- Extend large-library proof to WebKit and whole-process memory\n- Reliable PWA recovery and Google Drive authentication\n- Verify the first Google Drive publication and exact retry against the real local Library\n- Prove released Freed Desktop and PWA edits synchronize in both directions\n- Soak the verified build before production promotion\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.8.3103-dev.md
+++ b/release-notes/releases/v26.8.3103-dev.md
@@ -12,11 +12,13 @@ Atomic Google Drive checkpoints and resilient PWA sample data
 
 ### Fixes
 
+- Prevent stale PWA OAuth credential writes
 - Reader, feed, and header polish
 - Release build and type-safety cleanup
 - Sync and update reliability fixes
 - Admit Google Drive installed sync trigger
 - Clear retired follower enrollment before replacing a checkpoint in browser and native SQLite
+- Refresh Google Drive authentication once and retry the exact failed request after a 401
 - Reject corrupted PWA media ranges before they become available offline
 - Pin each Google Drive checkpoint export to one SQLite read transaction so concurrent local writes cannot invalidate the upload
 - Show progress while importing or clearing sample data


### PR DESCRIPTION
(AI Generated).

## Summary
- Bind the approved dev release artifact to the exact current product head after the PWA OAuth race fix merged.
- Preserve the reviewed Drive, OPFS, signed-intent, installed verification, bidirectional sync, and soak scope.

## Testing
- Release notes validation
- Exact release identity validation