### PR TITLE
chore: prepare v26.9.100-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.8.3104",
+  "version": "26.9.100",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.8.3104"
+version = "26.9.100"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.8.3104"
+version = "26.9.100"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.8.3104",
+  "version": "26.9.100",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.8.3104",
+  "version": "26.9.100",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.9.1.json
+++ b/release-notes/daily/dev/26.9.1.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.9.1",
+  "date": "2026-09-01",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-09-01T21:59:38.282Z"
+}

--- a/release-notes/releases/v26.9.100-dev.json
+++ b/release-notes/releases/v26.9.100-dev.json
@@ -1,0 +1,70 @@
+{
+  "tag": "v26.9.100-dev",
+  "version": "26.9.100-dev",
+  "channel": "dev",
+  "dayKey": "26.9.1",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-09-01T21:59:38.282Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.8.3104-dev",
+    "previousPublishedDayTag": "v26.8.3104-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "7f035735d6af129e3b7e8c50da88bdde6dffa298",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.8.3104-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "a2349a4635148d5140a03491565a167ae583c699",
+        "toInclusiveProductCommitSha": "7f035735d6af129e3b7e8c50da88bdde6dffa298"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:05e74f00da485c3a4b4569b5ecf2e118fa4a671a37372ea84cfbf36510fc4ad1",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.9.100-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.9.100-dev"
+    ],
+    "prNumbers": [
+      1762,
+      1766
+    ],
+    "commitSubjects": [
+      "chore: ship signed isolated dev build (#1766)",
+      "fix: recover Safari private OPFS bootstrap (#1762)"
+    ]
+  },
+  "release": {
+    "deck": "Private PWA recovery with a safe signed verifier",
+    "features": [
+      "Install a separately named, signed Freed Preview build for isolated testing without replacing the normal Freed application or joining its updater channel"
+    ],
+    "fixes": [
+      "Recover Safari Private Browsing startup when durable OPFS SQLite is unavailable while keeping persistent sessions fail closed"
+    ],
+    "followUps": [
+      "Run installed verification and the bounded stability soak against the isolated dev build"
+    ]
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.100-dev\n\nPrivate PWA recovery with a safe signed verifier\n\n### Features\n\n- Install a separately named, signed Freed Preview build for isolated testing without replacing the normal Freed application or joining its updater channel\n\n### Fixes\n\n- Recover Safari Private Browsing startup when durable OPFS SQLite is unavailable while keeping persistent sessions fail closed\n\n### Follow-ups\n\n- Run installed verification and the bounded stability soak against the isolated dev build\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.9.100-dev.md
+++ b/release-notes/releases/v26.9.100-dev.md
@@ -1,0 +1,25 @@
+(AI Generated).
+
+## Freed v26.9.100-dev
+
+Private PWA recovery with a safe signed verifier
+
+### Features
+
+- Install a separately named, signed Freed Preview build for isolated testing without replacing the normal Freed application or joining its updater channel
+
+### Fixes
+
+- Recover Safari Private Browsing startup when durable OPFS SQLite is unavailable while keeping persistent sessions fail closed
+
+### Follow-ups
+
+- Run installed verification and the bounded stability soak against the isolated dev build
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the approved v26.9.100-dev release from the current dev integration head. Include Safari Private Browsing OPFS recovery and the separately named signed Freed Preview verifier artifact.

## Testing
- npm run validate:feature