### PR TITLE
chore: ship signed isolated dev build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -491,6 +491,130 @@ jobs:
             echo "Artifact $SRC not found, skipping alias"
           fi
 
+  isolated-dev-macos:
+    name: Build Signed Isolated macOS Verifier
+    needs: [notes, create-release]
+    if: needs.notes.outputs.release_channel == 'dev'
+    runs-on: macos-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: ".nvmrc"
+          cache: "npm"
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2
+        with:
+          workspaces: packages/desktop/src-tauri
+
+      - name: Install frontend dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Build workspace dependencies
+        shell: bash
+        run: |
+          (cd packages/shared && npm run build)
+          (cd packages/sync && npm run build)
+          (cd packages/capture-rss && npm run build)
+
+      - name: Validate Apple signing secrets
+        shell: bash
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+        run: |
+          missing=()
+          for name in APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_TEAM_ID APPLE_ID APPLE_PASSWORD; do
+            if [ -z "${!name}" ]; then
+              missing+=("$name")
+            fi
+          done
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing required macOS signing/notarization secrets: ${missing[*]}"
+            exit 1
+          fi
+
+      - name: Import Apple signing certificate
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          CERT_PATH=$RUNNER_TEMP/certificate.p12
+          KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain-db
+          KEYCHAIN_PASSWORD=$(openssl rand -base64 24)
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode > "$CERT_PATH"
+
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security default-keychain -s "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" -P "$APPLE_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH"
+
+      - name: Build and release isolated verifier
+        id: isolated-build
+        uses: tauri-apps/tauri-action@1deb371b0cd8bd54025b384f1cd735e725c4060f # v1.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_PROVIDER_SHORT_NAME: ${{ secrets.APPLE_PROVIDER_SHORT_NAME }}
+          VITE_DROPBOX_CLIENT_ID: yaqbppqya009gky
+          VITE_GDRIVE_DESKTOP_CLIENT_ID: 304530272769-fkbpan1l071vdvum1j6kufvo8rbq6sm1.apps.googleusercontent.com
+          VITE_GDRIVE_TOKEN_PROXY_URL: https://app.freed.wtf/api/oauth/google
+          VITE_GDRIVE_FORCE_TOKEN_PROXY: "1"
+          FREED_BUILD_CHANNEL: dev
+          VITE_ENABLE_DEV_SYNC_TRIGGERS: "1"
+        with:
+          projectPath: packages/desktop
+          tauriScript: npx tauri
+          releaseId: ${{ needs.create-release.outputs.release_id }}
+          tagName: ${{ github.ref_name }}
+          releaseDraft: true
+          prerelease: true
+          uploadUpdaterJson: false
+          uploadUpdaterSignatures: false
+          releaseAssetNamePattern: Freed_Preview_[version]_aarch64[ext]
+          args: --target aarch64-apple-darwin --bundles app --features isolated-preview-data-root --config src-tauri/tauri.preview.conf.json
+
+      - name: Verify isolated verifier identity and notarization
+        shell: bash
+        run: |
+          APP_PATH="packages/desktop/src-tauri/target/aarch64-apple-darwin/release/bundle/macos/Freed Preview.app"
+          test -d "$APP_PATH"
+          codesign --verify --deep --strict "$APP_PATH"
+          spctl --assess --type execute --verbose=2 "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          BUNDLE_ID=$(/usr/libexec/PlistBuddy -c 'Print:CFBundleIdentifier' "$APP_PATH/Contents/Info.plist")
+          if [ "$BUNDLE_ID" != "wtf.freed.desktop.sqlite-native-preview" ]; then
+            echo "Unexpected isolated verifier bundle identifier: $BUNDLE_ID"
+            exit 1
+          fi
+
   updater-manifest:
     needs: [release, notes, create-release]
     runs-on: ubuntu-latest
@@ -615,11 +739,12 @@ jobs:
 
   # After all platform builds succeed, promote the draft to a published release
   publish:
-    needs: [updater-manifest, showcase-assets, create-release]
+    needs: [updater-manifest, showcase-assets, isolated-dev-macos, create-release]
     if: >-
       always() &&
       needs.updater-manifest.result == 'success' &&
       needs.create-release.result == 'success' &&
+      (needs.isolated-dev-macos.result == 'success' || needs.isolated-dev-macos.result == 'skipped') &&
       (needs.showcase-assets.result == 'success' || needs.showcase-assets.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
@@ -749,6 +874,7 @@ jobs:
         validation,
         create-release,
         release,
+        isolated-dev-macos,
         updater-manifest,
         publish,
         publish-website,

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -773,6 +773,7 @@ export async function captureDomFeed(
 | 5.192 | Admit the complete historical schema 6 through 12 predecessor range through the fenced read-only cutover verifier. Every accepted source keeps the exact application identity and stable migration columns, unsupported versions fail closed, and the deleted historical schema-upgrade engine does not return | High       | ✓ Complete |
 | 5.193 | Admit normalized checkpoint identities up to the canonical primary-key ceiling so real long URL identities publish to Google Drive without weakening bounded frame verification | High       | ✓ Complete |
 | 5.194 | Recover Google Drive Library Core requests when Google invalidates an access token before its recorded expiry. The shared Desktop transport forces one single-flight OAuth refresh after a 401, retries that request exactly once with the fresh token, and uses the stored replacement for the remainder of the bounded sync pass. The dev-only trigger helper, native watcher, and renderer bridge all admit `gdrive`, so installed-build verification invokes the same manual Library sync path as the Settings control | High       | ✓ Complete |
+| 5.195 | Publish a signed and notarized Apple Silicon `Freed Preview` application with every dev release. The verifier uses a distinct bundle name, identifier, Library root, and keyring service, disables updater artifacts, cannot overwrite the normal Freed application, stays outside `latest.json`, and blocks dev release publication when its signing or identity checks fail | High       | ✓ Complete |
 
 ---
 

--- a/packages/desktop/src-tauri/tauri.preview.conf.json
+++ b/packages/desktop/src-tauri/tauri.preview.conf.json
@@ -1,4 +1,5 @@
 {
+  "productName": "Freed Preview",
   "identifier": "wtf.freed.desktop.sqlite-native-preview",
   "bundle": {
     "createUpdaterArtifacts": false

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -375,13 +375,18 @@ test("draft release assets and publication use the exact release ID", () => {
   );
   assert.match(
     publishJob,
-    /needs:\s*\[updater-manifest, showcase-assets, create-release\]/,
+    /needs:\s*\[updater-manifest, showcase-assets, isolated-dev-macos, create-release\]/,
     "publish must directly depend on create-release before reading its output",
   );
   assert.match(
     publishJob,
     /needs\.showcase-assets\.result == 'success' \|\| needs\.showcase-assets\.result == 'skipped'/,
     "production showcase failure must block publication without blocking dev releases",
+  );
+  assert.match(
+    publishJob,
+    /needs\.isolated-dev-macos\.result == 'success' \|\| needs\.isolated-dev-macos\.result == 'skipped'/,
+    "isolated verifier failure must block dev publication without blocking production releases",
   );
   assert.doesNotMatch(publishJob, /gh release edit/);
 });

--- a/scripts/release-workflow-matrix.test.mjs
+++ b/scripts/release-workflow-matrix.test.mjs
@@ -8,6 +8,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const releaseWorkflowPath = path.join(repoRoot, ".github", "workflows", "release.yml");
+const isolatedDesktopConfigPath = path.join(
+  repoRoot,
+  "packages",
+  "desktop",
+  "src-tauri",
+  "tauri.preview.conf.json",
+);
 
 function loadPrimaryReleaseMatrix() {
   const workflow = readFileSync(releaseWorkflowPath, "utf8");
@@ -85,5 +92,51 @@ test("desktop releases pass the reviewed channel into build metadata", () => {
     workflow,
     /FREED_BUILD_CHANNEL:\s*\$\{\{ needs\.notes\.outputs\.release_channel \}\}/,
     "release builds should stamp the reviewed release channel into runtime identity",
+  );
+});
+
+test("dev releases publish a signed isolated Apple Silicon verifier without updater artifacts", () => {
+  const workflow = readFileSync(releaseWorkflowPath, "utf8");
+  const isolatedConfig = JSON.parse(
+    readFileSync(isolatedDesktopConfigPath, "utf8"),
+  );
+  const isolatedJob = workflow.slice(
+    workflow.indexOf("\n  isolated-dev-macos:"),
+    workflow.indexOf("\n  updater-manifest:"),
+  );
+  const publishJob = workflow.slice(
+    workflow.indexOf("\n  publish:"),
+    workflow.indexOf("\n  # Redeploy the public marketing site"),
+  );
+
+  assert.equal(isolatedConfig.productName, "Freed Preview");
+  assert.equal(
+    isolatedConfig.identifier,
+    "wtf.freed.desktop.sqlite-native-preview",
+  );
+  assert.equal(isolatedConfig.bundle.createUpdaterArtifacts, false);
+
+  assert.match(isolatedJob, /release_channel == 'dev'/);
+  assert.match(isolatedJob, /runs-on: macos-latest/);
+  assert.match(isolatedJob, /--target aarch64-apple-darwin/);
+  assert.match(isolatedJob, /--bundles app/);
+  assert.match(isolatedJob, /--features isolated-preview-data-root/);
+  assert.match(isolatedJob, /--config src-tauri\/tauri\.preview\.conf\.json/);
+  assert.match(
+    isolatedJob,
+    /releaseAssetNamePattern: Freed_Preview_\[version\]_aarch64\[ext\]/,
+  );
+  assert.match(isolatedJob, /uploadUpdaterJson: false/);
+  assert.match(isolatedJob, /uploadUpdaterSignatures: false/);
+  assert.match(isolatedJob, /codesign --verify --deep --strict/);
+  assert.match(isolatedJob, /xcrun stapler validate/);
+  assert.match(
+    isolatedJob,
+    /Print:CFBundleIdentifier[\s\S]*wtf\.freed\.desktop\.sqlite-native-preview/,
+  );
+
+  assert.match(
+    publishJob,
+    /needs\.isolated-dev-macos\.result == 'success' \|\| needs\.isolated-dev-macos\.result == 'skipped'/,
   );
 });


### PR DESCRIPTION
(AI Generated).

## Summary
- Publish a separately named, signed Apple Silicon Freed Preview application on dev releases.
- Keep the verifier outside updater metadata and block release publication unless its identity and notarization checks pass.
- Closes #1764.

## Testing
- npm run validate:feature
- npm run tauri:build:isolated, followed by isolated bundle identity and background startup verification