### PR TITLE
fix: unify provider beta metadata

### DIFF
--- a/packages/desktop/tests/e2e/youtube-capture.spec.ts
+++ b/packages/desktop/tests/e2e/youtube-capture.spec.ts
@@ -42,7 +42,7 @@ async function emitTauriEvent(
   );
 }
 
-test("beta source badges stay beside their source names", async ({ app }) => {
+test("beta source badges stay beside source names in navigation and settings", async ({ app }) => {
   await app.goto();
   await app.waitForReady();
 
@@ -71,6 +71,29 @@ test("beta source badges stay beside their source names", async ({ app }) => {
     expect(badgeBox!.x - (labelBox!.x + labelBox!.width)).toBeLessThanOrEqual(
       8,
     );
+  }
+
+  const settingsButton = app.page
+    .locator("button")
+    .filter({ hasText: /settings/i })
+    .first();
+  await settingsButton.click();
+  const dialog = settingsDialog(app.page);
+
+  for (const source of ["substack", "medium", "youtube"] as const) {
+    const label = source === "substack"
+      ? "Substack"
+      : source === "medium"
+        ? "Medium"
+        : "YouTube";
+    const sectionButton = dialog.locator("button").filter({
+      has: app.page.getByText(label, { exact: true }),
+    }).last();
+    await expect(sectionButton).toContainText("Beta");
+    await sectionButton.click();
+
+    const section = dialog.locator(`[data-section="${source}"]`);
+    await expect(section.getByRole("heading").first()).toContainText("Beta");
   }
 });
 

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -1445,6 +1445,11 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
   }
 
   function SectionContent({ id }: { id: SectionId }) {
+    const section = sectionById[id];
+    const providerHeading = section ? (
+      <SectionHeading label={section.label} stage={section.stage} />
+    ) : null;
+
     switch (id) {
       case "appearance":
         return (
@@ -1635,7 +1640,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       case "x":
         return XSettingsContent ? (
           <>
-            <SectionHeading label="X / Twitter" />
+            {providerHeading}
             <XSettingsContent surface="settings" />
           </>
         ) : null;
@@ -1643,7 +1648,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       case "facebook":
         return FacebookSettingsContent ? (
           <>
-            <SectionHeading label="Facebook" />
+            {providerHeading}
             <FacebookSettingsContent surface="settings" />
           </>
         ) : null;
@@ -1651,7 +1656,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       case "instagram":
         return InstagramSettingsContent ? (
           <>
-            <SectionHeading label="Instagram" />
+            {providerHeading}
             <InstagramSettingsContent surface="settings" />
           </>
         ) : null;
@@ -1659,7 +1664,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       case "linkedin":
         return LinkedInSettingsContent ? (
           <>
-            <SectionHeading label="LinkedIn" />
+            {providerHeading}
             <LinkedInSettingsContent surface="settings" />
           </>
         ) : null;
@@ -1667,7 +1672,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       case "substack":
         return SubstackSettingsContent ? (
           <>
-            <SectionHeading label="Substack" stage="beta" />
+            {providerHeading}
             <SubstackSettingsContent surface="settings" />
           </>
         ) : null;
@@ -1675,7 +1680,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       case "medium":
         return MediumSettingsContent ? (
           <>
-            <SectionHeading label="Medium" stage="beta" />
+            {providerHeading}
             <MediumSettingsContent surface="settings" />
           </>
         ) : null;
@@ -1683,7 +1688,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
       case "youtube":
         return YouTubeSettingsContent ? (
           <>
-            <SectionHeading label="YouTube" />
+            {providerHeading}
             <YouTubeSettingsContent surface="settings" />
           </>
         ) : null;

--- a/packages/ui/src/lib/provider-presentation.ts
+++ b/packages/ui/src/lib/provider-presentation.ts
@@ -1,0 +1,30 @@
+import { PLATFORM_LABELS, type Platform } from "@freed/shared";
+
+export type ProviderPresentationStage = "beta";
+
+export type SettingsProviderId = Extract<
+  Platform,
+  | "x"
+  | "facebook"
+  | "instagram"
+  | "linkedin"
+  | "substack"
+  | "medium"
+  | "youtube"
+>;
+
+export interface ProviderPresentation {
+  label: string;
+  stage?: ProviderPresentationStage;
+}
+
+/** Canonical labels and maturity stages shared by provider navigation surfaces. */
+export const PROVIDER_PRESENTATION = {
+  x: { label: "X / Twitter" },
+  facebook: { label: PLATFORM_LABELS.facebook },
+  instagram: { label: PLATFORM_LABELS.instagram },
+  linkedin: { label: PLATFORM_LABELS.linkedin },
+  substack: { label: PLATFORM_LABELS.substack, stage: "beta" },
+  medium: { label: PLATFORM_LABELS.medium, stage: "beta" },
+  youtube: { label: PLATFORM_LABELS.youtube, stage: "beta" },
+} as const satisfies Record<SettingsProviderId, ProviderPresentation>;

--- a/packages/ui/src/lib/settings-sections.ts
+++ b/packages/ui/src/lib/settings-sections.ts
@@ -5,6 +5,12 @@
  * Pure TypeScript (no React). Consumers add their own icons on top.
  */
 
+import {
+  PROVIDER_PRESENTATION,
+  type ProviderPresentationStage,
+  type SettingsProviderId,
+} from "./provider-presentation.js";
+
 export type SectionId =
   | "legal"
   | "appearance"
@@ -28,9 +34,16 @@ export type SectionId =
 export interface SectionMeta {
   id: SectionId;
   label: string;
-  stage?: "beta";
+  stage?: ProviderPresentationStage;
   /** Lowercase keywords matched against search queries. */
   keywords: string[];
+}
+
+function providerSectionMeta(
+  id: SettingsProviderId,
+  keywords: string[],
+): SectionMeta {
+  return { id, ...PROVIDER_PRESENTATION[id], keywords };
 }
 
 export interface SettingsSectionAvailability {
@@ -114,56 +127,38 @@ export const SHORTCUTS_SECTION_META: SectionMeta = {
 };
 
 /** Shown only when the platform provides an X/Twitter settings component (desktop). */
-export const X_SECTION_META: SectionMeta = {
-  id: "x",
-  label: "X / Twitter",
-  keywords: ["twitter", "x", "tweet", "timeline", "connect", "cookies", "auth", "token"],
-};
+export const X_SECTION_META = providerSectionMeta("x", [
+  "twitter", "x", "tweet", "timeline", "connect", "cookies", "auth", "token",
+]);
 
 /** Shown only when the platform provides a Facebook settings component (desktop). */
-export const FB_SECTION_META: SectionMeta = {
-  id: "facebook",
-  label: "Facebook",
-  keywords: ["facebook", "fb", "meta", "feed", "connect", "cookies", "auth", "mbasic"],
-};
+export const FB_SECTION_META = providerSectionMeta("facebook", [
+  "facebook", "fb", "meta", "feed", "connect", "cookies", "auth", "mbasic",
+]);
 
 /** Shown only when the platform provides an Instagram settings component (desktop). */
-export const IG_SECTION_META: SectionMeta = {
-  id: "instagram",
-  label: "Instagram",
-  keywords: ["instagram", "ig", "meta", "feed", "connect", "photos", "reels", "stories"],
-};
+export const IG_SECTION_META = providerSectionMeta("instagram", [
+  "instagram", "ig", "meta", "feed", "connect", "photos", "reels", "stories",
+]);
 
 /** Shown only when the platform provides a LinkedIn settings component (desktop). */
-export const LI_SECTION_META: SectionMeta = {
-  id: "linkedin",
-  label: "LinkedIn",
-  keywords: ["linkedin", "li", "professional", "feed", "connect", "network", "jobs", "posts"],
-};
+export const LI_SECTION_META = providerSectionMeta("linkedin", [
+  "linkedin", "li", "professional", "feed", "connect", "network", "jobs", "posts",
+]);
 
-export const SUBSTACK_SECTION_META: SectionMeta = {
-  id: "substack",
-  label: "Substack",
-  stage: "beta",
-  keywords: ["substack", "essay", "notes", "publication", "subscriptions", "followers", "following"],
-};
+export const SUBSTACK_SECTION_META = providerSectionMeta("substack", [
+  "substack", "essay", "notes", "publication", "subscriptions", "followers", "following",
+]);
 
-export const MEDIUM_SECTION_META: SectionMeta = {
-  id: "medium",
-  label: "Medium",
-  stage: "beta",
-  keywords: ["medium", "story", "essay", "responses", "claps", "followers", "following"],
-};
+export const MEDIUM_SECTION_META = providerSectionMeta("medium", [
+  "medium", "story", "essay", "responses", "claps", "followers", "following",
+]);
 
 /** Shown when this surface can manage or report YouTube integration state. */
-export const YOUTUBE_SECTION_META: SectionMeta = {
-  id: "youtube",
-  label: "YouTube",
-  keywords: [
+export const YOUTUBE_SECTION_META = providerSectionMeta("youtube", [
     "youtube", "video", "subscriptions", "channels", "focus mode", "offline",
     "premium", "playlist", "freed offline", "shorts", "reels",
-  ],
-};
+]);
 
 /** Shown only when the platform provides a Google Contacts settings component. */
 export const GOOGLE_CONTACTS_SECTION_META: SectionMeta = {

--- a/packages/ui/src/lib/source-navigation.tsx
+++ b/packages/ui/src/lib/source-navigation.tsx
@@ -11,25 +11,37 @@ import {
   XIcon,
   YoutubeIcon,
 } from "../components/icons.js";
+import {
+  PROVIDER_PRESENTATION,
+  type ProviderPresentationStage,
+  type SettingsProviderId,
+} from "./provider-presentation.js";
 
 export interface SourceNavigationItem {
   id: string | undefined;
   label: string;
   icon: ReactNode;
-  stage?: "beta";
+  stage?: ProviderPresentationStage;
+}
+
+function providerSourceItem(
+  id: SettingsProviderId,
+  icon: ReactNode,
+): SourceNavigationItem {
+  return { id, icon, ...PROVIDER_PRESENTATION[id] };
 }
 
 export function getTopSourceItems(useShortLabels = false): readonly SourceNavigationItem[] {
   return [
     { id: undefined, label: useShortLabels ? "Feed" : "Unified Feed", icon: <AllIcon /> },
     { id: "rss", label: "Feeds", icon: <RssIcon /> },
-    { id: "x", label: "X / Twitter", icon: <XIcon /> },
-    { id: "facebook", label: "Facebook", icon: <FacebookIcon /> },
-    { id: "instagram", label: "Instagram", icon: <InstagramIcon /> },
-    { id: "linkedin", label: "LinkedIn", icon: <LinkedInIcon /> },
-    { id: "substack", label: "Substack", icon: <SubstackIcon />, stage: "beta" },
-    { id: "medium", label: "Medium", icon: <MediumIcon />, stage: "beta" },
-    { id: "youtube", label: "YouTube", icon: <YoutubeIcon />, stage: "beta" },
+    providerSourceItem("x", <XIcon />),
+    providerSourceItem("facebook", <FacebookIcon />),
+    providerSourceItem("instagram", <InstagramIcon />),
+    providerSourceItem("linkedin", <LinkedInIcon />),
+    providerSourceItem("substack", <SubstackIcon />),
+    providerSourceItem("medium", <MediumIcon />),
+    providerSourceItem("youtube", <YoutubeIcon />),
   ] as const;
 }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Centralize provider labels and maturity stages so Settings and source navigation cannot drift
- Render YouTube as Beta in Settings from the canonical provider registry

## Testing
- npm run validate:feature
- Focused YouTube Settings badge browser regression

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `ac7383f1763cb69f296f25762c3e6a8d90b59268`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `provider-beta-metadata-20260901`
- Provider review decision: `diff_authorized`
- Provider review artifact: `851c4d5cbaa73fa17ec175d683fc460da7ae047c3258d5f12a6c22aec9c1f414`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: No provider-observable behavior changes. SettingsDialog renders provider labels and beta badges from canonical local metadata without changing requests, navigation, extraction, timing, cookies, headers, media, login, or background activity.
- Fingerprinting risk: None added. This diff performs no provider contact and does not alter any provider-visible request or interaction pattern.
- Lowest profile alternative: Keep provider traffic disabled while validating the local Settings rendering through synthetic browser fixtures.

Files bound into this provider review:
- `packages/ui/src/components/SettingsDialog.tsx`