### PR TITLE
feat: add searchable notes to saved content

### DIFF
--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -8,11 +8,19 @@ disable-model-invocation: true
 
 Build one attributable product change from the latest `origin/dev`. Keep the change connected to its task, evidence, authority, and post-merge verification.
 
+## Start from current policy
+
+1. Treat the supplied working directory as a launcher until proven otherwise.
+2. Before the owner-facing authorization exchange, run `git fetch --all --prune` and read `AGENTS.md` from `origin/dev` with `git show origin/dev:AGENTS.md`.
+3. If either command fails, stop. Do not rely on a possibly stale local instruction copy.
+4. Use the numbered Level 1 through Level 7 labels from the fetched `AGENTS.md` with the owner. Internal actor labels are bookkeeping only and must never be presented as owner authorization choices.
+5. After Level 2 or higher is active, create the implementation worktree from that exact fetched `origin/dev` head. Level 1 stays read-only and may inspect the fetched ref without creating a worktree.
+
 ## Establish the contract
 
 1. Confirm the destination is `dev`. Route public website work to `freed-build-www`.
 2. Search open GitHub Issues labeled `debt` before creating work for a tracked root cause. Keep the existing issue as the canonical debt record. When governed execution needs a control task, use the selected task ID and store the issue as `details.githubIssue: { number, url }`.
-3. Record canonical task authority as `observe-only`, `plan-only`, `pr-only`, or `merge-safe`. Record provider authority separately as `forbidden`, `approval-required`, or `approved`. Also record which external actions the user explicitly granted, such as publishing a PR, merging, releasing, or deploying. None of these fields substitutes for another.
+3. Map the active numbered owner authorization level to any operational record that requires `observe-only`, `plan-only`, `pr-only`, or `merge-safe`. Record provider authority separately as `forbidden`, `approval-required`, or `approved`. Also record which external actions the active numbered level grants, such as publishing a PR, merging, releasing, or deploying. These internal fields never replace the owner-facing number.
 4. For sync, capture, memory, or recovery work, name the metric-registry entry that will judge the change. Record its event predicate, denominator, target, baseline window, minimum coverage, and expected direction.
 5. Treat missing build identity, mixed-build evidence, insufficient coverage, or broken sources as `inconclusive`. Do not turn absence of evidence into a passing result.
 6. Record the source build identity for every baseline: app version, channel, git SHA, native boot ID, app session ID, and exact start and end timestamps when available.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,20 @@
 # Agent Instructions
 
+## Task startup freshness
+
+The checkout supplied as a new task's working directory is a launcher, not proof that the task has a fresh branch or an isolated worktree.
+
+Before asking for authorization, planning implementation, or changing files:
+
+1. Run the read-only `git fetch --all --prune` from the launcher checkout.
+2. Classify the destination lane from the request: `origin/dev` for product work, `origin/www` for public website work, or `origin/main` for production release preparation.
+3. Read the current `AGENTS.md` directly from that fetched remote ref with `git show <remote-ref>:AGENTS.md`. The already-loaded local copy may be stale. Follow the fetched instructions for the rest of the task.
+4. If the fetch or fetched instruction read fails, stop and report the exact blocker. Do not proceed under a possibly stale local policy.
+
+Level 1 remains read-only in the launcher checkout. For Level 2 or higher, create an isolated worktree from the explicit freshly fetched remote ref with the repository worktree helper before editing. A task may use its starting directory only when it is already a clean dedicated worktree at the required fetched ref.
+
+Never overwrite or discard launcher-checkout changes to make it fresh. Preserve and report unexpected work. After a task merges into its lane, fast-forward a clean launcher checkout to the verified remote head so the next task begins with the newest bootstrap policy.
+
 ## Authorization levels
 
 When authorization is required and the owner has not already set a level for the task, ask:
@@ -27,6 +42,8 @@ Do not request authorization for one isolated action. Do not append exclusions, 
 7. **Full task authority:** Level 6 plus autonomous execution of every reasonably necessary task-scoped action until the task is complete or a hard external blocker makes further progress impossible.
 
 Authorization applies to the stated task. Each level includes every lower level. The newest explicitly granted level controls. Once a level is active, do not ask again for actions included within it. Clarification questions about ambiguous task scope are not authorization challenges.
+
+Use these numbered levels in every owner-facing authorization request and status. Internal actor labels such as `observe-only`, `plan-only`, `pr-only`, and `merge-safe` are implementation bookkeeping. They never replace or rename the numbered owner authorization levels.
 
 ## Rules
 

--- a/docs/PHASE-3-SAVE-FOR-LATER.md
+++ b/docs/PHASE-3-SAVE-FOR-LATER.md
@@ -3,9 +3,12 @@
 > **Status:** Current  
 > **Dependencies:** Phase 1-2 (Capture layers)
 >
-> Save for Later is functional across desktop and PWA. Saved URLs now write a
-> lightweight stub first so the dialog can close immediately, then Freed pulls
-> article details in the background where the platform can fetch them. Desktop
+> Save for Later is functional across desktop and PWA. The Save Content dialog
+> previews URL details before submission, suggests editable notes without
+> replacing user input, and writes searchable notes with the saved item. Saved
+> URLs then write a lightweight stub and Freed pulls article details in the
+> background where the platform can fetch them. Existing manual saves can be
+> edited to change their URL or notes. Desktop
 > has full article extraction, local HTML caching, Markdown import/export,
 > background fetch healing, user-visible AI controls, and hierarchical tag
 > navigation. PWA saves sync-healed stubs for Freed Desktop to hydrate. Saved
@@ -38,11 +41,17 @@ architecture is now:
 
 ### Save Flow
 
-- **Desktop:** writes a saved stub immediately, closes the Save Content dialog,
-  and queues a priority background detail fetch that caches readable HTML
-  locally and commits compact preserved text through a typed SQLite mutation.
+- **Desktop:** previews public URL metadata while the dialog remains editable,
+  writes the saved stub after submission, and queues a priority background
+  detail fetch that caches readable HTML locally and commits compact preserved
+  text through a typed SQLite mutation.
 - **PWA:** writes a saved stub immediately. Freed Desktop can hydrate the
   details after sync.
+- **Editable searchable notes:** every save can carry a whole-item note through
+  the synchronized annotation authority. Existing Library search indexes the
+  note. Manual saves expose an edit state for both URL and notes.
+- **Input ownership:** a fetched note suggestion fills only an untouched notes
+  field. Once the user edits the field, no preview result can replace it.
 - **Saved cache pinning:** saved URLs, posts, and stories enter the permanent
   device-local cache path when readable content is available. Unsaving does not
   immediately remove the local reader copy.
@@ -94,6 +103,7 @@ architecture is now:
 | 3.10 | Saved content pinned in local reader cache | ✓ Complete | Saved URLs, saved posts, and saved stories enter the high-priority local cache path |
 | 3.11 | Bound Saved overview analytics on Freed Desktop | ✓ Complete | The overview reads exact source, content, and time-bucket aggregates from authenticated SQLite and fails closed when that bounded source is unavailable. |
 | 3.12 | Complete bounded Saved reads on the PWA SQLite store | ✓ Complete | Official SQLite WebAssembly over OPFS executes the same named Saved queries and ordering contract as Freed Desktop. |
+| 3.13 | Add searchable notes, pre-submit URL previews, and manual-save editing | ✓ Complete | Desktop and PWA share synchronized whole-item notes. The dialog shows preview activity, preserves user input, and edits URL or notes before persistence. |
 
 ---
 

--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -155,7 +155,11 @@ import {
 } from "@freed/ui/lib/factory-reset";
 import { getDesktopFactoryResetFailureRecovery } from "./lib/factory-reset-recovery";
 import { resetThemePreference } from "@freed/ui/lib/theme";
-import { saveUrlInDesktop } from "./lib/save-url";
+import {
+  previewSaveUrlInDesktop,
+  saveUrlInDesktop,
+  updateSavedContentInDesktop,
+} from "./lib/save-url";
 import { hydrateReaderItem as hydrateReaderItemForDesktop } from "./lib/reader-hydration";
 import { importMarkdownFiles, exportLibrary } from "./lib/import-export";
 import { secureStorage } from "./lib/secure-storage";
@@ -1474,6 +1478,8 @@ function App() {
       saveUrl: async (url, options) => {
         return saveUrlInDesktop(url, options);
       },
+      previewSaveUrl: previewSaveUrlInDesktop,
+      updateSavedContent: updateSavedContentInDesktop,
       importMarkdown: importMarkdownFiles,
       exportMarkdown: () => exportLibrary(scanLibraryCoreItemsForDesktop),
       retryCloudProvider,

--- a/packages/desktop/src/lib/save-url.test.ts
+++ b/packages/desktop/src/lib/save-url.test.ts
@@ -22,9 +22,13 @@ const stubItem: FeedItem = {
 
 const mockAddLibraryStubItem = vi.fn(async () => stubItem);
 const mockEnqueue = vi.fn();
+const mockRemoveLibraryFeedItem = vi.fn(async () => undefined);
+const mockUpdateLibraryFeedItem = vi.fn(async () => undefined);
 
 vi.mock("./library-client.js", () => ({
   addLibraryStubItem: mockAddLibraryStubItem,
+  removeLibraryFeedItem: mockRemoveLibraryFeedItem,
+  updateLibraryFeedItem: mockUpdateLibraryFeedItem,
 }));
 
 vi.mock("./content-fetcher.js", () => ({
@@ -40,10 +44,26 @@ describe("saveUrlInDesktop", () => {
   it("writes a saved stub and queues background detail fetching", async () => {
     const { saveUrlInDesktop } = await import("./save-url.js");
 
-    const result = await saveUrlInDesktop(SAMPLE_URL, { tags: ["research"] });
+    const result = await saveUrlInDesktop(SAMPLE_URL, {
+      notes: "Follow up",
+      tags: ["research"],
+    });
 
     expect(mockAddLibraryStubItem).toHaveBeenCalledWith(SAMPLE_URL, ["research"]);
-    expect(mockEnqueue).toHaveBeenCalledWith([stubItem], {
+    expect(mockUpdateLibraryFeedItem).toHaveBeenCalledWith(
+      "saved:abc123",
+      expect.objectContaining({
+        userState: expect.objectContaining({
+          highlights: [expect.objectContaining({ note: "Follow up" })],
+        }),
+      }),
+    );
+    expect(mockEnqueue).toHaveBeenCalledWith([expect.objectContaining({
+      globalId: stubItem.globalId,
+      userState: expect.objectContaining({
+        highlights: [expect.objectContaining({ note: "Follow up" })],
+      }),
+    })], {
       priority: true,
       force: true,
       bypassStartupDelay: true,

--- a/packages/desktop/src/lib/save-url.ts
+++ b/packages/desktop/src/lib/save-url.ts
@@ -7,15 +7,72 @@
  *  3. Queue background detail fetching and cache hydration.
  */
 
-import { addLibraryStubItem } from "./library-client";
+import { invoke } from "@tauri-apps/api/core";
+import { extractMetadataBrowser } from "@freed/capture-save/browser";
+import {
+  withSavedItemNote,
+  type FeedItem,
+} from "@freed/shared";
+import {
+  addLibraryStubItem,
+  removeLibraryFeedItem,
+  updateLibraryFeedItem,
+} from "./library-client";
 import { enqueue } from "./content-fetcher.js";
 
 export interface SaveUrlOptions {
+  notes?: string;
+  preview?: {
+    description?: string;
+    suggestedNote: string;
+    title: string;
+    url: string;
+  };
   tags?: string[];
 }
 
 export interface SaveUrlResult {
   globalId: string;
+}
+
+const SAVE_PREVIEW_MAX_BYTES = 2 * 1024 * 1024;
+
+function stableHttpUrl(url: string): string {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error("Invalid URL");
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Only http and https URLs are supported");
+  }
+  return parsed.toString();
+}
+
+export async function previewSaveUrlInDesktop(
+  url: string,
+  signal?: AbortSignal,
+): Promise<{
+  description?: string;
+  suggestedNote: string;
+  title: string;
+  url: string;
+}> {
+  const stableUrl = stableHttpUrl(url);
+  signal?.throwIfAborted();
+  const html = await invoke<string>("fetch_url", {
+    url: stableUrl,
+    maxBytes: SAVE_PREVIEW_MAX_BYTES,
+  });
+  signal?.throwIfAborted();
+  const metadata = extractMetadataBrowser(html, stableUrl);
+  return {
+    url: stableUrl,
+    title: metadata.title,
+    ...(metadata.description ? { description: metadata.description } : {}),
+    suggestedNote: metadata.description ?? "",
+  };
 }
 
 /**
@@ -28,24 +85,67 @@ export async function saveUrlInDesktop(
   url: string,
   options: SaveUrlOptions = {},
 ): Promise<SaveUrlResult> {
-  let parsed: URL;
-  try {
-    parsed = new URL(url);
-  } catch {
-    throw new Error("Invalid URL");
-  }
-
-  if (!["http:", "https:"].includes(parsed.protocol)) {
-    throw new Error("Only http and https URLs are supported");
-  }
-
-  const stableUrl = parsed.toString();
+  const stableUrl = stableHttpUrl(url);
+  const preview = options.preview?.url === stableUrl ? options.preview : undefined;
   const item = await addLibraryStubItem(stableUrl, options.tags);
-  enqueue([item], {
+  const content = preview
+    ? {
+        ...item.content,
+        text: preview.description ?? item.content.text,
+        linkPreview: {
+          url: stableUrl,
+          title: preview.title,
+          ...(preview.description ? { description: preview.description } : {}),
+        },
+      }
+    : item.content;
+  const userState = options.notes
+    ? {
+        ...item.userState,
+        highlights: withSavedItemNote([], options.notes),
+      }
+    : item.userState;
+  const savedItem = { ...item, content, userState };
+  if (preview || options.notes) {
+    await updateLibraryFeedItem(item.globalId, {
+      ...(preview ? { content } : {}),
+      ...(options.notes ? { userState } : {}),
+    });
+  }
+  enqueue([savedItem], {
     priority: true,
     force: true,
     bypassStartupDelay: true,
     reopenSaveDialogOnError: true,
   });
-  return { globalId: item.globalId };
+  return { globalId: savedItem.globalId };
+}
+
+export async function updateSavedContentInDesktop(
+  item: FeedItem,
+  input: {
+    notes: string;
+    preview?: SaveUrlOptions["preview"];
+    url: string;
+  },
+): Promise<SaveUrlResult> {
+  const stableUrl = stableHttpUrl(input.url);
+  const currentUrl = item.sourceUrl ?? item.content.linkPreview?.url ?? "";
+  if (stableUrl === currentUrl) {
+    await updateLibraryFeedItem(item.globalId, {
+      userState: {
+        ...item.userState,
+        highlights: withSavedItemNote(item.userState.highlights, input.notes),
+      },
+    });
+    return { globalId: item.globalId };
+  }
+
+  const saved = await saveUrlInDesktop(stableUrl, {
+    notes: input.notes,
+    preview: input.preview,
+    tags: item.userState.tags,
+  });
+  await removeLibraryFeedItem(item.globalId);
+  return saved;
 }

--- a/packages/desktop/tests/e2e/clipboard-save-shortcut.spec.ts
+++ b/packages/desktop/tests/e2e/clipboard-save-shortcut.spec.ts
@@ -103,7 +103,49 @@ test("global clipboard shortcut opens Save Content blank for non-URL clipboard t
   await expect(page.getByLabel("Article or page URL")).toHaveValue("");
 });
 
-test("saving new content opens the saved item in reader mode", async ({ app, page, ipc }) => {
+test("URL preview shows activity and fills untouched notes", async ({ app, page, ipc }) => {
+  await app.goto();
+  await app.waitForReady();
+  await ipc.setHandler("fetch_url", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    return '<html><head><meta name="description" content="A useful preview note." /></head></html>';
+  });
+
+  const shortcut = await waitForRegisteredShortcut(page);
+  await page.evaluate(() => {
+    (window as unknown as { __TAURI_MOCK_CLIPBOARD_TEXT__?: string })
+      .__TAURI_MOCK_CLIPBOARD_TEXT__ = "https://example.com/preview-note";
+  });
+  await triggerShortcut(page, shortcut);
+
+  await expect(page.getByRole("status", { name: "Reading URL details" })).toBeVisible();
+  await expect(page.getByLabel("Notes")).toHaveValue("A useful preview note.");
+  await expect(page.getByPlaceholder("Notes will be auto-populated from the URL when available.")).toBeVisible();
+});
+
+test("URL preview never replaces notes after the user edits them", async ({ app, page, ipc }) => {
+  await app.goto();
+  await app.waitForReady();
+  await ipc.setHandler("fetch_url", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 700));
+    return '<html><head><meta name="description" content="Fetched note that must not win." /></head></html>';
+  });
+
+  const shortcut = await waitForRegisteredShortcut(page);
+  await page.evaluate(() => {
+    (window as unknown as { __TAURI_MOCK_CLIPBOARD_TEXT__?: string })
+      .__TAURI_MOCK_CLIPBOARD_TEXT__ = "https://example.com/user-note-wins";
+  });
+  await triggerShortcut(page, shortcut);
+
+  const notes = page.getByLabel("Notes");
+  await notes.fill("My note");
+  await expect(page.getByRole("status", { name: "Reading URL details" })).toBeVisible();
+  await expect(page.getByRole("status", { name: "Reading URL details" })).toBeHidden();
+  await expect(notes).toHaveValue("My note");
+});
+
+test("saving and editing content persists preview details and searchable notes", async ({ app, page, ipc }) => {
   await app.goto();
   await app.waitForReady();
 
@@ -131,10 +173,11 @@ test("saving new content opens the saved item in reader mode", async ({ app, pag
   });
   await triggerShortcut(page, shortcut);
 
+  const notes = page.getByLabel("Notes");
+  await expect(notes).toHaveValue("A saved article should open immediately.");
+  await notes.fill("Updated comet note");
   await page.getByRole("button", { name: "Save", exact: true }).click();
 
-  await expect(page.getByText("Saved Reader Transition").first()).toBeVisible();
-  await expect(page.getByRole("article").getByText("A saved article should open immediately.")).toBeVisible();
   await page.waitForFunction(() => {
     const w = window as Record<string, unknown>;
     const state = (w.__FREED_STORE__ as { getState: () => {
@@ -147,6 +190,54 @@ test("saving new content opens the saved item in reader mode", async ({ app, pag
       && typeof state.selectedItemId === "string"
       && state.selectedItemId.startsWith("saved:");
   });
+
+  const savedState = await page.evaluate(() => {
+    const root = window as Record<string, unknown>;
+    const selectedItemId = (root.__FREED_STORE__ as {
+      getState: () => { selectedItemId: string | null };
+    }).getState().selectedItemId;
+    const library = root.__TAURI_MOCK_SQLITE_LIBRARY__ as {
+      items: Record<string, {
+        content: { linkPreview: { title: string; url: string } };
+        userState: { highlights?: Array<{ note?: string }> };
+      }>;
+    };
+    return {
+      item: selectedItemId ? library.items[selectedItemId] : null,
+      selectedItemId,
+    };
+  });
+  expect(savedState.item?.content.linkPreview.title).toBe("Saved Reader Transition");
+  expect(savedState.item?.userState.highlights?.[0]?.note).toBe("Updated comet note");
+
+  await page.evaluate((item) => {
+    window.dispatchEvent(new CustomEvent("freed:edit-saved-content", { detail: { item } }));
+  }, savedState.item);
+  await expect(page.getByText("Edit Save", { exact: true })).toBeVisible();
+  await expect(page.getByLabel("Article or page URL")).toHaveValue(
+    "https://example.com/saved-reader-transition",
+  );
+  await expect(page.getByLabel("Notes")).toHaveValue("Updated comet note");
+  await page.getByLabel("Article or page URL").fill(
+    "https://example.com/saved-reader-transition-edited",
+  );
+  await page.waitForTimeout(500);
+  await page.getByRole("button", { name: "Update save", exact: true }).click();
+  await page.waitForFunction((previousId) => {
+    const state = ((window as Record<string, unknown>).__FREED_STORE__ as {
+      getState: () => { selectedItemId: string | null };
+    }).getState();
+    return typeof state.selectedItemId === "string" && state.selectedItemId !== previousId;
+  }, savedState.selectedItemId);
+
+  const search = page.locator('[aria-label="Search or run"]:visible').first();
+  await search.fill("Updated comet note");
+  const searchAction = page.getByRole("option", {
+    name: /Search current feed for "Updated comet note"/,
+  });
+  await expect(searchAction).toBeVisible();
+  await searchAction.click();
+  await expect(page.getByText("Saved Reader Transition").first()).toBeVisible();
 });
 
 test("Settings records, disables, and resets the Save Content shortcut", async ({ app, page }) => {

--- a/packages/desktop/tests/e2e/fixtures/tauri-init.ts
+++ b/packages/desktop/tests/e2e/fixtures/tauri-init.ts
@@ -1500,6 +1500,10 @@ export function tauriInitScript(): string {
           var preview = content.linkPreview || {};
           var author = item.author || {};
           var rssSource = item.rssSource || {};
+          var user = sqliteItemState(item);
+          var highlights = (user.highlights || []).flatMap(function(highlight) {
+            return [highlight.text, highlight.note];
+          });
           var searchable = [
             content.text,
             preview.title,
@@ -1507,6 +1511,7 @@ export function tauriInitScript(): string {
             author.displayName,
             author.handle,
             rssSource.feedTitle,
+            highlights.join(' '),
           ].filter(Boolean).join(' ').toLowerCase();
           return searchTerms.every(function(term) { return searchable.includes(term); });
         }).slice(0, request.limit || 32).map(function(item) {

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -64,7 +64,11 @@ import {
   buildPwaReleaseChannelUrl,
   persistReleaseChannel,
 } from "@freed/ui/lib/release-channel";
-import { saveUrlInPwa } from "./lib/save-url";
+import {
+  previewSaveUrlInPwa,
+  saveUrlInPwa,
+  updateSavedContentInPwa,
+} from "./lib/save-url";
 import { getCachedArticleHtml } from "@freed/ui/lib/article-cache";
 import { clearDeviceAIPreferences } from "@freed/ui/lib/device-ai-preferences";
 import { clearDeviceDisplayPreferences } from "@freed/ui/lib/device-display-preferences";
@@ -525,6 +529,8 @@ function App() {
       saveUrl: IS_DEMO
         ? undefined
         : async (url, options) => saveUrlInPwa(url, options),
+      previewSaveUrl: IS_DEMO ? undefined : previewSaveUrlInPwa,
+      updateSavedContent: IS_DEMO ? undefined : updateSavedContentInPwa,
       // PWA local content: check the Workbox Cache API
       getLocalContent: async (globalId: string) => {
         try {

--- a/packages/pwa/src/lib/save-url.test.ts
+++ b/packages/pwa/src/lib/save-url.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
 
 const mockEnqueueCapture = vi.fn(async () => undefined);
+const mockEnqueueAnnotations = vi.fn(async () => undefined);
+const mockEnqueueRemove = vi.fn(async () => undefined);
 
 vi.mock("@freed/capture-save/normalize", () => ({
   buildSavedFeedItem: (metadata: { url: string }, _content: null, options: { tags?: string[] }) => ({
@@ -16,6 +18,8 @@ vi.mock("@freed/capture-save/normalize", () => ({
 
 vi.mock("./library-core-runtime", () => ({
   enqueuePwaLibraryCoreFeedItemCapture: mockEnqueueCapture,
+  enqueuePwaLibraryCoreFeedItemAnnotationSets: mockEnqueueAnnotations,
+  enqueuePwaLibraryCoreFeedItemRemove: mockEnqueueRemove,
 }));
 
 describe("saveUrlInPwa", () => {
@@ -28,6 +32,7 @@ describe("saveUrlInPwa", () => {
     const { saveUrlInPwa } = await import("./save-url");
 
     await expect(saveUrlInPwa("https://example.com/article", {
+      notes: "Follow up",
       tags: ["research"],
     })).resolves.toEqual({ globalId: "saved:abc123" });
     expect(mockEnqueueCapture).toHaveBeenCalledWith(
@@ -37,6 +42,13 @@ describe("saveUrlInPwa", () => {
         userState: expect.objectContaining({ tags: ["research"] }),
       }),
     );
+    expect(mockEnqueueAnnotations).toHaveBeenCalledWith([
+      expect.objectContaining({
+        entityId: "saved:abc123",
+        highlights: [expect.objectContaining({ note: "Follow up" })],
+        tags: ["research"],
+      }),
+    ]);
     expect(fetch).not.toHaveBeenCalled();
     vi.unstubAllGlobals();
   });

--- a/packages/pwa/src/lib/save-url.ts
+++ b/packages/pwa/src/lib/save-url.ts
@@ -1,11 +1,22 @@
 import {
   buildSavedFeedItem,
 } from "@freed/capture-save/normalize";
+import { extractMetadataBrowser } from "@freed/capture-save/browser";
+import { withSavedItemNote, type FeedItem } from "@freed/shared";
 import {
   enqueuePwaLibraryCoreFeedItemCapture,
+  enqueuePwaLibraryCoreFeedItemAnnotationSets,
+  enqueuePwaLibraryCoreFeedItemRemove,
 } from "./library-core-runtime";
 
 export interface SaveUrlOptions {
+  notes?: string;
+  preview?: {
+    description?: string;
+    suggestedNote: string;
+    title: string;
+    url: string;
+  };
   tags?: string[];
 }
 
@@ -13,24 +24,93 @@ export interface SaveUrlResult {
   globalId: string;
 }
 
-export async function saveUrlInPwa(
-  url: string,
-  options: SaveUrlOptions = {},
-): Promise<SaveUrlResult> {
+const SAVE_PREVIEW_MAX_BYTES = 2 * 1024 * 1024;
+
+function stableHttpUrl(url: string): string {
   let parsed: URL;
   try {
     parsed = new URL(url);
   } catch {
     throw new Error("Invalid URL");
   }
-
   if (!["http:", "https:"].includes(parsed.protocol)) {
     throw new Error("Only http and https URLs are supported");
   }
+  return parsed.toString();
+}
 
-  const stableUrl = parsed.toString();
+async function readBoundedResponseText(response: Response): Promise<string> {
+  const declaredLength = Number(response.headers.get("content-length"));
+  if (Number.isFinite(declaredLength) && declaredLength > SAVE_PREVIEW_MAX_BYTES) {
+    throw new Error("URL preview response is too large");
+  }
+  if (!response.body) {
+    const text = await response.text();
+    if (new TextEncoder().encode(text).byteLength > SAVE_PREVIEW_MAX_BYTES) {
+      throw new Error("URL preview response is too large");
+    }
+    return text;
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let byteLength = 0;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    byteLength += value.byteLength;
+    if (byteLength > SAVE_PREVIEW_MAX_BYTES) {
+      await reader.cancel();
+      throw new Error("URL preview response is too large");
+    }
+    chunks.push(value);
+  }
+  const bytes = new Uint8Array(byteLength);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+export async function previewSaveUrlInPwa(
+  url: string,
+  signal?: AbortSignal,
+): Promise<{
+  description?: string;
+  suggestedNote: string;
+  title: string;
+  url: string;
+}> {
+  const stableUrl = stableHttpUrl(url);
+  const response = await fetch(stableUrl, {
+    signal,
+    headers: { Accept: "text/html,application/xhtml+xml" },
+  });
+  if (!response.ok) throw new Error(`URL preview failed (${response.status.toLocaleString()})`);
+  const html = await readBoundedResponseText(response);
+  const metadata = extractMetadataBrowser(html, stableUrl);
+  return {
+    url: stableUrl,
+    title: metadata.title,
+    ...(metadata.description ? { description: metadata.description } : {}),
+    suggestedNote: metadata.description ?? "",
+  };
+}
+
+export async function saveUrlInPwa(
+  url: string,
+  options: SaveUrlOptions = {},
+): Promise<SaveUrlResult> {
+  const stableUrl = stableHttpUrl(url);
+  const preview = options.preview?.url === stableUrl ? options.preview : undefined;
   const item = buildSavedFeedItem(
-    { title: stableUrl, url: stableUrl },
+    {
+      title: preview?.title ?? stableUrl,
+      url: stableUrl,
+      ...(preview?.description ? { description: preview.description } : {}),
+    },
     null,
     {
       includeSourceUrl: true,
@@ -39,5 +119,44 @@ export async function saveUrlInPwa(
   );
   const canonicalItem = JSON.parse(JSON.stringify(item)) as typeof item;
   await enqueuePwaLibraryCoreFeedItemCapture(canonicalItem);
+  if ((options.tags?.length ?? 0) > 0 || (options.notes?.length ?? 0) > 0) {
+    await enqueuePwaLibraryCoreFeedItemAnnotationSets([
+      {
+        entityId: item.globalId,
+        highlights: withSavedItemNote([], options.notes ?? ""),
+        tags: options.tags ?? [],
+      },
+    ]);
+  }
   return { globalId: item.globalId };
+}
+
+export async function updateSavedContentInPwa(
+  item: FeedItem,
+  input: {
+    notes: string;
+    preview?: SaveUrlOptions["preview"];
+    url: string;
+  },
+): Promise<SaveUrlResult> {
+  const stableUrl = stableHttpUrl(input.url);
+  const currentUrl = item.sourceUrl ?? item.content.linkPreview?.url ?? "";
+  if (stableUrl === currentUrl) {
+    await enqueuePwaLibraryCoreFeedItemAnnotationSets([
+      {
+        entityId: item.globalId,
+        highlights: withSavedItemNote(item.userState.highlights, input.notes),
+        tags: item.userState.tags,
+      },
+    ]);
+    return { globalId: item.globalId };
+  }
+
+  const saved = await saveUrlInPwa(stableUrl, {
+    notes: input.notes,
+    preview: input.preview,
+    tags: item.userState.tags,
+  });
+  await enqueuePwaLibraryCoreFeedItemRemove(item.globalId);
+  return saved;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -53,3 +53,4 @@ export * from "./bug-report";
 export * from "./redact-sensitive";
 export * from "./story-wall";
 export * from "./youtube";
+export * from "./saved-item-note";

--- a/packages/shared/src/saved-item-note.test.ts
+++ b/packages/shared/src/saved-item-note.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import {
+  SAVED_ITEM_NOTE_MARKER,
+  getSavedItemNote,
+  withSavedItemNote,
+} from "./saved-item-note";
+
+describe("saved item notes", () => {
+  it("stores one whole-item note without disturbing text highlights", () => {
+    const highlights = [{ text: "quoted text", note: "source note", createdAt: 10 }];
+    const next = withSavedItemNote(highlights, "Remember this", 20);
+
+    expect(next).toEqual([
+      ...highlights,
+      { text: SAVED_ITEM_NOTE_MARKER, note: "Remember this", createdAt: 20 },
+    ]);
+    expect(getSavedItemNote(next)).toBe("Remember this");
+  });
+
+  it("replaces and removes only the reserved note", () => {
+    const original = withSavedItemNote(
+      [{ text: "quoted text", createdAt: 10 }],
+      "First",
+      20,
+    );
+    const replaced = withSavedItemNote(original, "Second", 30);
+
+    expect(getSavedItemNote(replaced)).toBe("Second");
+    expect(replaced.filter((highlight) => highlight.text === SAVED_ITEM_NOTE_MARKER)).toHaveLength(1);
+    expect(withSavedItemNote(replaced, "")).toEqual([
+      { text: "quoted text", createdAt: 10 },
+    ]);
+  });
+});

--- a/packages/shared/src/saved-item-note.ts
+++ b/packages/shared/src/saved-item-note.ts
@@ -1,0 +1,35 @@
+import type { Highlight } from "./types";
+
+/**
+ * Reserved annotation text for a whole-item note.
+ *
+ * U+2063 is intentionally invisible and does not add a synthetic search term.
+ * The note remains a normal synchronized annotation, so existing Library Core
+ * search and replacement-sync behavior apply without a second storage path.
+ */
+export const SAVED_ITEM_NOTE_MARKER = "\u2063";
+
+export function getSavedItemNote(
+  highlights: readonly Highlight[] | undefined,
+): string {
+  return highlights?.find((highlight) => highlight.text === SAVED_ITEM_NOTE_MARKER)?.note ?? "";
+}
+
+export function withSavedItemNote(
+  highlights: readonly Highlight[] | undefined,
+  note: string,
+  createdAt = Date.now(),
+): Highlight[] {
+  const remaining = (highlights ?? []).filter(
+    (highlight) => highlight.text !== SAVED_ITEM_NOTE_MARKER,
+  );
+  if (note.length === 0) return remaining;
+  return [
+    ...remaining,
+    {
+      text: SAVED_ITEM_NOTE_MARKER,
+      note,
+      createdAt,
+    },
+  ];
+}

--- a/packages/ui/src/components/SavedContentDialog.tsx
+++ b/packages/ui/src/components/SavedContentDialog.tsx
@@ -5,15 +5,21 @@
  * Import and export live in Settings > Saved Content.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+import { getSavedItemNote, type FeedItem } from "@freed/shared";
 import { BottomSheet } from "./BottomSheet.js";
 import { toast } from "./Toast.js";
-import { useAppStore, usePlatform } from "../context/PlatformContext.js";
+import {
+  useAppStore,
+  usePlatform,
+  type SaveUrlPreview,
+} from "../context/PlatformContext.js";
 
 interface SavedContentDialogProps {
   open: boolean;
   initialUrl?: string;
   initialError?: string;
+  editItem?: FeedItem | null;
   onClose: () => void;
 }
 
@@ -21,6 +27,7 @@ export function SavedContentDialog({
   open,
   initialUrl = "",
   initialError = "",
+  editItem = null,
   onClose,
 }: SavedContentDialogProps) {
   const { saveUrl } = usePlatform();
@@ -28,8 +35,8 @@ export function SavedContentDialog({
   const handleClose = () => onClose();
 
   return (
-    <BottomSheet open={open} onClose={handleClose} title="Save Content" maxWidth="sm:max-w-lg" headerDivider={false}>
-      {saveUrl && <SaveUrlTab initialUrl={initialUrl} initialError={initialError} open={open} onClose={handleClose} />}
+    <BottomSheet open={open} onClose={handleClose} title={editItem ? "Edit Save" : "Save Content"} maxWidth="sm:max-w-lg" headerDivider={false}>
+      {saveUrl && <SaveUrlTab initialUrl={initialUrl} initialError={initialError} editItem={editItem} open={open} onClose={handleClose} />}
     </BottomSheet>
   );
 }
@@ -39,31 +46,79 @@ export function SavedContentDialog({
 function SaveUrlTab({
   initialUrl,
   initialError,
+  editItem,
   open,
   onClose,
 }: {
   initialUrl: string;
   initialError: string;
+  editItem: FeedItem | null;
   open: boolean;
   onClose: () => void;
 }) {
-  const { saveUrl } = usePlatform();
+  const { previewSaveUrl, saveUrl, updateSavedContent } = usePlatform();
   const setFilter = useAppStore((s) => s.setFilter);
   const setActiveView = useAppStore((s) => s.setActiveView);
+  const activeFilter = useAppStore((s) => s.activeFilter);
+  const activeView = useAppStore((s) => s.activeView);
   const setSelectedItem = useAppStore((s) => s.setSelectedItem);
   const setSelectedPerson = useAppStore((s) => s.setSelectedPerson);
   const setSelectedAccount = useAppStore((s) => s.setSelectedAccount);
   const [url, setUrl] = useState(initialUrl);
+  const [notes, setNotes] = useState("");
   const [error, setError] = useState(initialError);
+  const [preview, setPreview] = useState<SaveUrlPreview | null>(null);
+  const [isPreviewing, setIsPreviewing] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const notesEditedRef = useRef(false);
 
   useEffect(() => {
     if (open) {
+      const existingNote = getSavedItemNote(editItem?.userState.highlights);
       setUrl(initialUrl);
+      setNotes(existingNote);
       setError(initialError);
+      setPreview(null);
+      setIsPreviewing(false);
+      setIsSubmitting(false);
+      notesEditedRef.current = existingNote.length > 0;
     }
-  }, [initialError, initialUrl, open]);
+  }, [editItem, initialError, initialUrl, open]);
 
-  const handleSubmit = (e: React.FormEvent) => {
+  useEffect(() => {
+    if (!open || !previewSaveUrl) return;
+    let stableUrl: string;
+    try {
+      const parsed = new URL(url.trim());
+      if (!["http:", "https:"].includes(parsed.protocol)) return;
+      stableUrl = parsed.toString();
+    } catch {
+      return;
+    }
+
+    const controller = new AbortController();
+    const timer = window.setTimeout(() => {
+      setIsPreviewing(true);
+      setPreview(null);
+      void previewSaveUrl(stableUrl, controller.signal)
+        .then((preview) => {
+          setPreview(preview);
+          if (!notesEditedRef.current && preview.suggestedNote) {
+            setNotes(preview.suggestedNote);
+          }
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          if (!controller.signal.aborted) setIsPreviewing(false);
+        });
+    }, 350);
+    return () => {
+      window.clearTimeout(timer);
+      controller.abort();
+    };
+  }, [open, previewSaveUrl, url]);
+
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     const trimmed = url.trim();
     if (!trimmed || !saveUrl) return;
@@ -82,31 +137,42 @@ function SaveUrlTab({
     }
 
     const stableUrl = parsed.toString();
+    const noteBytes = new TextEncoder().encode(notes).byteLength;
+    if (noteBytes > 8_192) {
+      setError(`Notes must be ${Number(8_192).toLocaleString()} bytes or fewer`);
+      return;
+    }
     setError("");
-    setUrl("");
-    toast.success("Saved to library");
-    onClose();
-
-    void saveUrl(stableUrl)
-      .then((saved) => {
-        setActiveView("feed");
-        setFilter({ savedOnly: true });
-        setSelectedPerson(null);
-        setSelectedAccount(null);
-        setSelectedItem(saved.globalId);
-      })
-      .catch((err) => {
-        const message = err instanceof Error ? err.message : "Failed to save URL";
-        toast.error(message);
-        window.dispatchEvent(
-          new CustomEvent("freed:save-content-details-error", {
-            detail: {
-              initialUrl: stableUrl,
-              errorMessage: message,
-            },
-          }),
-        );
-      });
+    setIsSubmitting(true);
+    const previousFilter = activeFilter;
+    const previousView = activeView;
+    setActiveView("feed");
+    setFilter({ savedOnly: true });
+    setSelectedPerson(null);
+    setSelectedAccount(null);
+    try {
+      const saved = editItem && updateSavedContent
+        ? await updateSavedContent(editItem, {
+            url: stableUrl,
+            notes,
+            ...(preview?.url === stableUrl ? { preview } : {}),
+          })
+        : await saveUrl(stableUrl, {
+            notes,
+            ...(preview?.url === stableUrl ? { preview } : {}),
+          });
+      toast.success(editItem ? "Save updated" : "Saved to library");
+      setSelectedItem(saved.globalId);
+      onClose();
+    } catch (err) {
+      setActiveView(previousView);
+      setFilter(previousFilter);
+      const message = err instanceof Error ? err.message : "Failed to save URL";
+      setError(message);
+      toast.error(message);
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -127,19 +193,42 @@ function SaveUrlTab({
           className="w-full rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-input)] px-4 py-3 text-[var(--theme-text-primary)] placeholder-[var(--theme-text-muted)] transition-colors focus:outline-none focus:border-[var(--theme-border-strong)]"
           autoFocus
         />
+        {isPreviewing && (
+          <div role="status" aria-label="Reading URL details" className="mt-2 flex items-center gap-2 text-sm text-[var(--theme-text-muted)]">
+            <span aria-hidden="true" className="h-4 w-4 animate-spin rounded-full border border-[var(--theme-border-strong)] border-t-[var(--theme-accent-secondary)]" />
+            Reading URL details
+          </div>
+        )}
         {error && (
           <p className="mt-2 rounded-lg border border-amber-500/25 bg-amber-500/10 px-3 py-2 text-sm text-amber-200">
             {error}
           </p>
         )}
       </div>
+      <div className="mb-4">
+        <label htmlFor="save-notes-input" className="mb-2 block text-sm text-[var(--theme-text-secondary)]">
+          Notes
+        </label>
+        <textarea
+          id="save-notes-input"
+          value={notes}
+          onChange={(event) => {
+            notesEditedRef.current = true;
+            setNotes(event.target.value);
+            if (error) setError("");
+          }}
+          placeholder="Notes will be auto-populated from the URL when available."
+          rows={4}
+          className="w-full resize-y rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-input)] px-4 py-3 text-[var(--theme-text-primary)] placeholder-[var(--theme-text-muted)] transition-colors focus:border-[var(--theme-border-strong)] focus:outline-none"
+        />
+      </div>
       <div className="flex justify-end">
         <button
           type="submit"
           className="btn-primary px-6 py-2.5 disabled:opacity-50 disabled:cursor-not-allowed"
-          disabled={!url.trim()}
+          disabled={!url.trim() || isSubmitting}
         >
-          Save
+          {isSubmitting ? "Saving..." : editItem ? "Update save" : "Save"}
         </button>
       </div>
     </form>

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -23,6 +23,7 @@ import { ExternalLinkIcon, TrashIcon } from "../icons.js";
 import { FocusText } from "./FocusText.js";
 import { YouTubeFocusPlayer } from "./YouTubeFocusPlayer.js";
 import { useDeviceDisplayPreferences } from "../../lib/device-display-preferences.js";
+import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 
 interface ReaderViewProps {
   item: FeedItemType;
@@ -352,8 +353,10 @@ export function ReaderView({
     hydrateReaderItem,
     pinReaderItem,
     openUrl: platformOpenUrl,
+    updateSavedContent,
     youtube,
   } = usePlatform();
+  const openSavedContentEditor = useCommandSurfaceStore((state) => state.openSavedContentEditor);
   const toggleSaved = useAppStore((s) => s.toggleSaved);
   const toggleArchived = useAppStore((s) => s.toggleArchived);
   const updatePreferences = useAppStore((s) => s.updatePreferences);
@@ -971,18 +974,31 @@ export function ReaderView({
             {readerPresentation.title}
           </h1>
 
-          {articleUrl && (
-            <a
-              href={articleUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="inline-flex items-center gap-1 text-sm font-medium text-[var(--theme-accent-secondary)] transition-colors hover:opacity-80"
-            >
-              View original
-              <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
-              </svg>
-            </a>
+          {(articleUrl || (item.platform === "saved" && updateSavedContent)) && (
+            <div className="flex flex-wrap items-center gap-3">
+              {articleUrl && (
+                <a
+                  href={articleUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1 text-sm font-medium text-[var(--theme-accent-secondary)] transition-colors hover:opacity-80"
+                >
+                  View original
+                  <svg className="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+                  </svg>
+                </a>
+              )}
+              {item.platform === "saved" && updateSavedContent && (
+                <button
+                  type="button"
+                  onClick={() => openSavedContentEditor(item)}
+                  className="btn-secondary rounded-lg px-3 py-2 text-sm font-semibold"
+                >
+                  Edit save
+                </button>
+              )}
+            </div>
           )}
         </div>
 

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -123,7 +123,9 @@ export function AppShell({ children }: AppShellProps) {
   const closeAddFeedDialog = useCommandSurfaceStore((s) => s.closeAddFeedDialog);
   const savedContentOpen = useCommandSurfaceStore((s) => s.savedContentOpen);
   const savedContentInitialUrl = useCommandSurfaceStore((s) => s.savedContentInitialUrl);
+  const savedContentEditItem = useCommandSurfaceStore((s) => s.savedContentEditItem);
   const openSavedContentDialog = useCommandSurfaceStore((s) => s.openSavedContentDialog);
+  const openSavedContentEditor = useCommandSurfaceStore((s) => s.openSavedContentEditor);
   const closeSavedContentDialog = useCommandSurfaceStore((s) => s.closeSavedContentDialog);
   const [savedContentError, setSavedContentError] = useState("");
   const libraryDialogOpen = useCommandSurfaceStore((s) => s.libraryDialogOpen);
@@ -175,14 +177,20 @@ export function AppShell({ children }: AppShellProps) {
       setSavedContentError(detail?.errorMessage ?? "Freed could not save details for this URL.");
       openSavedContentDialog(detail?.initialUrl);
     };
+    const handleEditSavedContent = (event: Event) => {
+      const detail = (event as CustomEvent<{ item?: import("@freed/shared").FeedItem }>).detail;
+      if (detail?.item) openSavedContentEditor(detail.item);
+    };
 
     window.addEventListener("freed:open-save-content-dialog", handleOpenSavedContent);
     window.addEventListener("freed:save-content-details-error", handleSaveDetailsError);
+    window.addEventListener("freed:edit-saved-content", handleEditSavedContent);
     return () => {
       window.removeEventListener("freed:open-save-content-dialog", handleOpenSavedContent);
       window.removeEventListener("freed:save-content-details-error", handleSaveDetailsError);
+      window.removeEventListener("freed:edit-saved-content", handleEditSavedContent);
     };
-  }, [openSavedContentDialog]);
+  }, [openSavedContentDialog, openSavedContentEditor]);
 
   const handleCloseSavedContentDialog = useCallback(() => {
     setSavedContentError("");
@@ -597,6 +605,7 @@ export function AppShell({ children }: AppShellProps) {
         <SavedContentDialog
           open={savedContentOpen}
           initialUrl={savedContentInitialUrl}
+          editItem={savedContentEditItem}
           initialError={savedContentError}
           onClose={handleCloseSavedContentDialog}
         />

--- a/packages/ui/src/context/PlatformContext.tsx
+++ b/packages/ui/src/context/PlatformContext.tsx
@@ -431,6 +431,25 @@ export interface SaveUrlResult {
   globalId: string;
 }
 
+export interface SaveUrlPreview {
+  description?: string;
+  suggestedNote: string;
+  title: string;
+  url: string;
+}
+
+export interface SaveUrlOptions {
+  notes?: string;
+  preview?: SaveUrlPreview;
+  tags?: string[];
+}
+
+export interface UpdateSavedContentInput {
+  notes: string;
+  preview?: SaveUrlPreview;
+  url: string;
+}
+
 export interface YouTubeOfflinePlaylistResult {
   playlistId: string;
   playlistUrl: string;
@@ -809,7 +828,19 @@ export interface PlatformConfig {
    */
   saveUrl?: (
     url: string,
-    options?: { tags?: string[] },
+    options?: SaveUrlOptions,
+  ) => Promise<SaveUrlResult>;
+
+  /** Fetch a bounded public preview while the save dialog remains editable. */
+  previewSaveUrl?: (
+    url: string,
+    signal?: AbortSignal,
+  ) => Promise<SaveUrlPreview>;
+
+  /** Replace the URL or whole-item note for an existing manual save. */
+  updateSavedContent?: (
+    item: FeedItem,
+    input: UpdateSavedContentInput,
   ) => Promise<SaveUrlResult>;
 
   /**

--- a/packages/ui/src/lib/command-surface-store.ts
+++ b/packages/ui/src/lib/command-surface-store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import type { FeedItem } from "@freed/shared";
 
 export type LibraryDialogTab = "import" | "export";
 
@@ -8,6 +9,7 @@ interface CommandSurfaceStore {
   addFeedOpen: boolean;
   savedContentOpen: boolean;
   savedContentInitialUrl: string;
+  savedContentEditItem: FeedItem | null;
   libraryDialogOpen: boolean;
   libraryDialogTab: LibraryDialogTab;
   requestSearchPalette: () => void;
@@ -15,6 +17,7 @@ interface CommandSurfaceStore {
   openAddFeedDialog: () => void;
   closeAddFeedDialog: () => void;
   openSavedContentDialog: (initialUrl?: string) => void;
+  openSavedContentEditor: (item: FeedItem) => void;
   closeSavedContentDialog: () => void;
   openLibraryDialog: (tab?: LibraryDialogTab) => void;
   closeLibraryDialog: () => void;
@@ -26,6 +29,7 @@ export const useCommandSurfaceStore = create<CommandSurfaceStore>((set) => ({
   addFeedOpen: false,
   savedContentOpen: false,
   savedContentInitialUrl: "",
+  savedContentEditItem: null,
   libraryDialogOpen: false,
   libraryDialogTab: "import",
   requestSearchPalette: () =>
@@ -37,9 +41,23 @@ export const useCommandSurfaceStore = create<CommandSurfaceStore>((set) => ({
   openAddFeedDialog: () => set({ addFeedOpen: true }),
   closeAddFeedDialog: () => set({ addFeedOpen: false }),
   openSavedContentDialog: (initialUrl = "") =>
-    set({ savedContentOpen: true, savedContentInitialUrl: initialUrl }),
+    set({
+      savedContentOpen: true,
+      savedContentInitialUrl: initialUrl,
+      savedContentEditItem: null,
+    }),
+  openSavedContentEditor: (item) =>
+    set({
+      savedContentOpen: true,
+      savedContentInitialUrl: item.sourceUrl ?? item.content.linkPreview?.url ?? "",
+      savedContentEditItem: item,
+    }),
   closeSavedContentDialog: () =>
-    set({ savedContentOpen: false, savedContentInitialUrl: "" }),
+    set({
+      savedContentOpen: false,
+      savedContentInitialUrl: "",
+      savedContentEditItem: null,
+    }),
   openLibraryDialog: (tab = "import") =>
     set({ libraryDialogOpen: true, libraryDialogTab: tab }),
   closeLibraryDialog: () => set({ libraryDialogOpen: false }),

--- a/scripts/validate-skills.test.mjs
+++ b/scripts/validate-skills.test.mjs
@@ -34,6 +34,32 @@ test("checked-in Freed skills keep safe invocation and resolvable commands", () 
   }
 });
 
+test("feature tasks refresh policy before owner authorization", () => {
+  const agentInstructions = readFileSync(
+    new URL("../AGENTS.md", import.meta.url),
+    "utf8",
+  );
+  const featureSkill = readFileSync(
+    new URL("../.agents/skills/freed-build-feature/SKILL.md", import.meta.url),
+    "utf8",
+  );
+
+  assert.ok(
+    agentInstructions.indexOf("## Task startup freshness") <
+      agentInstructions.indexOf("## Authorization levels"),
+    "startup freshness must precede the authorization policy",
+  );
+  assert.match(agentInstructions, /git show <remote-ref>:AGENTS\.md/);
+  assert.match(agentInstructions, /Internal actor labels[\s\S]*never replace or rename/);
+  assert.ok(
+    featureSkill.indexOf("## Start from current policy") <
+      featureSkill.indexOf("## Establish the contract"),
+    "the feature skill must refresh policy before establishing authority",
+  );
+  assert.match(featureSkill, /git show origin\/dev:AGENTS\.md/);
+  assert.match(featureSkill, /must never be presented as owner authorization choices/);
+});
+
 test("skill validation rejects automatic invocation and missing commands", () => {
   const root = mkdtempSync(path.join(os.tmpdir(), "freed-skill-validator-"));
   const skillDir = path.join(root, ".agents", "skills", "unsafe-skill");


### PR DESCRIPTION
(AI Generated).

## Summary
- Add synchronized whole-item notes to URL saves and index them through existing Library search.
- Preview URL metadata before submission, show activity, and preserve any user-edited notes.
- Add an edit state for manual saves and refresh task startup policy before authorization.

## Testing
- npm run validate:feature
- npm run test:e2e -- clipboard-save-shortcut.spec.ts --reporter=line

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `fb8461c59b4ab88fd9d2670d5c1e41fdea984cae`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `codex-task-01a06059-8f98-7f83-9250-536c87aa5da5`
- Provider review decision: `behavior_approved`
- Provider review artifact: `a1756244935250d34a99791b5fb83416ce48d0e323552e7a252b1af3369f4eb6`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: After a user enters a valid public HTTP or HTTPS URL in the Save Content dialog, Freed waits 350 milliseconds and makes one bounded HTML preview request before submission. Freed ignores aborted or stale results and does not add authenticated provider navigation, cookies, headers, scrolling, clicking, retries, or background cadence.
- Fingerprinting risk: The destination, including X, Facebook, Instagram, LinkedIn, Medium, Substack, YouTube, or another publisher, can observe that Freed contacted the URL before the user submitted or even if the user abandons the save.
- Lowest profile alternative: Keep the previous behavior and wait until the user submits before contacting the destination URL.

Files bound into this provider review:
- `packages/desktop/src/App.tsx`
- `packages/pwa/src/App.tsx`
- `packages/ui/src/components/feed/ReaderView.tsx`
- `packages/ui/src/context/PlatformContext.tsx`