### PR TITLE
fix: allow reviewed release lane divergence

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -30,6 +30,13 @@ export const RELEASE_ONLY_FILES = [
 
 export const RELEASE_ONLY_PREFIXES = ["release-notes/"];
 
+// Dev retains assertions for its signed isolated verifier job. Production main
+// intentionally omits that dev-only job, so this test has a reviewed lane-specific
+// variant instead of one blob that can be reverse-integrated between branches.
+const BRANCH_SPECIFIC_BACKFLOW_FILES = new Set([
+  "scripts/release-governance.test.mjs",
+]);
+
 export const FORBIDDEN_MAIN_PR_PREFIXES = ["website/"];
 
 export const PROMOTION_WEBSITE_CONFIG_FILES = ["website/next.config.ts"];
@@ -302,6 +309,7 @@ export function listMainBackflowDiffFiles({ devRef, mainRef, cwd }) {
 
   return mainChangedFiles
     .filter((filePath) => !isReleaseOnlyFile(filePath))
+    .filter((filePath) => !BRANCH_SPECIFIC_BACKFLOW_FILES.has(filePath))
     .filter(
       (filePath) =>
         filePath !== CARGO_LOCK_PATH ||

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -1105,6 +1105,38 @@ test("validate-main-backflow ignores release-only main metadata", (t) => {
   assert.match(result.stdout, /Main backflow is in sync/);
 });
 
+test("validate-main-backflow permits the reviewed branch-specific release governance test", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'dev-isolated-verifier';\n",
+  );
+  commitAll(cwd, "test: retain dev release verifier assertions");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'production';\n",
+  );
+  commitAll(cwd, "test: retain production release assertions");
+  updateOriginRef(cwd, "main");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Main backflow is in sync/);
+});
+
 test("validate-main-backflow rejects dependency drift in Cargo.lock", (t) => {
   const cwd = makeTempRepo();
   t.after(() => rmSync(cwd, { recursive: true, force: true }));


### PR DESCRIPTION
(AI Generated).

## Summary
- (AI Generated).

Allow the dev-only release governance test to differ from production while preserving backflow checks for shared product files. Closes #1772.

## Testing
- node --test scripts/release-promotion.test.mjs scripts/release-governance.test.mjs