### PR TITLE
chore: split and validate repository instructions

### DIFF
--- a/.agents/skills/AGENTS.md
+++ b/.agents/skills/AGENTS.md
@@ -1,0 +1,19 @@
+# Freed Skill Instructions
+
+Read the root `AGENTS.md` first. Skills route task-specific workflows and never grant authorization.
+Read [docs/AGENT-INSTRUCTIONS.md](../../docs/AGENT-INSTRUCTIONS.md) before changing the instruction architecture or its budgets.
+
+## Authoring contract
+
+- Keep `SKILL.md` focused on activation, decisions, safety stops, and the shortest complete workflow.
+- Keep each `SKILL.md` at or below 16 KiB. Move detailed modes, examples, command catalogs, and background into clearly named files under `references/`.
+- Link references directly from `SKILL.md` and state exactly when to read each one. Do not require an agent to scan a directory.
+- Put only `name` and `description` in skill frontmatter unless the current Agent Skills standard requires another field.
+- Make the description precise enough for reliable selection. Name both positive triggers and important exclusions.
+- Every skill must include `agents/openai.yaml` with interface metadata and an explicit `policy.allow_implicit_invocation` value. Freed skills currently allow implicit selection, so that value is `true`.
+- Do not use the legacy `disable-model-invocation` field. Codex does not use it as the invocation control.
+- Preserve the numbered repository authorization model. A selected skill cannot raise authority, approve provider traffic, satisfy Gate 1, or bypass a stop condition.
+- Link canonical repository documents instead of copying mutable policy into a skill.
+- Use imperative instructions. Explain rationale only where it changes judgment.
+
+Run `npm run validate:skills` after changing a skill.

--- a/.agents/skills/freed-build-feature/SKILL.md
+++ b/.agents/skills/freed-build-feature/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-build-feature
 description: Build governed Freed product work in a worktree based on origin/dev, verify the runnable slice, and publish a correctly staged pull request to dev. Use for Desktop, PWA, shared packages, sync, capture, release tooling, product behavior, and product documentation. Also use for stability tasks that require a stable task identity, a measurable counter, native validation, or an installed-build verification handoff. Do not use for public website work targeting www.
-disable-model-invocation: true
 ---
 
 # Build Feature

--- a/.agents/skills/freed-build-feature/agents/openai.yaml
+++ b/.agents/skills/freed-build-feature/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Build Freed Feature"
   short_description: "Build and publish governed product changes"
   default_prompt: "Use $freed-build-feature to implement this governed Freed product change and prepare it for review."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-build-www/SKILL.md
+++ b/.agents/skills/freed-build-www/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-build-www
 description: Build Freed marketing-site work in a worktree based on origin/www, verify the website, and publish a pull request to www. Use for freed.wtf pages, marketing copy, legal pages, public changelog presentation, and public roadmap presentation. Use roadmap mode only from an approved docs/roadmap-status.json source commit, never by inferring status from prose or by merging dev into www.
-disable-model-invocation: true
 ---
 
 # Build WWW

--- a/.agents/skills/freed-build-www/agents/openai.yaml
+++ b/.agents/skills/freed-build-www/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Build Freed WWW"
   short_description: "Build marketing changes in the www lane"
   default_prompt: "Use $freed-build-www to build and verify this Freed marketing-site change in the www lane."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-canary/SKILL.md
+++ b/.agents/skills/freed-canary/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-canary
 description: Judge an installed Freed Desktop build against comparable historical runtime windows. Use after a release has run long enough, when a soak looks worse than usual, or when deciding whether a metric regressed. Require event-derived build identity, immutable time bounds, healthy evidence sources, matching workload cohorts, and at least three comparable baselines before declaring a regression.
-disable-model-invocation: true
 ---
 
 # Canary

--- a/.agents/skills/freed-canary/agents/openai.yaml
+++ b/.agents/skills/freed-canary/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Canary"
   short_description: "Judge matched installed-build canary windows"
   default_prompt: "Use $freed-canary to judge this installed build against comparable historical windows."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-evidence-capture/SKILL.md
+++ b/.agents/skills/freed-evidence-capture/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-evidence-capture
 description: Preserve attributable, read-only evidence from a live Freed failure or baseline before changing the system. Use for freezes, crashes, sync stalls, memory growth, provider lifecycle failures, data-loss suspicions, and any rare or stateful incident where logs, process state, build identity, or local data could disappear after restart or repair.
-disable-model-invocation: true
 ---
 
 # Evidence Capture

--- a/.agents/skills/freed-evidence-capture/agents/openai.yaml
+++ b/.agents/skills/freed-evidence-capture/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Evidence Capture"
   short_description: "Capture attributable local stability evidence"
   default_prompt: "Use $freed-evidence-capture to collect attributable, read-only stability evidence for this incident."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-library-core/SKILL.md
+++ b/.agents/skills/freed-library-core/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-library-core
 description: Build or migrate Freed's bounded-memory Library Core across Desktop and PWA. Use for native SQLite storage, browser row storage, operation journals, causal merge rules, tombstones, bounded queries, Automerge migration, storage-epoch cutover, rollback, snapshots, imports, operation-segment sync, renderer corpus eviction, or any change that can alter durable library authority.
-disable-model-invocation: true
 ---
 
 # Library Core
@@ -32,796 +31,85 @@ Record:
 If any item is unknown, inspect the current implementation. Do not invent a
 placeholder authority or a temporary second writer.
 
-The dormant census does not create the one-time legacy epoch bootstrap. Close
-the bootstrap record, prepared journal, local control, receipt, identity, and
-recovery-state schemas first. A later slice may implement their durable
-initialization transaction. Never guess an initial epoch or infer authority
-from file presence or synchronized bytes.
+## Read the applicable contract
 
-Keep the pure A1 contract package-internal until A2 provides its first
-production caller. A compiler-checked dormant module is useful. A public
-package export with no runtime consumer is dead API.
+Read every reference whose trigger matches before designing or editing. A slice
+may cross several modes, so use every matching reference.
 
-Bootstrap uses one explicit local owner action to create one durable prepared
-operation journal for the creator installation. The synchronized object is an
-unsigned, content-addressed bootstrap record. It names the legacy epoch and
-source frontier, but it does not grant owner or write authority. Every current
-legacy writer can create synchronized Automerge values, so a self-signature or
-an in-document key would be theater.
+- For legacy epoch bootstrap, creator and adopter control, IndexedDB legacy
+  saves, ancestry, recovery, or bootstrap retries, read
+  [bootstrap-and-legacy-control.md](references/bootstrap-and-legacy-control.md).
+- For Gate A registries, authoritative SQLite, browser row storage, derived
+  projections, shadow rebuilds, generation publication, or dormant readers,
+  read
+  [dormant-census-and-shadow-stores.md](references/dormant-census-and-shadow-stores.md).
+- For canonical values, digests, signed transactions, actor enrollment, native
+  verification, authoritative journaling, or replication outboxes, read
+  [canonical-operations-and-enrollment.md](references/canonical-operations-and-enrollment.md).
+- For active readers, writers, replication, materialization, provider effects,
+  blobs, rollback, or any data-authority change, read
+  [runtime-authority-invariants.md](references/runtime-authority-invariants.md).
+- For Gate C through Gate H migration, candidate claims, operation grants,
+  source fences, external-memory decoding, reader targets, backups, cleanup,
+  recovery, cutover, or Automerge retirement, read
+  [migration-cutover-and-recovery.md](references/migration-cutover-and-recovery.md).
+- For sequencing, tests, performance admission, publication, release,
+  activation, or handoff, read
+  [delivery-validation-and-closeout.md](references/delivery-validation-and-closeout.md).
 
-The record synchronizes under
-`libraryCoreLegacyBootstrapRecord:<record_digest>`. Never add a cloud sidecar,
-second provider object, request, or cadence for bootstrap. Readers complete
-one bounded scan of the entire current reserved root namespace and every
-conflict value, plus the complete historical set of reserved root keys in the
-accepted Automerge change graph. Absence requires both sets to be empty. An
-incomplete scan, deleted root, or tombstoned root blocks rebootstrap. Overflow
-fails before allocation. Exact duplicates collapse. Two unequal records block
-without winner selection.
+Do not load unrelated references merely because the skill is active. Do not
+skip a matching reference to save context.
 
-The live owner action is required only to atomically create the closed local
-prepared journal. That journal binds the exact installation, operation ID,
-storage generation, save revision, source binary digest, source heads,
-candidate record, candidate binary, candidate heads, and creator control. The
-candidate frontier must descend from the exact source frontier. The executable
-transaction loads the staged candidate bytes by their bound digest, proves
-their exact candidate heads and record occurrence, and only then attempts its
-compare-and-swap. The commit compare-and-swaps those source facts and writes
-the candidate document, control, receipt, retained prepared journal, and next
-revision in one local transaction. The receipt completes that exact journal.
-Exact retry reads the prepared or committed objects without asking again.
-Changed source bytes require explicit abandonment and a fresh owner action.
+## Always-on authority boundaries
 
-Another installation treats a valid synchronized record as TOFU read-only.
-Its local control must say `adopter_tofu_read_only`, and that mode cannot
-write. Writable adoption requires a separate authenticated pairing with an
-existing authority holder or real user presence. Ordinary sync state, copied
-credentials, a self-signature, and an in-document key cannot satisfy pairing.
+- Keep exactly one active writer epoch. A local file, schema, registry entry,
+  synchronized value, incremented number, or compiled module does not create
+  authority.
+- Acknowledge a mutation only after its operation, rows, tombstones, cursor,
+  and outbox commit atomically. Retries after timeout or response loss reuse
+  the exact operation ID and read back the durable result.
+- Fail closed on incomplete, conflicting, future, oversized, or unsupported
+  state. Preserve evidence. Never repair ambiguity by selecting a plausible
+  winner, deleting a fork, guessing an epoch, or creating a temporary writer.
+- Keep all interfaces bounded. Do not move a full corpus into React, Zustand,
+  or a resident Web Worker. Gate C migration must use bounded external-memory
+  decoding and must not call `Automerge.load` or retain a source-sized change
+  graph.
+- Dormant means no production caller, command registration, startup database
+  open, backfill, read route, writer route, authority receipt, network action,
+  or activation-manifest transition. Code presence never advances a gate.
+- Keep provider traffic off during development. Any slice that can turn a
+  memory-rejected Facebook or Instagram attempt into real contact must read
+  the exact approved behavior and limits in the runtime authority reference.
+  A cadence, request, navigation, cookie, header, extractor, or provider set
+  change requires its own decision before code.
+- Keep cloud-replication and provider-action outboxes separate. A remote
+  library operation never directly triggers provider activity.
+- Roll back only from a receipt at the same frontier. Otherwise roll forward.
+  Never activate a cutover without its exact rollback or recovery evidence.
+- Any Gate C through Gate H dormant-to-active transition stops at an
+  owner-reviewed pull request. Task or merge authority alone never activates a
+  migration candidate, source fence, reader cutover, renderer eviction, writer,
+  replication epoch, rollback, restore, authority rotation, soak activation,
+  or legacy retirement. Obtain the separate release, installation, and
+  activation authority required by the delivery reference.
+- Do not append to
+  `docs/library-core-activation-manifest.json` for dormant work. Only the
+  product pull request that deliberately crosses a gate appends one immutable,
+  closed transition entry.
 
-Before adoption or creator readback, prove that the record's immutable source
-frontier is an ancestor of the current document. Do not require old head
-hashes to remain in the current head set. The local control tracks the current
-frontier, schema, storage generation, and local access mode separately from the
-immutable record. Every ordinary legacy save compare-and-swaps its local save
-revision and atomically updates the document plus the current control
-frontier. The prepared candidate and exact first commit name the bootstrap
-operation in local control. A later ordinary save or adopter TOFU pin names
-its own local operation instead of falsifying current provenance.
-Derive incremental persistence from the last committed heads with repeatable
-`saveSince` semantics. Never let `saveIncremental` advance its process-local
-cursor before the storage transaction commits. Storage failure and response
-loss must leave the exact same changes available for retry.
-The legacy IndexedDB bridge uses schema version 2. A load returns exact bytes,
-generation, and save revision. Every save and clear compares both version
-fields in the transaction that changes bytes. Clear advances generation and
-resets save revision to zero. Preserve version 1 bytes exactly at revision
-zero, close connections on `versionchange`, and fail closed when an upgrade is
-blocked. Full replacement requires the caller revision captured before its
-asynchronous work began. Publish candidate bytes, heads, and derived worker
-state only after storage commit. A failed decode retains the exact bytes and
-revision from that read. Never re-read storage to broaden a later clear.
-Recognized Automerge decode failures may enter explicit revision-fenced
-recovery. Allocation exhaustion and unknown failures preserve the bytes and
-fail closed.
-Do not activate bootstrap while a compatibility rebuild can replace an
-Automerge document through value-only export and import. Such a rebuild loses
-the recorded change graph. Fence it after any bootstrap record exists or replace
-it with an authenticated history-preserving transition first. Lost ancestry is
-corruption, never authority to bootstrap again.
+## Execute the slice
 
-Protocol validators snapshot untrusted fields and arrays once into new
-immutable plain values. They bound head and occurrence arrays before
-allocation, never return-cast input objects, and never retain mutable aliases.
-Digest, ancestry, and state checks use only those snapshots.
-
-Retries after timeout or response loss reuse the exact operation ID and read
-back the durable result. They never generate a second identity or silently
-rebase an old owner action. Only wholly prepared or wholly committed creator
-tuples are recoverable. Document-only, control-only, receipt-only, incomplete
-scan, resource overflow, multiple records, and unsupported newer state block
-without repairing or deleting evidence.
-
-## Keep the dormant census honest
-
-The checked-in Gate A census is a compiler-enforced inventory, not activation
-authority:
-
-- synchronized schema work updates
-  `packages/shared/src/library-core/field-registry.ts`;
-- shared store contract work updates
-  `packages/shared/src/library-core/store-surface-registry.ts`;
-- Desktop and PWA worker message changes update the platform-owned
-  `library-core-worker-surface-registry.ts` beside each worker type union;
-- planned operation or query vocabulary changes update the corresponding
-  shared registry;
-- localStorage, IndexedDB, Cache API, Tauri store, native file, Keychain, or
-  operating-system session ownership changes update
-  `local-authority-registry.ts`.
-
-Run the focused registry tests and the affected platform typechecks. A new
-schema leaf, store method, or worker message must fail typecheck until
-classified. Current authority and planned authority remain separate. An
-unresolved codec, algebra, projection, retention limit, platform locator, or
-migration rule stays typed as blocked instead of receiving a plausible
-placeholder.
-
-Never infer activation from registry presence. The combined census must keep
-`activationAllowed: false` until every blocker is closed and the exact
-transition is recorded through the activation manifest and its required
-receipt.
-
-## Keep dormant SQLite honest
-
-The native and browser shadow stores share the versioned migrations under
-`packages/shared/src/library-core/shadow-schema-v*.sql`. Rust consumes those
-files with `include_str!`; the shared TypeScript contract must prove its
-generated DDL is byte-equivalent after whitespace normalization. Do not add a
-second handwritten native schema.
-
-Do not trust `PRAGMA user_version` by itself. Before accepting an authoritative
-database, compare its complete non-internal table, index, trigger, and view
-catalog against a fresh reference generated from the checked-in schema for
-that version. A missing or additional object fails closed before authority
-state is read or written. Integrity checking and catalog identity are separate
-contracts. Neither substitutes for the other.
-
-Bind every authoritative physical schema to one fixed SQLite `application_id`
-and verify it with `user_version` before accepting the live catalog. A blank
-file may have identity zero before first initialization. Any other preexisting
-identity, or any missing or changed identity on a versioned file, fails closed.
-The header marker proves database kind only. It does not prove page integrity.
-
-Enable defensive mode, disable trusted-schema behavior, and enable
-`cell_size_check` on every authoritative SQLite connection. This blocks
-dangerous database configuration changes, prevents schema text from invoking
-privileged application functions, and checks B-tree cell structure when each
-page is read. It adds bounded incremental corruption detection without a full
-startup walk. It does not validate unread pages, cross-page relationships,
-application invariants, or external blobs.
-
-Open an authoritative SQLite database with URI interpretation disabled and
-private-cache, extended-result-code, and `SQLITE_OPEN_NOFOLLOW` flags enabled.
-A configured path names one ordinary database file. It cannot smuggle SQLite
-URI parameters, join SQLite's discouraged process-global shared cache, or
-redirect the final component through a symbolic link. Resolve the existing
-parent directory before opening so a system-level path alias does not defeat
-the final-file check. Parent-directory and root identity remain a separate
-production-opener contract before activation.
-
-Lower SQLite's per-connection run-time limits to the registered Library Core
-contract before compiling schema or query SQL. Bound strings and rows above
-the 4 MiB canonical payload ceiling, and cap SQL length, columns, expression
-depth, compound terms, function arguments, attached databases, pattern bytes,
-variable indexes, trigger depth, and auxiliary worker threads. These limits
-contain parser and row allocations for malformed files or accidental future
-queries. They do not replace payload validation, bounded result paging,
-database-size policy, or an authenticated production file locator.
-
-On macOS, pair `synchronous=FULL` with SQLite `fullfsync=ON` for the
-authoritative journal. This makes SQLite request `F_FULLFSYNC` for commit and
-checkpoint synchronization instead of relying on ordinary `fsync`, which may
-leave data in a drive's volatile cache. The later activation gate must measure
-the resulting commit latency on supported storage. Do not weaken this receipt
-durability promise to hide a slow device.
-
-Disable SQLite's legacy double-quoted string-literal fallback for both schema
-and data statements. Checked-in SQL must use double quotes only for identifiers
-and single quotes for string literals. A misspelled identifier must fail instead
-of silently changing query meaning.
-
-Before opening an existing authoritative file for writing, inspect its database
-identity, physical version, and exact live catalog through a no-follow,
-private-cache, read-only connection. A foreign, future, unversioned, or changed
-file must be rejected without changing its database bytes or first receiving a
-writable database handle. SQLite may still create ephemeral coordination
-sidecars while reading a WAL-mode database. This preflight reduces accidental
-mutation. Recheck the same identity and catalog on the exact read-write handle
-before applying WAL or durability configuration, so a path replacement between
-the two opens also fails without database mutation. This does not replace the
-later authenticated storage-root handle and root-identity contract.
-
-Apply projection upserts, deletions, and the monotone projection revision in
-one database transaction. A bounded page or count binds one revision. A later
-page using a cursor from an older revision fails closed instead of walking
-across mixed projections. Prove the query plan uses the declared keyset index
-without a temporary sort. Enforce the registered query limit at the adapter
-boundary. Pin a physical schema version and set bounded busy handling, cache,
-temporary storage, and mmap behavior explicitly even while the store is dark.
-
-Bind every derived projection batch to one stable batch ID, canonical input
-digest, and expected previous projection revision. Commit its rows, deletions,
-revision advance, and durable receipt together. Bound each batch to at most
-1,000 combined row upserts and deletion intents. Admit one 4 MiB canonical
-source document plus no more than 64 KiB of bounded projection metadata so an
-accepted source row always fits without weakening the source ceiling.
-Exact retry after response loss returns the original receipt without
-reapplying. Changed replay tuples, oversized batches, and incompatible
-migration objects fail closed, and a receipt write failure rolls back the whole
-batch. Keep this derived receipt explicitly separate from signed authoritative
-operation receipts. It grants no mutation or activation authority.
-
-A short-lived Automerge worker may populate and verify the derived shadow store
-while Automerge remains authoritative. Bind that probe to one exact durable
-frontier and storage revision, bound its retained index and every response, and
-release the decoded document between requests. This is a compatibility bridge,
-not the Gate C migration decoder. Any path that calls `Automerge.load`, retains
-the complete change graph, or allocates source-sized memory cannot produce an
-authoritative migration candidate, satisfy the external-memory migration
-contract, or authorize cutover.
-
-Build a derived shadow generation in a fresh staging database. Bind the durable
-rebuild record to the exact source identity and declared row count. Commit each
-sequential batch's rows, derived receipt, batch mapping, revision, cumulative
-row count, and completion state in one transaction. Exact retry returns the
-stored result. Partial generations are never readable. Close a rebuild only
-when declared, projected, and actual row counts agree. Completion inside the
-database is not file publication. A native adapter must close, verify, and
-atomically publish the complete staging file before assigning it to a reader.
-This remains derived shadow work and does not satisfy Gate C.
-
-A browser shadow materializer may scan the already resident immutable
-Automerge document only while the legacy worker remains authoritative. Derive
-its source identity from the exact committed heads and storage revision, never
-from renderer-supplied metadata. Count and project with bounded iteration.
-Stage no more than one registered page at a time and let the row store's
-compound key provide query order instead of allocating a corpus-sized sort
-array. Each page needs an exact replay receipt and generation-plus-entity
-uniqueness. A complete selected browser generation remains derived cache state,
-does not prove the external-memory Gate C migration, and cannot receive a
-product caller before the Gate D reader and renderer-eviction contract lands.
-
-Publish a derived generation as a new immutable file. Checkpoint and remove
-WAL mode, verify SQLite and the exact completed rebuild, close and sync the
-staging bytes, perform one same-directory durable no-replace publication, then
-verify the destination read-only. The publication primitive itself must reject
-a racing destination. Exact readback is the response-loss path. Never overwrite
-a prior generation or treat publication as reader assignment.
-Production assignment still requires the trusted storage-root handle, a
-generation transition, rollback state, and bounded cleanup.
-
-A dormant engine has no production caller, opens no user database, emits no
-authority receipt, and does not append an activation-manifest transition. It
-may compile into Freed Desktop behind an explicit dark-module boundary. A
-command registration, startup open, backfill, read route, or writer route is an
-activation change and follows the corresponding gate.
-
-When a closed field operation reaches the dark projection, update only its
-registered columns. Do not rebuild or overwrite the full row. Validate current
-projected state, apply the shared field algebra, advance the projection
-revision, and commit the derived receipt in one transaction. Missing entities,
-malformed current values, stale revisions, and receipt failures roll back
-without repair. This derived path does not satisfy the authoritative operation
-materializer blocker.
-
-## Keep canonical operation bytes honest
-
-Use the shared cross-runtime vectors for every canonical construction change.
-Library Core v1 accepts only null, booleans, Unicode scalar strings, dense
-arrays, plain closed records, and safe integers. Reject negative zero,
-fractions, unsafe or nonfinite numbers, sparse or decorated arrays, accessors,
-symbol keys, non-enumerable fields, non-plain objects, invalid Unicode, cycles,
-more than 128 nesting levels, and a direct domain input above 4 MiB including
-its prefix. Reject more than 65,536 nodes even when their canonical bytes fit.
-
-Sort object names by UTF-16 code units and do not normalize Unicode. Domain
-prefixes include their terminal zero byte. A generic string label is not a
-registered digest domain. Desktop and PWA must match the same exact bytes and
-digest vectors before either path may construct authoritative operations.
-Before constructing or verifying an epoch transition, require the shared and
-native canonical codecs to register identical `epoch-transition-certificate`
-digest and signature prefixes plus the `authority-key-possession` signature
-prefix. Registering these domains grants no authority and does not validate a
-transition body, certificate chain, recovery delegation, or cloud compare-and-swap.
-
-The construction encoder is not an inbound verifier. Never verify received
-bytes by calling `JSON.parse` or a duplicate-erasing native JSON parser because
-duplicate object names have already been erased. Use the shared bounded
-duplicate-preserving parser and byte-for-byte canonical comparison first. That
-parser establishes only canonical Library Core value bytes. The authoritative
-inbound path still needs closed-schema validation, exact digest derivation, and
-strict signature verification before materialization.
-
-Reuse the shared protocol scalar predicates for fixed lowercase hexadecimal
-values, operation-instance IDs, bounded Unicode-scalar entity IDs, and
-nonnegative safe integers. Do not create artifact-specific regex copies or
-allocate encoded copies merely to count a bounded entity ID. Scalar syntax does
-not prove randomness, cryptographic derivation, authority, or semantic
-ownership.
-
-Closing one operation payload or entity-ID schema does not close the operation.
-Keep entity existence, touched fields, field algebra, materialization, provider
-intent, and runtime authority independently blocked until each has an
-executable contract. Every operation without an exact entity-key binding keeps
-the typed `entity_id_schema_unresolved` blocker. Bind touched fields by their
-exact field-registry keys and keep `touched_fields_unresolved` until the full
-set is closed. The initial `feed_item_read_assignment` payload is local
-read-state syntax only. Its `readAt` algebra treats absence as unread and
-retains the earliest valid assignment under duplicate, reordered, or
-concurrent delivery. It never authorizes or schedules a provider-visible seen
-action.
-
-Close transaction-member construction one operation at a time. Snapshot a
-closed input, enforce the registered payload and entity codecs, bound the
-causal frontier before allocation, and derive payload and member digests only
-through registered domains. A member-body schema omits chain, transaction, and
-signature fields exactly where the protocol says to omit them. It does not
-claim transaction completeness, actor-chain validity, signature verification,
-materialization, journaling, or runtime authority.
-
-Aggregate a transaction only from closed member constructions. Bound count and
-canonical member bytes before returning it. Require one library, epoch, actor,
-transaction ID, contiguous member indexes, contiguous actor sequences, unique
-operation IDs, and exact previous-operation links. Derive the transaction
-digest before actor-chain digests and derive signing-body digests only after
-both are fixed. Unsigned construction grants no persistence or authority.
-
-Finalize operation envelopes only from a provenance-branded assembled
-transaction. Close public keys as 32-byte lowercase hexadecimal Ed25519 values
-and signatures as 64-byte lowercase hexadecimal Ed25519 values. Preflight the
-complete canonical envelope budget before invoking the signer, sign only the
-domain-separated signing-body digest input, and return no transaction unless
-every signature and envelope digest succeeds. Finalization remains construction
-only until strict inbound verification, actor enrollment, journaling,
-materialization, and replication land independently.
-
-Prove Ed25519 verification across browser and native runtimes with the same
-public vector before an envelope verifier can become authoritative. Snapshot
-the bounded message bytes before the first asynchronous platform call. Reuse an
-audited cryptographic implementation already present in the runtime when it
-supports strict Ed25519 verification. Do not add a second elliptic-curve stack,
-write custom cryptography, generate keys, or infer actor enrollment from a
-syntactically valid public key.
-
-Verify received operations as one complete transaction from canonical bytes,
-not independently decoded objects. Snapshot the accepted actor tip first.
-Reconstruct the closed member bodies and aggregate transaction, then require
-exact actor, epoch, predecessor, sequence, payload, transaction, and actor-chain
-derivations before checking every actor signature. Preserve the exact canonical
-journal text in the verified result. Causal-tip authority, retry identity,
-operation conflicts, and the actor-tip recheck still belong inside the later
-authoritative SQLite transaction.
-
-Construct enrollment identity without self-reference. Derive the public-key
-fingerprint first, then derive the actor ID from the exact library,
-installation incarnation, public key, and random actor nonce, then derive the
-closed enrollment-body digest. Reuse the same sorted bounded causal-tip
-contract for the observed frontier. Body construction is not proof of key
-possession, an authority certificate, committed enrollment, or writer
-authority.
-
-Construct an enrollment certificate only from the provenance-branded body.
-Sign the exact enrollment-body digest through the actor-proof domain, close and
-digest the certificate body, sign that digest through the enrollment-authority
-domain, and derive actor-chain genesis from the certificate digest, actor ID,
-and epoch ID. Reject malformed signer or digest output and return no partial
-certificate. Construction alone does not verify either signature, establish
-current authority state, commit enrollment, persist a key, or grant writer
-authority.
-
-Verify enrollment from canonical received bytes, never a duplicate-erased
-object. Recompute the authority key ID from the accepted authority public key,
-then recompute the actor fingerprint, actor ID, body digest, certificate digest,
-and chain genesis. Require exact accepted library, epoch, epoch ID, authority
-key ID, schema, algorithm, and observed frontier. Verify actor possession before
-the active-authority signature. A verified certificate is still not committed
-enrollment: retry identity, operation and actor conflicts, sequence allocation,
-and authority-state mutation remain one later atomic transaction.
-
-Repeat complete operation verification inside the native authoritative
-boundary. Shared TypeScript verification is useful for early rejection and
-cross-runtime parity, but it is not authority for SQLite. Rust must parse the
-original canonical bytes, load the immutable enrolled actor identity and public
-key from the authoritative database, reconstruct every digest and claimed chain
-link, verify every signature, then create the sealed journal input privately.
-The atomic commit must distinguish an exact stored retry from a fresh current
-tip and reject every stale fork. Never expose a renderer command that accepts a
-preverified-looking object or a digest bundle assembled by JavaScript.
-Native enrollment may construct the same kind of sealed input only from an
-exact private authority snapshot. Do not expose a verify-and-enroll path until
-that authority epoch is itself stored authoritatively and rechecked inside the
-same enrollment transaction.
-Store immutable accepted authority epochs separately from the one active
-authority pointer. Enrollment and ordinary operation commits must recheck that
-pointer after beginning their SQLite write transaction. Verification completed
-before an epoch change never authorizes a write after the change.
-An exact retry of an enrollment that already committed is not a new authority
-write and must still return its existing actor state after a later epoch
-advance. New enrollment under an inactive epoch must fail closed. Encode the
-epoch relationship in SQLite foreign keys as well as native admission code.
-
-Keep the native authoritative commit input sealed inside the verifier and
-journal module. Renderer IPC must never gain authority by sending an object
-that merely resembles a verified transaction. Commit the immutable journal,
-causal-tip references, projection updates, actor-tip compare-and-swap, exact
-retry receipt, contiguous per-operation ingest sequence, materializer frontier,
-projection revision, and the applicable enrollment or operation replication
-outbox in one immediate `synchronous=FULL` SQLite transaction.
-Outbox rows reference the immutable canonical journal row by primary key. Do
-not copy canonical operation or enrollment bytes into a second hot table.
-Read pending outbox entries through bounded keyset pages with both row and byte
-ceilings. Order from indexed outbox or ingest keys and prove the query plan
-does not build a temporary sort. Return canonical payloads only by joining the
-single immutable journal or enrollment row. A dormant page reader grants no
-network, acknowledgment, deletion, or runtime replication authority.
-Scope actor-sequence uniqueness and compare-and-swap state to the exact
-library, epoch ID, and actor. Actor sequence restarts at one after an epoch
-transition even when actor identity remains stable.
-Fault injection must prove rollback from the latest write in that transaction.
-
-## Preserve the invariants
-
-1. Keep exactly one active writer epoch. Advance it only with a signed immutable
-   transition certificate and one compare-and-swap of the complete cloud
-   authority tuple. Local file presence or an incremented number is not
-   authority.
-2. Acknowledge a mutation only after the operation, rows, tombstones, cursor,
-   and outbox commit together.
-3. Reuse the same operation ID after timeout or response loss.
-4. Derive core-body, transaction, actor-chain, and signature digests in the
-   contract's non-circular phases. Desktop and PWA must produce identical
-   canonical bytes.
-5. Use causal context for later intent and the registered algebra for
-   concurrent intent. Do not use SQL order or wall time as the merge contract.
-6. Enroll device-local actor keys through the library authority and verify every
-   operation signature, sequence, previous-operation link, and chain digest.
-   Rotate actor identity only for a new installation incarnation, clone
-   recovery, or restore. Preserve it across ordinary app updates. Reject stale
-   epochs, retired actors, gaps, forks, unknown schemas, and changed migration
-   sources.
-7. Preserve forked suffixes as immutable quarantine evidence. Recovery emits
-   new signed repair operations with source references. Never rewrite or replay
-   the compromised envelopes.
-8. Buffer a remote transaction until count, contiguous member indexes,
-   signatures, individual digests, and aggregate digest all verify. Never
-   materialize or acknowledge a partial transaction.
-9. Read migration data from an immutable complete source, never UI state.
-10. Return bounded DTOs with one source revision. Never cross a full corpus into
-   React, Zustand, or a Web Worker that remains resident.
-11. Keep Automerge authoritative until both Desktop and PWA can use the
-   replacement replication epoch.
-12. Fence every retired epoch through epoch-bound operation and manifest
-    authentication. Treat old-client uploads and late writes as explicit orphan
-    recovery input, never active authority.
-13. Authenticate manifests and preserve branch-qualified actor tips. Never
-    sequence-max incompatible forks for sync, acknowledgment, or compaction.
-14. Roll back only from a receipt at the same frontier. Otherwise roll forward.
-15. Make external blobs durable before an authoritative database reference,
-    replicate and verify them before applying a referencing transaction, and
-    snapshot the database plus its pinned reachable blob set at one frontier.
-16. Keep provider traffic off during development. The first slice capable of
-    turning a memory-rejected provider attempt into real provider contact is
-    provider-observable. The owner approved the exact effect of existing
-    scheduled Facebook and Instagram pulls succeeding after memory relief in
-    `codex-task:019f4ce3-2ee3-76b2-bc0c-eb7f4958a7de`, with the statement "You
-    are fully authorized to continue this optimization in ways which will
-    increase provider pull frequency by fixing cases where we were previously
-    unable to pull." The provider can therefore observe successful contact where memory
-    rejection previously produced none. The lowest-profile alternative is to
-    preserve the memory rejection and leave that data unsynced. This decision
-    does not expire while the existing schedule, retry policy, requests,
-    navigation, cookies, headers, and extraction behavior remain unchanged.
-    Cite that exact decision and write and validate its healthy artifact before
-    publishing the first active slice. Do not ask the owner to approve the same
-    behavior again. Dormant storage work remains provider-free. Cadence,
-    request, navigation, cookie, header, or extractor changes require their own
-    decision.
-17. Keep cloud replication and provider-action outboxes separate. A remote
-    library operation never directly triggers provider activity.
-18. Advance materializer work by local ingest sequence, not HLC.
-19. Commit materialized state through the canonical persistent Merkle Patricia
-    trie. Update only touched leaves and ancestor paths in ordinary writes and
-    migration batches. Never rehash the complete corpus per transaction.
-20. Elect one capable migration authority for the exact immutable Automerge
-    source through the authenticated response-loss-safe candidate claim. Cloud
-    claims expire only by authenticated store time. Local claims never expire
-    and require explicit abandonment or winning cutover. Require the live exact
-    claim and an exact payload-bound one-use grant for candidate registration,
-    source contribution, fence reservation, fence activation, candidate-object
-    commit, and cutover. Candidate registration is the first claim-bound
-    authority mutation. While its registry entry is absent, no other operation
-    grant may issue or consume. Registration and candidate-absent abandonment
-    serialize over the same claim pointer and registry state. Cloud operations
-    consume the grant in the authority store. Local operations bind it inside
-    the same local control transaction. A cloud source grant binds a
-    runtime-owned process generation and monotonic anchor created before grant
-    acquisition. Commit requires the original nonserializable live attempt
-    handle and the current runtime-owned generation. Serialized equality cannot
-    revive an attempt after restart. A pause consumes the allowance but does
-    not invalidate an otherwise timely attempt. A pause that exhausts the
-    allowance, a restart, a missing live handle, a changed generation, or an
-    invalid clock sample requires a fresh operation ID and grant. Cutover grants
-    bind the closed transition-core payload, then the final certificate binds
-    that payload, grant, and consumption without a hash cycle. Other
-    installations prove adapter fixtures and bootstrap from the accepted
-    checkpoint and operation segments. Do not make every browser decode the
-    owner's private corpus. A second unreconciled permanent media vault blocks
-    cutover.
-21. Bound startup recovery by item count and elapsed time. Verify a referenced
-    blob before exposing that entity, quarantine only affected state, and
-    resume the remaining integrity scan from a durable background cursor.
-    Never block startup on a full blob-corpus walk.
-22. Keep every migration fence secret out of portable evidence. Persist only a
-    domain-separated token digest in authority records, proofs, receipts,
-    backups, and logs. The source owner generates and retains the private token
-    only in protected, crash-recoverable operation state. A coordinator never
-    publishes or retains it.
-23. Serialize source-fence acquire, release, and abandonment revocation through
-    one durable source-local authority domain. Prepare corpus-sized candidate
-    work, prepared proof, reservations, and genesis closure before fence
-    activation. Activate every fence only for the final bounded
-    compare-and-swap window. Library Core v1 permits at most 64 local sources,
-    65 fences including Automerge, a 2 MiB activation-evidence sidecar, 1,024
-    sidecar objects, 65 source mutations, and 60 seconds. The sidecar contains
-    only activation entries, authenticated-set nodes, the bounded final proof,
-    and dependency-acyclic wrappers. It excludes the genesis closure, receipt,
-    cutover payload, certificate, and manifest authentication object. Commit
-    sidecar, final proof, receipt, cutover authority records, certificate,
-    manifest authentication, and target tuple in one atomic authority bundle.
-    No full decode, cache census, filesystem walk, external sort, arbitrary
-    upload, closure mutation, or prepared-proof traversal runs while a source
-    fence is active. While active, acknowledge a new source write only after
-    its exact epoch-neutral replay intent is durable. Otherwise reject it before
-    acknowledgment.
-24. Decode Automerge through bounded external-memory runs. Never use
-    `Automerge.load`, keep a source-sized change graph resident, or grant a
-    large-host exception. A row consumer may stream only the exact
-    receipt-bound payload range for its current row through a fixed buffer into
-    an uncommitted target transaction. Rehash the complete spool after
-    consumption and commit only after that verification succeeds. A scratch
-    SQLite stage preserves counters as fixed-width sortable bytes, writes
-    payloads through incremental blobs, verifies its exact schema catalog, and
-    pins the bounded actor and head catalog from the verified layout. It commits
-    change or operation rows, dependencies or successors, payloads, and the
-    corresponding source receipt together. Exact retry returns that receipt
-    only while the layout and receipted row, relationship, and payload counts
-    remain complete. Every staged head must resolve to a staged change before
-    the change receipt is accepted. Change and operation receipts in one stage
-    must bind the same exact source identity. Missing rows, changed layout
-    entries, dangling graph references, unreceipted rows, mixed sources, or
-    changed input fail closed. Seal the complete stage only after actor
-    sequences are contiguous, per-actor operation counters exactly close every
-    change interval, and one bounded canonical digest covers every receipt,
-    metadata row, relationship, and incrementally read payload byte. Exact
-    seal replay recomputes that digest and rejects same-count semantic or
-    payload tampering. The scratch schema enforces actor, change dependency,
-    operation object and element-key references with foreign keys. Automerge
-    document chunks intentionally omit delete rows. A successor therefore
-    resolves either to one exact staged operation or to one reconstructed
-    omitted-delete identity whose object and effective property or list-element
-    target matches every predecessor. Reject explicitly encoded delete rows,
-    unequal targets for one omitted delete, non-Lamport successor edges, and
-    explicit successors attached to another target. Actor operation intervals
-    close over the union of stored operations and reconstructed delete IDs.
-    Derive the immutable current-operation set only after graph sealing.
-    Preserve every visible non-increment operation whose successors are all
-    explicit increments. Exclude increment rows themselves and operations
-    superseded by any explicit non-increment or omitted-delete successor.
-    Retain concurrent current operations without choosing a winner. Bind the
-    exact set and payload bytes to the graph digest in a replay-checked receipt
-    before object or entity materialization. The later resolved-value stage
-    preserves every concurrent value, marks exactly one Lamport-maximum winner
-    per effective map or list target, and applies explicit increment successors
-    only to their current counter bases. Compute winners in one disk-spilling
-    SQLite window pass instead of scanning all conflicts once per operation.
-    Page counter bases through a fixed bound, reject orphan, non-counter,
-    malformed, or overflowing increments, and bind the complete winner and
-    counter projection to the sealed graph and current-operation receipts.
-    The later sequence stage orders every list and text insertion through one
-    disk-backed iterative depth-first walk. Visit concurrent siblings in
-    descending Lamport order and descendants before the next sibling. Retain
-    deleted insertions as ordering anchors without restoring their resolved
-    values. Page objects, reject cross-object or non-sequence anchors, and bind
-    exact replay to the graph and resolved-value receipts. This does not
-    reconstruct objects or select registered product entities. The later
-    FeedItem topology stage selects one winning `feedItems` map, admits only
-    map-valued entities with bounded IDs, and reconstructs their winning map
-    and sequence nodes in temporary SQLite. Omit deleted entities and their
-    still-current descendants, densely renumber visible sequence values, cap
-    nesting at 128 levels, and reject shared nodes, malformed container
-    children, scalar parents with children, and replay drift. Bind the complete
-    entity topology to the graph, resolved-value, and sequence receipts. The
-    next document stage reconstructs binary-key-ordered maps, visible-order
-    lists, text, and JSON-compatible scalar values from that topology. Limit
-    each entity to 4 MiB, require its embedded `globalId` to equal the owning
-    map key, preserve nonfinite floats through the canonical `__nonFinite`
-    escape, reject unsafe integers, negative zero, bytes, unknown scalar
-    extensions, malformed text chunks, and any user property that collides
-    with the reserved nonfinite escape, and bind every exact JSON byte to a
-    replayable document receipt. Keep temporary node values in SQLite and hold
-    at most one bounded output plus one bounded child or scalar payload in
-    native memory. Do not populate a published generation until the later
-    schema-projection stage validates the complete FeedItem domain. That next
-    stage must consume one receipt-verified document at a time and produce the
-    exact shared shadow-row shape. Admit only faithful strings, booleans, and
-    JavaScript-safe integers into typed columns. Preserve missing paths in
-    `__absent`, unrepresentable values in `__raw`, unknown author and user-state
-    members in their reserved rest objects, and full content in its dedicated
-    JSON columns. Encode every projected JSON object in one recursive UTF-8
-    key order shared by Rust and TypeScript, and reject reserved nonfinite tags
-    or invalid Unicode instead of producing adapter-specific bytes. Reject
-    negative zero because JSON cannot preserve its sign. Bind the complete row
-    sequence and derived sort keys to the document receipt, then reproject and
-    compare every row on replay. Do not batch complete projected documents in
-    Rust memory or publish a generation before the row receipt closes. Populate
-    the derived generation from one transaction-pinned scratch snapshot. Bind
-    every bounded page to the complete row receipt, source operation indexes,
-    and exact projected bytes. Resume from the destination's durable row count
-    after response loss, and fail closed on source drift, oversized rows, or an
-    incomplete page. Population does not publish or select the generation.
-    Admission proves both the fixed memory ceiling and private staging capacity.
-25. Build PWA reader manifests from both registered Cache namespaces and the
-    durable logical lookup plan. Use one plan row and one probe per unique
-    physical locator with sorted candidate bindings. Call only exact
-    `cache.match` with every ignore option false and no network fallback.
-    Persist one authenticated hit, missing, or error outcome for every plan row.
-    Never enumerate the full Cache API key set. Resolve native reader files
-    beneath one pinned root handle with
-    no-follow semantics and reject links, reparse points, mount crossings, and
-    root replacement. A mapped target identity must equal independently
-    verified source identity.
-26. Capture backups from one immutable checkpoint and media-vault generation,
-    then release writers. Finalization may proceed across authenticated
-    ordinary same-transition descendants without changing captured backup,
-    bundle, delegation, or encrypted payload bytes. Keep one stable registration
-    ID. Use a fresh attempt operation ID whenever the predecessor tuple,
-    descendant proof, or signed certificate bytes change; exact retry means
-    byte-identical attempt bytes. A busy library must not starve backup merely
-    because new writes continue.
-27. Commit cleanup through persistent candidate-census, source-fence, and
-    terminal-disposition sets. Candidate size may delay physical deletion but
-    never blocks ordinary legacy writes. An unreachable authoritative source
-    blocks registered-candidate cleanup and a successor migration claim until
-    it reconnects or is retired through policy. A claim abandoned before
-    candidate registration uses the bounded candidate-absent cleanup branch:
-    null candidate fields, canonical empty disposition sets, no source
-    revocation, and no claim that unregistered temporary bytes were deleted. It
-    is never blocked on source reachability. Same-library recovery is the
-    cleanup-free authority escape hatch.
-    Same-library recovery may supersede an active or abandoned lifecycle with
-    its canonical proof before distributed cleanup. Later cleanup is garbage
-    collection, not authority. Represent it with the recovery-supersession
-    selector, signed disposition receipts, and the optional signed recovery-GC
-    aggregate. Never fabricate an abandonment digest for an active-claim
-    recovery.
-
-## Build in the safe order
-
-Use `freed-build-feature` for worktree and publication mechanics. Within the
-Library Core program, prefer this sequence:
-
-1. measurement and budgets;
-2. exhaustive field, operation, query, deletion, and locality registries;
-3. closed legacy-bootstrap and local-control schemas with pure validation and
-   state classification;
-4. a dormant atomic creator and adopter bootstrap transaction with readback,
-   conflict preservation, and response-loss recovery;
-5. dormant native or browser core;
-6. one elected immutable resumable migration, bounded device-local source
-   contributions, and full-field verification;
-7. bounded reads at one revision;
-8. exhaustive full-corpus consumer cutover, renderer eviction, and a
-   short-lived compatibility engine;
-9. dormant replacement replication on Desktop and PWA;
-10. one coordinated writer and protocol epoch cutover;
-11. installed soak and rollback window;
-12. Automerge retirement.
-
-Do not activate a later step because its code exists. Require the preceding
-receipt and exact source frontier.
-
-## Validate economically
-
-During implementation, run the smallest deterministic proof for the contract
-changed. At the publish checkpoint, run changed-path feature validation.
-
-Blocking Library Core proofs are:
-
-- closed legacy-bootstrap record, prepared-journal, receipt, and local-control
-  shapes; exact identity codecs; 1 through 65 sorted unique Automerge heads;
-  bounded complete namespace scans; canonical digest recomputation; exact
-  source generation, revision, binary, and frontier fencing; bootstrap-frontier
-  ancestry; creator versus TOFU read-only adopter classification; partial
-  transaction rejection; multiple-record conflict; and response-loss readback
-  without regeneration or renewed owner action;
-- transaction crash atomicity on every writable Desktop and PWA adapter;
-- duplicate operation and response-loss recovery;
-- actor enrollment and signature rejection, restore rotation, retirement, fork
-  detection, and deterministic repair convergence;
-- incomplete and corrupted transaction-member rejection without partial apply;
-- future-clock quarantine and certified repair convergence;
-- concurrent delete, update, and explicit restore;
-- elected migration claim races and response loss, interruption,
-  cloud expiry and local non-expiry, operation-grant consumption,
-  grant-bound live source attempts across process restart, source-revision
-  drift, registration versus candidate-absent abandonment, state-correct
-  absent cleanup, dead-claimant abandonment, recovery supersession, persistent
-  registered-candidate cleanup sets larger than one page, external-memory
-  decode, prepared migration and rollback proofs, valid rollback fences,
-  65-fence and 2 MiB finalization boundaries, atomic sidecar publication,
-  short fence activation, composite device-local source identity, pinned-root
-  native traversal, lookup-plan Cache probes without `Cache.keys()`,
-  reader-target identity equality, authoritative reader-content and permanent
-  media-vault closure, adapter fixture parity, and bounded checkpoint
-  bootstrap;
-- global epoch races, same-epoch manifest races, compound authority-state
-  compare-and-swap, remote genesis closure, prepared-transition recovery,
-  stale-writer fencing, and legacy-namespace isolation;
-- cutover, rollback, authority recovery, and concurrent-restore receipts;
-- same-revision page and count behavior;
-- two-device offline convergence through cloud manifest conflicts;
-- authenticated manifest generation, exact branch acknowledgment, and safe
-  compaction;
-- schema and database-plus-blob snapshot atomicity, including blob crash
-  boundaries;
-- bidirectional Desktop and PWA encrypted backup and restore vectors, including
-  a busy same-transition source that advances during backup construction;
-- import idempotency;
-- bounded query enforcement and full semantics beyond the legacy 2,500-item cap
-  on every supported adapter.
-
-Before the first production release of a new read engine, profile the cold
-first result on the owner's largest available corpus. Exercise startup, the
-default feed, each common filter transition, search, map, friends, saved, and
-one single-row mutation. A bounded page API must return its first bounded page
-without scanning or decoding the full corpus first. Audit always-mounted
-aggregates, subscriptions, and mutation refreshes for hidden O(n) work and
-record the bytes crossing the native-to-renderer boundary. While a row query is
-pending, the UI must render that query's loading state. It must never infer an
-empty result from stale or absent rows. Long stress matrices remain Tier 4, but
-this cold-path admission is part of the feature slice because it proves the
-architecture actually serves the product workload it was built for.
-
-For a read cutover, typecheck is also a consumer inventory: removing the
-full-corpus state field must expose every remaining reader. Preserve existing
-search semantics with parity fixtures or deliberately version the query after
-an explicit product decision. A native feed query alone is not a memory
-cutover while navigation, settings, search, content fetch, provider-action
-derivation, backup, export, or product/UI sync still scans the complete corpus.
-The registered short-lived legacy migration and replication bridges may
-continue through Gate D until Gate E replaces them; they do not excuse another
-full-corpus product reader.
-
-Use `freed-sync-replay` for fault injection and `freed-memory-profile` for
-memory admission. Route large fuzz matrices, private-corpus migration,
-100,000-item performance, browser permutations, and long slopes to dedicated
-or nightly evidence. Do not add them to every PR or release.
-
-## Close the slice
-
-Before publication:
-
-1. Confirm every changed export has a real caller.
-2. Confirm no unbounded DTO or whole-document transport was introduced.
-3. Record exact head, tree, schema, epoch, source frontier, focused tests,
-   runtime, rollback plan, and exact rollback trigger. If this slice executed
-   a transition, also record the same-frontier rollback or recovery receipt.
-   Dormant code and measurement do not invent a receipt for a transition that
-   never occurred.
-4. Classify provider-visible paths by behavior. A path-only change with no
-   observable provider effect uses the approved `diff_authorized` audit path.
-5. Dormant code and measurement may be merge-safe. Any Gate C through Gate H
-   dormant-to-active transition is owner-reviewed work. This includes claiming
-   or executing a migration candidate, source admission fencing, SQL read
-   cutover, legacy-worker or renderer-corpus eviction, an active writer,
-   replication protocol, storage epoch, rollback, restore, authority-key
-   rotation, recovery transition, installed-soak activation at Gate G, or
-   legacy-engine retirement. Stop at an
-   owner-reviewed PR and obtain separate release, install, and activation
-   authority. Task or merge authority alone never activates one of these
-   transitions.
-6. Do not append to
-   `docs/library-core-activation-manifest.json` for dormant implementation. The
-   exact product PR that deliberately makes the next release cross a Gate C
-   through Gate H boundary appends one closed transition entry with its stable
-   activation ID, rollback trigger, and receipt expectations. Never delete,
-   edit, reorder, or reuse an earlier entry. Release tooling derives the exact
-   activation delta from this history. It never trusts a handwritten
-   `no_activation_declared` assertion.
-7. A first `complete_history` release with no previous published boundary must
-   set `previousPresent: false`. When a previous boundary exists, a release may
-   set `previousPresent: false` only after an exact Git tree lookup at that
-   resolved commit proves the activation manifest path is absent. Missing
-   objects, invalid refs, wrong object kinds, permission errors, and read
-   failures block release validation. After any prior release artifact records
-   activation evidence, require `previousPresent: true` and exact digest
-   continuity.
+1. Confirm the current authority facts and blockers from code, registries,
+   receipts, and the activation manifest.
+2. Read the matching references and implement the smallest complete slice.
+   Keep unresolved authority typed as blocked.
+3. Prove the changed contract with the smallest deterministic focused test.
+   Use dormant fixtures and synthetic sources unless the applicable gate
+   explicitly authorizes more.
+4. Before publication, read the delivery reference and run changed-path feature
+   validation. Confirm every changed export has a real caller, no unbounded
+   transport was introduced, and rollback evidence matches the exact frontier.
+5. Use `freed-build-feature` for worktree and publication mechanics. Use
+   `freed-sync-replay` for fault injection and `freed-memory-profile` for
+   memory admission when those proofs apply.

--- a/.agents/skills/freed-library-core/agents/openai.yaml
+++ b/.agents/skills/freed-library-core/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Library Core"
   short_description: "Build and activate Freed Library Core safely"
   default_prompt: "Use $freed-library-core to build or migrate Freed Library Core through bounded queries, transactional operations, verified epochs, and deterministic replay."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-library-core/references/bootstrap-and-legacy-control.md
+++ b/.agents/skills/freed-library-core/references/bootstrap-and-legacy-control.md
@@ -1,0 +1,90 @@
+# Bootstrap and legacy control
+
+The dormant census does not create the one-time legacy epoch bootstrap. Close
+the bootstrap record, prepared journal, local control, receipt, identity, and
+recovery-state schemas first. A later slice may implement their durable
+initialization transaction. Never guess an initial epoch or infer authority
+from file presence or synchronized bytes.
+
+Keep the pure A1 contract package-internal until A2 provides its first
+production caller. A compiler-checked dormant module is useful. A public
+package export with no runtime consumer is dead API.
+
+Bootstrap uses one explicit local owner action to create one durable prepared
+operation journal for the creator installation. The synchronized object is an
+unsigned, content-addressed bootstrap record. It names the legacy epoch and
+source frontier, but it does not grant owner or write authority. Every current
+legacy writer can create synchronized Automerge values, so a self-signature or
+an in-document key would be theater.
+
+The record synchronizes under
+`libraryCoreLegacyBootstrapRecord:<record_digest>`. Never add a cloud sidecar,
+second provider object, request, or cadence for bootstrap. Readers complete
+one bounded scan of the entire current reserved root namespace and every
+conflict value, plus the complete historical set of reserved root keys in the
+accepted Automerge change graph. Absence requires both sets to be empty. An
+incomplete scan, deleted root, or tombstoned root blocks rebootstrap. Overflow
+fails before allocation. Exact duplicates collapse. Two unequal records block
+without winner selection.
+
+The live owner action is required only to atomically create the closed local
+prepared journal. That journal binds the exact installation, operation ID,
+storage generation, save revision, source binary digest, source heads,
+candidate record, candidate binary, candidate heads, and creator control. The
+candidate frontier must descend from the exact source frontier. The executable
+transaction loads the staged candidate bytes by their bound digest, proves
+their exact candidate heads and record occurrence, and only then attempts its
+compare-and-swap. The commit compare-and-swaps those source facts and writes
+the candidate document, control, receipt, retained prepared journal, and next
+revision in one local transaction. The receipt completes that exact journal.
+Exact retry reads the prepared or committed objects without asking again.
+Changed source bytes require explicit abandonment and a fresh owner action.
+
+Another installation treats a valid synchronized record as TOFU read-only.
+Its local control must say `adopter_tofu_read_only`, and that mode cannot
+write. Writable adoption requires a separate authenticated pairing with an
+existing authority holder or real user presence. Ordinary sync state, copied
+credentials, a self-signature, and an in-document key cannot satisfy pairing.
+
+Before adoption or creator readback, prove that the record's immutable source
+frontier is an ancestor of the current document. Do not require old head
+hashes to remain in the current head set. The local control tracks the current
+frontier, schema, storage generation, and local access mode separately from the
+immutable record. Every ordinary legacy save compare-and-swaps its local save
+revision and atomically updates the document plus the current control
+frontier. The prepared candidate and exact first commit name the bootstrap
+operation in local control. A later ordinary save or adopter TOFU pin names
+its own local operation instead of falsifying current provenance.
+Derive incremental persistence from the last committed heads with repeatable
+`saveSince` semantics. Never let `saveIncremental` advance its process-local
+cursor before the storage transaction commits. Storage failure and response
+loss must leave the exact same changes available for retry.
+The legacy IndexedDB bridge uses schema version 2. A load returns exact bytes,
+generation, and save revision. Every save and clear compares both version
+fields in the transaction that changes bytes. Clear advances generation and
+resets save revision to zero. Preserve version 1 bytes exactly at revision
+zero, close connections on `versionchange`, and fail closed when an upgrade is
+blocked. Full replacement requires the caller revision captured before its
+asynchronous work began. Publish candidate bytes, heads, and derived worker
+state only after storage commit. A failed decode retains the exact bytes and
+revision from that read. Never re-read storage to broaden a later clear.
+Recognized Automerge decode failures may enter explicit revision-fenced
+recovery. Allocation exhaustion and unknown failures preserve the bytes and
+fail closed.
+Do not activate bootstrap while a compatibility rebuild can replace an
+Automerge document through value-only export and import. Such a rebuild loses
+the recorded change graph. Fence it after any bootstrap record exists or replace
+it with an authenticated history-preserving transition first. Lost ancestry is
+corruption, never authority to bootstrap again.
+
+Protocol validators snapshot untrusted fields and arrays once into new
+immutable plain values. They bound head and occurrence arrays before
+allocation, never return-cast input objects, and never retain mutable aliases.
+Digest, ancestry, and state checks use only those snapshots.
+
+Retries after timeout or response loss reuse the exact operation ID and read
+back the durable result. They never generate a second identity or silently
+rebase an old owner action. Only wholly prepared or wholly committed creator
+tuples are recoverable. Document-only, control-only, receipt-only, incomplete
+scan, resource overflow, multiple records, and unsupported newer state block
+without repairing or deleting evidence.

--- a/.agents/skills/freed-library-core/references/canonical-operations-and-enrollment.md
+++ b/.agents/skills/freed-library-core/references/canonical-operations-and-enrollment.md
@@ -1,0 +1,156 @@
+# Canonical operations and enrollment
+
+## Keep canonical operation bytes honest
+
+Use the shared cross-runtime vectors for every canonical construction change.
+Library Core v1 accepts only null, booleans, Unicode scalar strings, dense
+arrays, plain closed records, and safe integers. Reject negative zero,
+fractions, unsafe or nonfinite numbers, sparse or decorated arrays, accessors,
+symbol keys, non-enumerable fields, non-plain objects, invalid Unicode, cycles,
+more than 128 nesting levels, and a direct domain input above 4 MiB including
+its prefix. Reject more than 65,536 nodes even when their canonical bytes fit.
+
+Sort object names by UTF-16 code units and do not normalize Unicode. Domain
+prefixes include their terminal zero byte. A generic string label is not a
+registered digest domain. Desktop and PWA must match the same exact bytes and
+digest vectors before either path may construct authoritative operations.
+Before constructing or verifying an epoch transition, require the shared and
+native canonical codecs to register identical `epoch-transition-certificate`
+digest and signature prefixes plus the `authority-key-possession` signature
+prefix. Registering these domains grants no authority and does not validate a
+transition body, certificate chain, recovery delegation, or cloud compare-and-swap.
+
+The construction encoder is not an inbound verifier. Never verify received
+bytes by calling `JSON.parse` or a duplicate-erasing native JSON parser because
+duplicate object names have already been erased. Use the shared bounded
+duplicate-preserving parser and byte-for-byte canonical comparison first. That
+parser establishes only canonical Library Core value bytes. The authoritative
+inbound path still needs closed-schema validation, exact digest derivation, and
+strict signature verification before materialization.
+
+Reuse the shared protocol scalar predicates for fixed lowercase hexadecimal
+values, operation-instance IDs, bounded Unicode-scalar entity IDs, and
+nonnegative safe integers. Do not create artifact-specific regex copies or
+allocate encoded copies merely to count a bounded entity ID. Scalar syntax does
+not prove randomness, cryptographic derivation, authority, or semantic
+ownership.
+
+Closing one operation payload or entity-ID schema does not close the operation.
+Keep entity existence, touched fields, field algebra, materialization, provider
+intent, and runtime authority independently blocked until each has an
+executable contract. Every operation without an exact entity-key binding keeps
+the typed `entity_id_schema_unresolved` blocker. Bind touched fields by their
+exact field-registry keys and keep `touched_fields_unresolved` until the full
+set is closed. The initial `feed_item_read_assignment` payload is local
+read-state syntax only. Its `readAt` algebra treats absence as unread and
+retains the earliest valid assignment under duplicate, reordered, or
+concurrent delivery. It never authorizes or schedules a provider-visible seen
+action.
+
+Close transaction-member construction one operation at a time. Snapshot a
+closed input, enforce the registered payload and entity codecs, bound the
+causal frontier before allocation, and derive payload and member digests only
+through registered domains. A member-body schema omits chain, transaction, and
+signature fields exactly where the protocol says to omit them. It does not
+claim transaction completeness, actor-chain validity, signature verification,
+materialization, journaling, or runtime authority.
+
+Aggregate a transaction only from closed member constructions. Bound count and
+canonical member bytes before returning it. Require one library, epoch, actor,
+transaction ID, contiguous member indexes, contiguous actor sequences, unique
+operation IDs, and exact previous-operation links. Derive the transaction
+digest before actor-chain digests and derive signing-body digests only after
+both are fixed. Unsigned construction grants no persistence or authority.
+
+Finalize operation envelopes only from a provenance-branded assembled
+transaction. Close public keys as 32-byte lowercase hexadecimal Ed25519 values
+and signatures as 64-byte lowercase hexadecimal Ed25519 values. Preflight the
+complete canonical envelope budget before invoking the signer, sign only the
+domain-separated signing-body digest input, and return no transaction unless
+every signature and envelope digest succeeds. Finalization remains construction
+only until strict inbound verification, actor enrollment, journaling,
+materialization, and replication land independently.
+
+Prove Ed25519 verification across browser and native runtimes with the same
+public vector before an envelope verifier can become authoritative. Snapshot
+the bounded message bytes before the first asynchronous platform call. Reuse an
+audited cryptographic implementation already present in the runtime when it
+supports strict Ed25519 verification. Do not add a second elliptic-curve stack,
+write custom cryptography, generate keys, or infer actor enrollment from a
+syntactically valid public key.
+
+Verify received operations as one complete transaction from canonical bytes,
+not independently decoded objects. Snapshot the accepted actor tip first.
+Reconstruct the closed member bodies and aggregate transaction, then require
+exact actor, epoch, predecessor, sequence, payload, transaction, and actor-chain
+derivations before checking every actor signature. Preserve the exact canonical
+journal text in the verified result. Causal-tip authority, retry identity,
+operation conflicts, and the actor-tip recheck still belong inside the later
+authoritative SQLite transaction.
+
+Construct enrollment identity without self-reference. Derive the public-key
+fingerprint first, then derive the actor ID from the exact library,
+installation incarnation, public key, and random actor nonce, then derive the
+closed enrollment-body digest. Reuse the same sorted bounded causal-tip
+contract for the observed frontier. Body construction is not proof of key
+possession, an authority certificate, committed enrollment, or writer
+authority.
+
+Construct an enrollment certificate only from the provenance-branded body.
+Sign the exact enrollment-body digest through the actor-proof domain, close and
+digest the certificate body, sign that digest through the enrollment-authority
+domain, and derive actor-chain genesis from the certificate digest, actor ID,
+and epoch ID. Reject malformed signer or digest output and return no partial
+certificate. Construction alone does not verify either signature, establish
+current authority state, commit enrollment, persist a key, or grant writer
+authority.
+
+Verify enrollment from canonical received bytes, never a duplicate-erased
+object. Recompute the authority key ID from the accepted authority public key,
+then recompute the actor fingerprint, actor ID, body digest, certificate digest,
+and chain genesis. Require exact accepted library, epoch, epoch ID, authority
+key ID, schema, algorithm, and observed frontier. Verify actor possession before
+the active-authority signature. A verified certificate is still not committed
+enrollment: retry identity, operation and actor conflicts, sequence allocation,
+and authority-state mutation remain one later atomic transaction.
+
+Repeat complete operation verification inside the native authoritative
+boundary. Shared TypeScript verification is useful for early rejection and
+cross-runtime parity, but it is not authority for SQLite. Rust must parse the
+original canonical bytes, load the immutable enrolled actor identity and public
+key from the authoritative database, reconstruct every digest and claimed chain
+link, verify every signature, then create the sealed journal input privately.
+The atomic commit must distinguish an exact stored retry from a fresh current
+tip and reject every stale fork. Never expose a renderer command that accepts a
+preverified-looking object or a digest bundle assembled by JavaScript.
+Native enrollment may construct the same kind of sealed input only from an
+exact private authority snapshot. Do not expose a verify-and-enroll path until
+that authority epoch is itself stored authoritatively and rechecked inside the
+same enrollment transaction.
+Store immutable accepted authority epochs separately from the one active
+authority pointer. Enrollment and ordinary operation commits must recheck that
+pointer after beginning their SQLite write transaction. Verification completed
+before an epoch change never authorizes a write after the change.
+An exact retry of an enrollment that already committed is not a new authority
+write and must still return its existing actor state after a later epoch
+advance. New enrollment under an inactive epoch must fail closed. Encode the
+epoch relationship in SQLite foreign keys as well as native admission code.
+
+Keep the native authoritative commit input sealed inside the verifier and
+journal module. Renderer IPC must never gain authority by sending an object
+that merely resembles a verified transaction. Commit the immutable journal,
+causal-tip references, projection updates, actor-tip compare-and-swap, exact
+retry receipt, contiguous per-operation ingest sequence, materializer frontier,
+projection revision, and the applicable enrollment or operation replication
+outbox in one immediate `synchronous=FULL` SQLite transaction.
+Outbox rows reference the immutable canonical journal row by primary key. Do
+not copy canonical operation or enrollment bytes into a second hot table.
+Read pending outbox entries through bounded keyset pages with both row and byte
+ceilings. Order from indexed outbox or ingest keys and prove the query plan
+does not build a temporary sort. Return canonical payloads only by joining the
+single immutable journal or enrollment row. A dormant page reader grants no
+network, acknowledgment, deletion, or runtime replication authority.
+Scope actor-sequence uniqueness and compare-and-swap state to the exact
+library, epoch ID, and actor. Actor sequence restarts at one after an epoch
+transition even when actor identity remains stable.
+Fault injection must prove rollback from the latest write in that transaction.

--- a/.agents/skills/freed-library-core/references/delivery-validation-and-closeout.md
+++ b/.agents/skills/freed-library-core/references/delivery-validation-and-closeout.md
@@ -1,0 +1,143 @@
+# Delivery, validation, and closeout
+
+## Build in the safe order
+
+Use `freed-build-feature` for worktree and publication mechanics. Within the
+Library Core program, prefer this sequence:
+
+1. measurement and budgets;
+2. exhaustive field, operation, query, deletion, and locality registries;
+3. closed legacy-bootstrap and local-control schemas with pure validation and
+   state classification;
+4. a dormant atomic creator and adopter bootstrap transaction with readback,
+   conflict preservation, and response-loss recovery;
+5. dormant native or browser core;
+6. one elected immutable resumable migration, bounded device-local source
+   contributions, and full-field verification;
+7. bounded reads at one revision;
+8. exhaustive full-corpus consumer cutover, renderer eviction, and a
+   short-lived compatibility engine;
+9. dormant replacement replication on Desktop and PWA;
+10. one coordinated writer and protocol epoch cutover;
+11. installed soak and rollback window;
+12. Automerge retirement.
+
+Do not activate a later step because its code exists. Require the preceding
+receipt and exact source frontier.
+
+## Validate economically
+
+During implementation, run the smallest deterministic proof for the contract
+changed. At the publish checkpoint, run changed-path feature validation.
+
+Blocking Library Core proofs are:
+
+- closed legacy-bootstrap record, prepared-journal, receipt, and local-control
+  shapes; exact identity codecs; 1 through 65 sorted unique Automerge heads;
+  bounded complete namespace scans; canonical digest recomputation; exact
+  source generation, revision, binary, and frontier fencing; bootstrap-frontier
+  ancestry; creator versus TOFU read-only adopter classification; partial
+  transaction rejection; multiple-record conflict; and response-loss readback
+  without regeneration or renewed owner action;
+- transaction crash atomicity on every writable Desktop and PWA adapter;
+- duplicate operation and response-loss recovery;
+- actor enrollment and signature rejection, restore rotation, retirement, fork
+  detection, and deterministic repair convergence;
+- incomplete and corrupted transaction-member rejection without partial apply;
+- future-clock quarantine and certified repair convergence;
+- concurrent delete, update, and explicit restore;
+- elected migration claim races and response loss, interruption,
+  cloud expiry and local non-expiry, operation-grant consumption,
+  grant-bound live source attempts across process restart, source-revision
+  drift, registration versus candidate-absent abandonment, state-correct
+  absent cleanup, dead-claimant abandonment, recovery supersession, persistent
+  registered-candidate cleanup sets larger than one page, external-memory
+  decode, prepared migration and rollback proofs, valid rollback fences,
+  65-fence and 2 MiB finalization boundaries, atomic sidecar publication,
+  short fence activation, composite device-local source identity, pinned-root
+  native traversal, lookup-plan Cache probes without `Cache.keys()`,
+  reader-target identity equality, authoritative reader-content and permanent
+  media-vault closure, adapter fixture parity, and bounded checkpoint
+  bootstrap;
+- global epoch races, same-epoch manifest races, compound authority-state
+  compare-and-swap, remote genesis closure, prepared-transition recovery,
+  stale-writer fencing, and legacy-namespace isolation;
+- cutover, rollback, authority recovery, and concurrent-restore receipts;
+- same-revision page and count behavior;
+- two-device offline convergence through cloud manifest conflicts;
+- authenticated manifest generation, exact branch acknowledgment, and safe
+  compaction;
+- schema and database-plus-blob snapshot atomicity, including blob crash
+  boundaries;
+- bidirectional Desktop and PWA encrypted backup and restore vectors, including
+  a busy same-transition source that advances during backup construction;
+- import idempotency;
+- bounded query enforcement and full semantics beyond the legacy 2,500-item cap
+  on every supported adapter.
+
+Before the first production release of a new read engine, profile the cold
+first result on the owner's largest available corpus. Exercise startup, the
+default feed, each common filter transition, search, map, friends, saved, and
+one single-row mutation. A bounded page API must return its first bounded page
+without scanning or decoding the full corpus first. Audit always-mounted
+aggregates, subscriptions, and mutation refreshes for hidden O(n) work and
+record the bytes crossing the native-to-renderer boundary. While a row query is
+pending, the UI must render that query's loading state. It must never infer an
+empty result from stale or absent rows. Long stress matrices remain Tier 4, but
+this cold-path admission is part of the feature slice because it proves the
+architecture actually serves the product workload it was built for.
+
+For a read cutover, typecheck is also a consumer inventory: removing the
+full-corpus state field must expose every remaining reader. Preserve existing
+search semantics with parity fixtures or deliberately version the query after
+an explicit product decision. A native feed query alone is not a memory
+cutover while navigation, settings, search, content fetch, provider-action
+derivation, backup, export, or product/UI sync still scans the complete corpus.
+The registered short-lived legacy migration and replication bridges may
+continue through Gate D until Gate E replaces them; they do not excuse another
+full-corpus product reader.
+
+Use `freed-sync-replay` for fault injection and `freed-memory-profile` for
+memory admission. Route large fuzz matrices, private-corpus migration,
+100,000-item performance, browser permutations, and long slopes to dedicated
+or nightly evidence. Do not add them to every PR or release.
+
+## Close the slice
+
+Before publication:
+
+1. Confirm every changed export has a real caller.
+2. Confirm no unbounded DTO or whole-document transport was introduced.
+3. Record exact head, tree, schema, epoch, source frontier, focused tests,
+   runtime, rollback plan, and exact rollback trigger. If this slice executed
+   a transition, also record the same-frontier rollback or recovery receipt.
+   Dormant code and measurement do not invent a receipt for a transition that
+   never occurred.
+4. Classify provider-visible paths by behavior. A path-only change with no
+   observable provider effect uses the approved `diff_authorized` audit path.
+5. Dormant code and measurement may be merge-safe. Any Gate C through Gate H
+   dormant-to-active transition is owner-reviewed work. This includes claiming
+   or executing a migration candidate, source admission fencing, SQL read
+   cutover, legacy-worker or renderer-corpus eviction, an active writer,
+   replication protocol, storage epoch, rollback, restore, authority-key
+   rotation, recovery transition, installed-soak activation at Gate G, or
+   legacy-engine retirement. Stop at an
+   owner-reviewed PR and obtain separate release, install, and activation
+   authority. Task or merge authority alone never activates one of these
+   transitions.
+6. Do not append to
+   `docs/library-core-activation-manifest.json` for dormant implementation. The
+   exact product PR that deliberately makes the next release cross a Gate C
+   through Gate H boundary appends one closed transition entry with its stable
+   activation ID, rollback trigger, and receipt expectations. Never delete,
+   edit, reorder, or reuse an earlier entry. Release tooling derives the exact
+   activation delta from this history. It never trusts a handwritten
+   `no_activation_declared` assertion.
+7. A first `complete_history` release with no previous published boundary must
+   set `previousPresent: false`. When a previous boundary exists, a release may
+   set `previousPresent: false` only after an exact Git tree lookup at that
+   resolved commit proves the activation manifest path is absent. Missing
+   objects, invalid refs, wrong object kinds, permission errors, and read
+   failures block release validation. After any prior release artifact records
+   activation evidence, require `previousPresent: true` and exact digest
+   continuity.

--- a/.agents/skills/freed-library-core/references/dormant-census-and-shadow-stores.md
+++ b/.agents/skills/freed-library-core/references/dormant-census-and-shadow-stores.md
@@ -1,0 +1,173 @@
+# Dormant census and shadow stores
+
+## Keep the dormant census honest
+
+The checked-in Gate A census is a compiler-enforced inventory, not activation
+authority:
+
+- synchronized schema work updates
+  `packages/shared/src/library-core/field-registry.ts`;
+- shared store contract work updates
+  `packages/shared/src/library-core/store-surface-registry.ts`;
+- Desktop and PWA worker message changes update the platform-owned
+  `library-core-worker-surface-registry.ts` beside each worker type union;
+- planned operation or query vocabulary changes update the corresponding
+  shared registry;
+- localStorage, IndexedDB, Cache API, Tauri store, native file, Keychain, or
+  operating-system session ownership changes update
+  `local-authority-registry.ts`.
+
+Run the focused registry tests and the affected platform typechecks. A new
+schema leaf, store method, or worker message must fail typecheck until
+classified. Current authority and planned authority remain separate. An
+unresolved codec, algebra, projection, retention limit, platform locator, or
+migration rule stays typed as blocked instead of receiving a plausible
+placeholder.
+
+Never infer activation from registry presence. The combined census must keep
+`activationAllowed: false` until every blocker is closed and the exact
+transition is recorded through the activation manifest and its required
+receipt.
+
+## Keep dormant SQLite honest
+
+The native and browser shadow stores share the versioned migrations under
+`packages/shared/src/library-core/shadow-schema-v*.sql`. Rust consumes those
+files with `include_str!`; the shared TypeScript contract must prove its
+generated DDL is byte-equivalent after whitespace normalization. Do not add a
+second handwritten native schema.
+
+Do not trust `PRAGMA user_version` by itself. Before accepting an authoritative
+database, compare its complete non-internal table, index, trigger, and view
+catalog against a fresh reference generated from the checked-in schema for
+that version. A missing or additional object fails closed before authority
+state is read or written. Integrity checking and catalog identity are separate
+contracts. Neither substitutes for the other.
+
+Bind every authoritative physical schema to one fixed SQLite `application_id`
+and verify it with `user_version` before accepting the live catalog. A blank
+file may have identity zero before first initialization. Any other preexisting
+identity, or any missing or changed identity on a versioned file, fails closed.
+The header marker proves database kind only. It does not prove page integrity.
+
+Enable defensive mode, disable trusted-schema behavior, and enable
+`cell_size_check` on every authoritative SQLite connection. This blocks
+dangerous database configuration changes, prevents schema text from invoking
+privileged application functions, and checks B-tree cell structure when each
+page is read. It adds bounded incremental corruption detection without a full
+startup walk. It does not validate unread pages, cross-page relationships,
+application invariants, or external blobs.
+
+Open an authoritative SQLite database with URI interpretation disabled and
+private-cache, extended-result-code, and `SQLITE_OPEN_NOFOLLOW` flags enabled.
+A configured path names one ordinary database file. It cannot smuggle SQLite
+URI parameters, join SQLite's discouraged process-global shared cache, or
+redirect the final component through a symbolic link. Resolve the existing
+parent directory before opening so a system-level path alias does not defeat
+the final-file check. Parent-directory and root identity remain a separate
+production-opener contract before activation.
+
+Lower SQLite's per-connection run-time limits to the registered Library Core
+contract before compiling schema or query SQL. Bound strings and rows above
+the 4 MiB canonical payload ceiling, and cap SQL length, columns, expression
+depth, compound terms, function arguments, attached databases, pattern bytes,
+variable indexes, trigger depth, and auxiliary worker threads. These limits
+contain parser and row allocations for malformed files or accidental future
+queries. They do not replace payload validation, bounded result paging,
+database-size policy, or an authenticated production file locator.
+
+On macOS, pair `synchronous=FULL` with SQLite `fullfsync=ON` for the
+authoritative journal. This makes SQLite request `F_FULLFSYNC` for commit and
+checkpoint synchronization instead of relying on ordinary `fsync`, which may
+leave data in a drive's volatile cache. The later activation gate must measure
+the resulting commit latency on supported storage. Do not weaken this receipt
+durability promise to hide a slow device.
+
+Disable SQLite's legacy double-quoted string-literal fallback for both schema
+and data statements. Checked-in SQL must use double quotes only for identifiers
+and single quotes for string literals. A misspelled identifier must fail instead
+of silently changing query meaning.
+
+Before opening an existing authoritative file for writing, inspect its database
+identity, physical version, and exact live catalog through a no-follow,
+private-cache, read-only connection. A foreign, future, unversioned, or changed
+file must be rejected without changing its database bytes or first receiving a
+writable database handle. SQLite may still create ephemeral coordination
+sidecars while reading a WAL-mode database. This preflight reduces accidental
+mutation. Recheck the same identity and catalog on the exact read-write handle
+before applying WAL or durability configuration, so a path replacement between
+the two opens also fails without database mutation. This does not replace the
+later authenticated storage-root handle and root-identity contract.
+
+Apply projection upserts, deletions, and the monotone projection revision in
+one database transaction. A bounded page or count binds one revision. A later
+page using a cursor from an older revision fails closed instead of walking
+across mixed projections. Prove the query plan uses the declared keyset index
+without a temporary sort. Enforce the registered query limit at the adapter
+boundary. Pin a physical schema version and set bounded busy handling, cache,
+temporary storage, and mmap behavior explicitly even while the store is dark.
+
+Bind every derived projection batch to one stable batch ID, canonical input
+digest, and expected previous projection revision. Commit its rows, deletions,
+revision advance, and durable receipt together. Bound each batch to at most
+1,000 combined row upserts and deletion intents. Admit one 4 MiB canonical
+source document plus no more than 64 KiB of bounded projection metadata so an
+accepted source row always fits without weakening the source ceiling.
+Exact retry after response loss returns the original receipt without
+reapplying. Changed replay tuples, oversized batches, and incompatible
+migration objects fail closed, and a receipt write failure rolls back the whole
+batch. Keep this derived receipt explicitly separate from signed authoritative
+operation receipts. It grants no mutation or activation authority.
+
+A short-lived Automerge worker may populate and verify the derived shadow store
+while Automerge remains authoritative. Bind that probe to one exact durable
+frontier and storage revision, bound its retained index and every response, and
+release the decoded document between requests. This is a compatibility bridge,
+not the Gate C migration decoder. Any path that calls `Automerge.load`, retains
+the complete change graph, or allocates source-sized memory cannot produce an
+authoritative migration candidate, satisfy the external-memory migration
+contract, or authorize cutover.
+
+Build a derived shadow generation in a fresh staging database. Bind the durable
+rebuild record to the exact source identity and declared row count. Commit each
+sequential batch's rows, derived receipt, batch mapping, revision, cumulative
+row count, and completion state in one transaction. Exact retry returns the
+stored result. Partial generations are never readable. Close a rebuild only
+when declared, projected, and actual row counts agree. Completion inside the
+database is not file publication. A native adapter must close, verify, and
+atomically publish the complete staging file before assigning it to a reader.
+This remains derived shadow work and does not satisfy Gate C.
+
+A browser shadow materializer may scan the already resident immutable
+Automerge document only while the legacy worker remains authoritative. Derive
+its source identity from the exact committed heads and storage revision, never
+from renderer-supplied metadata. Count and project with bounded iteration.
+Stage no more than one registered page at a time and let the row store's
+compound key provide query order instead of allocating a corpus-sized sort
+array. Each page needs an exact replay receipt and generation-plus-entity
+uniqueness. A complete selected browser generation remains derived cache state,
+does not prove the external-memory Gate C migration, and cannot receive a
+product caller before the Gate D reader and renderer-eviction contract lands.
+
+Publish a derived generation as a new immutable file. Checkpoint and remove
+WAL mode, verify SQLite and the exact completed rebuild, close and sync the
+staging bytes, perform one same-directory durable no-replace publication, then
+verify the destination read-only. The publication primitive itself must reject
+a racing destination. Exact readback is the response-loss path. Never overwrite
+a prior generation or treat publication as reader assignment.
+Production assignment still requires the trusted storage-root handle, a
+generation transition, rollback state, and bounded cleanup.
+
+A dormant engine has no production caller, opens no user database, emits no
+authority receipt, and does not append an activation-manifest transition. It
+may compile into Freed Desktop behind an explicit dark-module boundary. A
+command registration, startup open, backfill, read route, or writer route is an
+activation change and follows the corresponding gate.
+
+When a closed field operation reaches the dark projection, update only its
+registered columns. Do not rebuild or overwrite the full row. Validate current
+projected state, apply the shared field algebra, advance the projection
+revision, and commit the derived receipt in one transaction. Missing entities,
+malformed current values, stale revisions, and receipt failures roll back
+without repair. This derived path does not satisfy the authoritative operation
+materializer blocker.

--- a/.agents/skills/freed-library-core/references/migration-cutover-and-recovery.md
+++ b/.agents/skills/freed-library-core/references/migration-cutover-and-recovery.md
@@ -1,0 +1,174 @@
+# Migration, cutover, and recovery
+
+20. Elect one capable migration authority for the exact immutable Automerge
+    source through the authenticated response-loss-safe candidate claim. Cloud
+    claims expire only by authenticated store time. Local claims never expire
+    and require explicit abandonment or winning cutover. Require the live exact
+    claim and an exact payload-bound one-use grant for candidate registration,
+    source contribution, fence reservation, fence activation, candidate-object
+    commit, and cutover. Candidate registration is the first claim-bound
+    authority mutation. While its registry entry is absent, no other operation
+    grant may issue or consume. Registration and candidate-absent abandonment
+    serialize over the same claim pointer and registry state. Cloud operations
+    consume the grant in the authority store. Local operations bind it inside
+    the same local control transaction. A cloud source grant binds a
+    runtime-owned process generation and monotonic anchor created before grant
+    acquisition. Commit requires the original nonserializable live attempt
+    handle and the current runtime-owned generation. Serialized equality cannot
+    revive an attempt after restart. A pause consumes the allowance but does
+    not invalidate an otherwise timely attempt. A pause that exhausts the
+    allowance, a restart, a missing live handle, a changed generation, or an
+    invalid clock sample requires a fresh operation ID and grant. Cutover grants
+    bind the closed transition-core payload, then the final certificate binds
+    that payload, grant, and consumption without a hash cycle. Other
+    installations prove adapter fixtures and bootstrap from the accepted
+    checkpoint and operation segments. Do not make every browser decode the
+    owner's private corpus. A second unreconciled permanent media vault blocks
+    cutover.
+21. Bound startup recovery by item count and elapsed time. Verify a referenced
+    blob before exposing that entity, quarantine only affected state, and
+    resume the remaining integrity scan from a durable background cursor.
+    Never block startup on a full blob-corpus walk.
+22. Keep every migration fence secret out of portable evidence. Persist only a
+    domain-separated token digest in authority records, proofs, receipts,
+    backups, and logs. The source owner generates and retains the private token
+    only in protected, crash-recoverable operation state. A coordinator never
+    publishes or retains it.
+23. Serialize source-fence acquire, release, and abandonment revocation through
+    one durable source-local authority domain. Prepare corpus-sized candidate
+    work, prepared proof, reservations, and genesis closure before fence
+    activation. Activate every fence only for the final bounded
+    compare-and-swap window. Library Core v1 permits at most 64 local sources,
+    65 fences including Automerge, a 2 MiB activation-evidence sidecar, 1,024
+    sidecar objects, 65 source mutations, and 60 seconds. The sidecar contains
+    only activation entries, authenticated-set nodes, the bounded final proof,
+    and dependency-acyclic wrappers. It excludes the genesis closure, receipt,
+    cutover payload, certificate, and manifest authentication object. Commit
+    sidecar, final proof, receipt, cutover authority records, certificate,
+    manifest authentication, and target tuple in one atomic authority bundle.
+    No full decode, cache census, filesystem walk, external sort, arbitrary
+    upload, closure mutation, or prepared-proof traversal runs while a source
+    fence is active. While active, acknowledge a new source write only after
+    its exact epoch-neutral replay intent is durable. Otherwise reject it before
+    acknowledgment.
+24. Decode Automerge through bounded external-memory runs. Never use
+    `Automerge.load`, keep a source-sized change graph resident, or grant a
+    large-host exception. A row consumer may stream only the exact
+    receipt-bound payload range for its current row through a fixed buffer into
+    an uncommitted target transaction. Rehash the complete spool after
+    consumption and commit only after that verification succeeds. A scratch
+    SQLite stage preserves counters as fixed-width sortable bytes, writes
+    payloads through incremental blobs, verifies its exact schema catalog, and
+    pins the bounded actor and head catalog from the verified layout. It commits
+    change or operation rows, dependencies or successors, payloads, and the
+    corresponding source receipt together. Exact retry returns that receipt
+    only while the layout and receipted row, relationship, and payload counts
+    remain complete. Every staged head must resolve to a staged change before
+    the change receipt is accepted. Change and operation receipts in one stage
+    must bind the same exact source identity. Missing rows, changed layout
+    entries, dangling graph references, unreceipted rows, mixed sources, or
+    changed input fail closed. Seal the complete stage only after actor
+    sequences are contiguous, per-actor operation counters exactly close every
+    change interval, and one bounded canonical digest covers every receipt,
+    metadata row, relationship, and incrementally read payload byte. Exact
+    seal replay recomputes that digest and rejects same-count semantic or
+    payload tampering. The scratch schema enforces actor, change dependency,
+    operation object and element-key references with foreign keys. Automerge
+    document chunks intentionally omit delete rows. A successor therefore
+    resolves either to one exact staged operation or to one reconstructed
+    omitted-delete identity whose object and effective property or list-element
+    target matches every predecessor. Reject explicitly encoded delete rows,
+    unequal targets for one omitted delete, non-Lamport successor edges, and
+    explicit successors attached to another target. Actor operation intervals
+    close over the union of stored operations and reconstructed delete IDs.
+    Derive the immutable current-operation set only after graph sealing.
+    Preserve every visible non-increment operation whose successors are all
+    explicit increments. Exclude increment rows themselves and operations
+    superseded by any explicit non-increment or omitted-delete successor.
+    Retain concurrent current operations without choosing a winner. Bind the
+    exact set and payload bytes to the graph digest in a replay-checked receipt
+    before object or entity materialization. The later resolved-value stage
+    preserves every concurrent value, marks exactly one Lamport-maximum winner
+    per effective map or list target, and applies explicit increment successors
+    only to their current counter bases. Compute winners in one disk-spilling
+    SQLite window pass instead of scanning all conflicts once per operation.
+    Page counter bases through a fixed bound, reject orphan, non-counter,
+    malformed, or overflowing increments, and bind the complete winner and
+    counter projection to the sealed graph and current-operation receipts.
+    The later sequence stage orders every list and text insertion through one
+    disk-backed iterative depth-first walk. Visit concurrent siblings in
+    descending Lamport order and descendants before the next sibling. Retain
+    deleted insertions as ordering anchors without restoring their resolved
+    values. Page objects, reject cross-object or non-sequence anchors, and bind
+    exact replay to the graph and resolved-value receipts. This does not
+    reconstruct objects or select registered product entities. The later
+    FeedItem topology stage selects one winning `feedItems` map, admits only
+    map-valued entities with bounded IDs, and reconstructs their winning map
+    and sequence nodes in temporary SQLite. Omit deleted entities and their
+    still-current descendants, densely renumber visible sequence values, cap
+    nesting at 128 levels, and reject shared nodes, malformed container
+    children, scalar parents with children, and replay drift. Bind the complete
+    entity topology to the graph, resolved-value, and sequence receipts. The
+    next document stage reconstructs binary-key-ordered maps, visible-order
+    lists, text, and JSON-compatible scalar values from that topology. Limit
+    each entity to 4 MiB, require its embedded `globalId` to equal the owning
+    map key, preserve nonfinite floats through the canonical `__nonFinite`
+    escape, reject unsafe integers, negative zero, bytes, unknown scalar
+    extensions, malformed text chunks, and any user property that collides
+    with the reserved nonfinite escape, and bind every exact JSON byte to a
+    replayable document receipt. Keep temporary node values in SQLite and hold
+    at most one bounded output plus one bounded child or scalar payload in
+    native memory. Do not populate a published generation until the later
+    schema-projection stage validates the complete FeedItem domain. That next
+    stage must consume one receipt-verified document at a time and produce the
+    exact shared shadow-row shape. Admit only faithful strings, booleans, and
+    JavaScript-safe integers into typed columns. Preserve missing paths in
+    `__absent`, unrepresentable values in `__raw`, unknown author and user-state
+    members in their reserved rest objects, and full content in its dedicated
+    JSON columns. Encode every projected JSON object in one recursive UTF-8
+    key order shared by Rust and TypeScript, and reject reserved nonfinite tags
+    or invalid Unicode instead of producing adapter-specific bytes. Reject
+    negative zero because JSON cannot preserve its sign. Bind the complete row
+    sequence and derived sort keys to the document receipt, then reproject and
+    compare every row on replay. Do not batch complete projected documents in
+    Rust memory or publish a generation before the row receipt closes. Populate
+    the derived generation from one transaction-pinned scratch snapshot. Bind
+    every bounded page to the complete row receipt, source operation indexes,
+    and exact projected bytes. Resume from the destination's durable row count
+    after response loss, and fail closed on source drift, oversized rows, or an
+    incomplete page. Population does not publish or select the generation.
+    Admission proves both the fixed memory ceiling and private staging capacity.
+25. Build PWA reader manifests from both registered Cache namespaces and the
+    durable logical lookup plan. Use one plan row and one probe per unique
+    physical locator with sorted candidate bindings. Call only exact
+    `cache.match` with every ignore option false and no network fallback.
+    Persist one authenticated hit, missing, or error outcome for every plan row.
+    Never enumerate the full Cache API key set. Resolve native reader files
+    beneath one pinned root handle with
+    no-follow semantics and reject links, reparse points, mount crossings, and
+    root replacement. A mapped target identity must equal independently
+    verified source identity.
+26. Capture backups from one immutable checkpoint and media-vault generation,
+    then release writers. Finalization may proceed across authenticated
+    ordinary same-transition descendants without changing captured backup,
+    bundle, delegation, or encrypted payload bytes. Keep one stable registration
+    ID. Use a fresh attempt operation ID whenever the predecessor tuple,
+    descendant proof, or signed certificate bytes change; exact retry means
+    byte-identical attempt bytes. A busy library must not starve backup merely
+    because new writes continue.
+27. Commit cleanup through persistent candidate-census, source-fence, and
+    terminal-disposition sets. Candidate size may delay physical deletion but
+    never blocks ordinary legacy writes. An unreachable authoritative source
+    blocks registered-candidate cleanup and a successor migration claim until
+    it reconnects or is retired through policy. A claim abandoned before
+    candidate registration uses the bounded candidate-absent cleanup branch:
+    null candidate fields, canonical empty disposition sets, no source
+    revocation, and no claim that unregistered temporary bytes were deleted. It
+    is never blocked on source reachability. Same-library recovery is the
+    cleanup-free authority escape hatch.
+    Same-library recovery may supersede an active or abandoned lifecycle with
+    its canonical proof before distributed cleanup. Later cleanup is garbage
+    collection, not authority. Represent it with the recovery-supersession
+    selector, signed disposition receipts, and the optional signed recovery-GC
+    aggregate. Never fabricate an abandonment digest for an active-claim
+    recovery.

--- a/.agents/skills/freed-library-core/references/runtime-authority-invariants.md
+++ b/.agents/skills/freed-library-core/references/runtime-authority-invariants.md
@@ -1,0 +1,65 @@
+# Runtime authority invariants
+
+## Preserve the invariants
+
+1. Keep exactly one active writer epoch. Advance it only with a signed immutable
+   transition certificate and one compare-and-swap of the complete cloud
+   authority tuple. Local file presence or an incremented number is not
+   authority.
+2. Acknowledge a mutation only after the operation, rows, tombstones, cursor,
+   and outbox commit together.
+3. Reuse the same operation ID after timeout or response loss.
+4. Derive core-body, transaction, actor-chain, and signature digests in the
+   contract's non-circular phases. Desktop and PWA must produce identical
+   canonical bytes.
+5. Use causal context for later intent and the registered algebra for
+   concurrent intent. Do not use SQL order or wall time as the merge contract.
+6. Enroll device-local actor keys through the library authority and verify every
+   operation signature, sequence, previous-operation link, and chain digest.
+   Rotate actor identity only for a new installation incarnation, clone
+   recovery, or restore. Preserve it across ordinary app updates. Reject stale
+   epochs, retired actors, gaps, forks, unknown schemas, and changed migration
+   sources.
+7. Preserve forked suffixes as immutable quarantine evidence. Recovery emits
+   new signed repair operations with source references. Never rewrite or replay
+   the compromised envelopes.
+8. Buffer a remote transaction until count, contiguous member indexes,
+   signatures, individual digests, and aggregate digest all verify. Never
+   materialize or acknowledge a partial transaction.
+9. Read migration data from an immutable complete source, never UI state.
+10. Return bounded DTOs with one source revision. Never cross a full corpus into
+   React, Zustand, or a Web Worker that remains resident.
+11. Keep Automerge authoritative until both Desktop and PWA can use the
+   replacement replication epoch.
+12. Fence every retired epoch through epoch-bound operation and manifest
+    authentication. Treat old-client uploads and late writes as explicit orphan
+    recovery input, never active authority.
+13. Authenticate manifests and preserve branch-qualified actor tips. Never
+    sequence-max incompatible forks for sync, acknowledgment, or compaction.
+14. Roll back only from a receipt at the same frontier. Otherwise roll forward.
+15. Make external blobs durable before an authoritative database reference,
+    replicate and verify them before applying a referencing transaction, and
+    snapshot the database plus its pinned reachable blob set at one frontier.
+16. Keep provider traffic off during development. The first slice capable of
+    turning a memory-rejected provider attempt into real provider contact is
+    provider-observable. The owner approved the exact effect of existing
+    scheduled Facebook and Instagram pulls succeeding after memory relief in
+    `codex-task:019f4ce3-2ee3-76b2-bc0c-eb7f4958a7de`, with the statement "You
+    are fully authorized to continue this optimization in ways which will
+    increase provider pull frequency by fixing cases where we were previously
+    unable to pull." The provider can therefore observe successful contact where memory
+    rejection previously produced none. The lowest-profile alternative is to
+    preserve the memory rejection and leave that data unsynced. This decision
+    does not expire while the existing schedule, retry policy, requests,
+    navigation, cookies, headers, and extraction behavior remain unchanged.
+    Cite that exact decision and write and validate its healthy artifact before
+    publishing the first active slice. Do not ask the owner to approve the same
+    behavior again. Dormant storage work remains provider-free. Cadence,
+    request, navigation, cookie, header, or extractor changes require their own
+    decision.
+17. Keep cloud replication and provider-action outboxes separate. A remote
+    library operation never directly triggers provider activity.
+18. Advance materializer work by local ingest sequence, not HLC.
+19. Commit materialized state through the canonical persistent Merkle Patricia
+    trie. Update only touched leaves and ancestor paths in ordinary writes and
+    migration batches. Never rehash the complete corpus per transaction.

--- a/.agents/skills/freed-memory-profile/SKILL.md
+++ b/.agents/skills/freed-memory-profile/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-memory-profile
 description: Measure Freed memory demand with matched builds, workloads, document fixtures, and process generations. Use for idle growth, provider WebKit retention, Automerge worker churn, document transport amplification, bulk import, cloud merge, or suspected native and renderer memory regressions. Do not use a slope that crosses restarts, sleep, renderer replacement, or mixed activity states.
-disable-model-invocation: true
 ---
 
 # Memory Profile

--- a/.agents/skills/freed-memory-profile/agents/openai.yaml
+++ b/.agents/skills/freed-memory-profile/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Memory Profile"
   short_description: "Profile memory by comparable process generation"
   default_prompt: "Use $freed-memory-profile to measure this memory scenario across comparable process generations."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-provider-risk-review/SKILL.md
+++ b/.agents/skills/freed-provider-risk-review/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-provider-risk-review
 description: Prepare and verify the owner behavior gate for any Freed change that could alter behavior visible to X, Facebook, Instagram, LinkedIn, or another provider. Use before implementation that changes WebView loads, navigation, requests, retries, cadence, cookies, headers, scrolling, clicking, extraction scripts, media loading, login behavior, or provider timing. Also use to classify a provider-visible path change that has no provider-observable behavior change. Preparing a review never grants live provider traffic.
-disable-model-invocation: true
 ---
 
 # Provider Risk Review

--- a/.agents/skills/freed-provider-risk-review/agents/openai.yaml
+++ b/.agents/skills/freed-provider-risk-review/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Provider Risk Review"
   short_description: "Prepare scoped provider behavior approvals"
   default_prompt: "Use $freed-provider-risk-review to prepare a scoped approval packet for this provider-visible change."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-ship-build/SKILL.md
+++ b/.agents/skills/freed-ship-build/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-ship-build
 description: Ship and verify a versioned Freed Desktop build through GitHub Actions. Use when asked to cut a dev or production release, publish a reviewed build, or repair a failed release pipeline. Preserve source and installed build identity, require exact-head validation including native tests, and create a governed post-install verification task.
-disable-model-invocation: true
 ---
 
 # Ship Build

--- a/.agents/skills/freed-ship-build/agents/openai.yaml
+++ b/.agents/skills/freed-ship-build/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Ship Freed Build"
   short_description: "Ship and verify a versioned Desktop build"
   default_prompt: "Use $freed-ship-build to publish and verify this versioned Freed Desktop build."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-ship-www/SKILL.md
+++ b/.agents/skills/freed-ship-www/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-ship-www
 description: Publish verified Freed marketing changes from www, refresh the public changelog after a release, or apply an approved structured roadmap update. Use for production freed.wtf deployments. Require explicit deployment authority, exact commit and deployment identity, and source-attributed roadmap data. Never fast-forward www to dev.
-disable-model-invocation: true
 ---
 
 # Ship WWW

--- a/.agents/skills/freed-ship-www/agents/openai.yaml
+++ b/.agents/skills/freed-ship-www/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Ship Freed WWW"
   short_description: "Deploy verified marketing changes from www"
   default_prompt: "Use $freed-ship-www to deploy this verified Freed marketing change from www."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-soak/SKILL.md
+++ b/.agents/skills/freed-soak/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-soak
 description: Run and judge an installed-build soak of Freed Desktop from terminal evidence. Use for release observation, overnight stability windows, or post-change verification. Require the canonical release-verifier lease, the exclusive collector session lock, event-derived build identity, immutable time bounds, source-health checks, comparable process generations, and explicit inconclusive results when identity or coverage is insufficient.
-disable-model-invocation: true
 ---
 
 # Soak

--- a/.agents/skills/freed-soak/agents/openai.yaml
+++ b/.agents/skills/freed-soak/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Soak"
   short_description: "Judge an attributable installed-build window"
   default_prompt: "Use $freed-soak to run and judge an attributable soak for this installed Freed build."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-stability-controller/SKILL.md
+++ b/.agents/skills/freed-stability-controller/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-stability-controller
 description: Reconcile Freed stability observations, tasks, approvals, releases, soaks, and outcomes into one governed lifecycle. Use when coordinating the continuous background agents, deduplicating repeated findings, selecting the next stability action, advancing task state, or deciding that no fresh actionable work exists. This skill coordinates authority and handoffs but does not implement product code.
-disable-model-invocation: true
 ---
 
 # Stability Controller

--- a/.agents/skills/freed-stability-controller/agents/openai.yaml
+++ b/.agents/skills/freed-stability-controller/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Stability Controller"
   short_description: "Reconcile evidence into governed stability tasks"
   default_prompt: "Use $freed-stability-controller to reconcile current evidence into one governed stability task."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-sync-replay/SKILL.md
+++ b/.agents/skills/freed-sync-replay/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-sync-replay
 description: Reproduce Freed sync and provider-lifecycle failures with deterministic offline fixtures and fault injection. Use for Automerge worker, cloud merge, relay, scheduler, capture journal, timeout, retry, crash, wake, duplicate delivery, or corruption scenarios that should be tested without live provider traffic. Stop before any real provider navigation, request, cookie access, or cadence change.
-disable-model-invocation: true
 ---
 
 # Sync Replay

--- a/.agents/skills/freed-sync-replay/agents/openai.yaml
+++ b/.agents/skills/freed-sync-replay/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Sync Replay"
   short_description: "Replay sync failures without provider traffic"
   default_prompt: "Use $freed-sync-replay to reproduce this sync failure with offline fixtures and deterministic faults."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-triage/SKILL.md
+++ b/.agents/skills/freed-triage/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: freed-triage
 description: Reconcile fresh Freed stability evidence into governed, deduplicated GitHub debt issues. Use after runtime alarms, soak verdicts, canary results, or CI failures, and when deciding what to fix next. Require healthy evidence sources, temporal and build matching, issue identity, atomic evidence generations, explicit authority, and instrumentation-first handling of contradictory metrics.
-disable-model-invocation: true
 ---
 
 # Triage

--- a/.agents/skills/freed-triage/agents/openai.yaml
+++ b/.agents/skills/freed-triage/agents/openai.yaml
@@ -2,3 +2,6 @@ interface:
   display_name: "Freed Triage"
   short_description: "Turn fresh stability evidence into governed work"
   default_prompt: "Use $freed-triage to reconcile current stability evidence into governed Freed work."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-ui-polish/SKILL.md
+++ b/.agents/skills/freed-ui-polish/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: freed-ui-polish
+description: Manage an open batch of small visual UI corrections on one Freed product surface while the owner reviews screenshots or a live preview and sends iterative feedback. Use for queues of spacing, color, typography, control placement, responsive layout, or similar polish. Do not use for net-new features, broad redesigns, or an isolated change that does not need an iterative visual-review checkpoint.
+---
+
+# Freed UI Polish
+
+Keep related visual corrections in the same feature worktree and, once published, the same pull request until the owner closes the batch.
+The reviewer inspects rendered results. Only the owner moves a commit or publication checkpoint.
+
+## Prepare the surface
+
+Read [visual-contracts.md](references/visual-contracts.md) before changing UI. Apply those contracts to every package touched by the batch.
+
+## Run the review loop
+
+1. Make one narrow correction, then use the cheapest proof that answers the visual question: the live preview, a screenshot comparison, built-in Browser inspection, or a temporary geometry check.
+2. Keep the task's existing preview and built-in Browser tab current. Do not relaunch on the same port or run broad cleanup merely to refresh it.
+3. Hand the current rendered result to the reviewer after each correction. Agent-only inspection does not satisfy the review checkpoint.
+4. Treat continued screenshots, Browser comments, or adjustment requests as an open batch. Do not create or amend a commit while it remains open unless the owner explicitly requests that commit.
+5. Delay `npm run validate:feature` and Desktop e2e until the batch closes. Run tests earlier only when the owner requests that checkpoint or the live preview cannot answer a material risk. Focused checks needed to keep the preview runnable are allowed.
+6. Treat the owner's statement that the batch is ready as the normal commit boundary.
+
+## Close the batch
+
+1. Add permanent e2e coverage for a visual change only when it protects a shared layout contract, a demonstrated regression, or behavior that cannot be checked reliably in the active task. Delete temporary tests for exact pixels, gaps, colors, shadows, padding, or one-off toolbar geometry before publishing.
+2. Cover both inline and overflow states when a toolbar contract changes. Assert menu-section width when a collapsed form control is involved. Cover viewport bounds when a menu can outgrow the visible area.
+3. Run focused e2e after the queue settles when the durable risk warrants it. Run `npm run validate:feature` at the publish checkpoint.
+4. Update the draft pull request once after the batch is ready unless the owner requested an interim publication.
+5. Preserve the preview for review. At closeout, stop only this worktree's preview; use targeted worktree cleanup if cleanup is necessary.

--- a/.agents/skills/freed-ui-polish/agents/openai.yaml
+++ b/.agents/skills/freed-ui-polish/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Freed UI Polish"
+  short_description: "Batch small UI fixes through visual review"
+  default_prompt: "Use $freed-ui-polish to apply this batch of small Freed UI corrections and keep the preview ready for review."
+
+policy:
+  allow_implicit_invocation: true

--- a/.agents/skills/freed-ui-polish/references/visual-contracts.md
+++ b/.agents/skills/freed-ui-polish/references/visual-contracts.md
@@ -1,0 +1,8 @@
+# Visual Contracts
+
+- Inspect the nearest mature product surface and shared theme primitives before changing UI. Match the established tokens, radius, density, typography, borders, shadows, states, responsive behavior, and every active theme.
+- Search the package for an existing component, hook, or style before creating one. Extract a shared primitive when multiple surfaces need the same behavior.
+- Use the established primary and secondary control hierarchy. Do not add glossy or gradient utility controls, or hover effects that lift, bounce, or move a button vertically.
+- Map every new right-edge toolbar control into an existing overflow section or a new named section. Keep it reachable at every supported width. Collapsed form controls and tooltip or trigger wrappers must fill the menu content width.
+- Add focused e2e coverage for both inline and overflow states when a shared toolbar contract changes. Assert menu-section width for collapsed form controls.
+- Keep floating menus inside the viewport and internally scrollable. Use `theme-menu-shell` with its top or max-height variable instead of raw `overflow-hidden`. Add focused coverage when content can exceed the viewport.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,8 @@
 # Critical control plane and release surfaces require explicit owner review.
 /.github/ @AubreyF
 /AGENTS.md @AubreyF
+**/AGENTS.md @AubreyF
+**/AGENTS.override.md @AubreyF
 /.agents/skills/ @AubreyF
 /package.json @AubreyF
 /package-lock.json @AubreyF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,17 +7,17 @@ The checkout supplied as a new task's working directory is a launcher, not proof
 Before asking for authorization, planning implementation, or changing files:
 
 1. Run the read-only `git fetch --all --prune` from the launcher checkout.
-2. Classify the destination lane from the request: `origin/dev` for product work, `origin/www` for public website work, or `origin/main` for production release preparation.
-3. Read the current `AGENTS.md` directly from that fetched remote ref with `git show <remote-ref>:AGENTS.md`. The already-loaded local copy may be stale. Follow the fetched instructions for the rest of the task.
-4. If the fetch or fetched instruction read fails, stop and report the exact blocker. Do not proceed under a possibly stale local policy.
+2. Classify the destination lane: `origin/dev` for product work, `origin/www` for the public website, or `origin/main` for production release preparation. If the lane or path scope is unclear, ask before creating a worktree.
+3. Read the current root instructions directly from that fetched ref with `git show <remote-ref>:AGENTS.md`. The loaded local copy may be stale. Follow the fetched instructions for the rest of the task.
+4. If fetch or the remote instruction read fails, stop and report the exact blocker.
 
-Level 1 remains read-only in the launcher checkout. For Level 2 or higher, create an isolated worktree from the explicit freshly fetched remote ref with the repository worktree helper before editing. A task may use its starting directory only when it is already a clean dedicated worktree at the required fetched ref.
+Level 1 stays read-only in the launcher checkout. For Level 2 or higher, use `./scripts/worktree-add.sh` to create an isolated worktree from the explicit fetched remote ref. The starting directory is usable only when it is already a clean dedicated worktree at that ref.
 
-Never overwrite or discard launcher-checkout changes to make it fresh. Preserve and report unexpected work. After a task merges into its lane, fast-forward a clean launcher checkout to the verified remote head so the next task begins with the newest bootstrap policy.
+Never discard launcher changes to make it fresh. Preserve and report unexpected work. After a task merges into its lane, fast-forward a clean launcher checkout to the verified remote head so the next task starts with the newest bootstrap policy.
 
 ## Authorization levels
 
-When authorization is required and the owner has not already set a level for the task, ask:
+When authorization is required and the owner has not set a level, ask exactly:
 
 > What authorization level should this task proceed at?
 >
@@ -31,431 +31,138 @@ When authorization is required and the owner has not already set a level for the
 >
 > Reply with a number.
 
-Do not request authorization for one isolated action. Do not append exclusions, caveats, safety boilerplate, or a restatement of normal task boundaries.
+Do not request authorization for one isolated action or append exclusions and safety boilerplate.
 
 1. **Inspect:** Read-only diagnosis, evidence capture, and planning.
 2. **Build:** Level 1 plus local edits, tests, previews, synthetic fixtures, and reversible local files.
 3. **Publish:** Level 2 plus commits, pushes, pull requests, CI repair, and non-production merges.
 4. **Ship dev:** Level 3 plus dev releases, installation, deployment, real local-data testing, and exercising existing provider behavior at its current cadence. No production release or provider-observable behavior change.
-5. **Change provider behavior:** Level 4 plus new or changed provider requests, navigation, refresh frequency, timing, retries, cookies, headers, scraping behavior, and live provider mutations necessary for the stated task.
+5. **Change provider behavior:** Level 4 plus new or changed provider requests, navigation, refresh frequency, timing, retries, cookies, headers, scraping behavior, and necessary live provider mutations.
 6. **Ship production:** Level 5 plus production releases, production deployments, installation, rollback, and post-release verification.
-7. **Full task authority:** Level 6 plus autonomous execution of every reasonably necessary task-scoped action until the task is complete or a hard external blocker makes further progress impossible.
+7. **Full task authority:** Level 6 plus every reasonably necessary task-scoped action until completion or a hard external blocker.
 
-Authorization applies to the stated task. Each level includes every lower level. The newest explicitly granted level controls. Once a level is active, do not ask again for actions included within it. Clarification questions about ambiguous task scope are not authorization challenges.
+Each level includes lower levels. The newest explicit level controls for the stated task. Do not ask again for included actions. Clarification about ambiguous scope is not an authorization challenge.
 
-Use these numbered levels in every owner-facing authorization request and status. Internal actor labels such as `observe-only`, `plan-only`, `pr-only`, and `merge-safe` are implementation bookkeeping. They never replace or rename the numbered owner authorization levels.
+Use these numbers in owner-facing authorization requests and status. Internal labels such as `observe-only`, `plan-only`, `pr-only`, and `merge-safe` never replace them.
 
-## Rules
+## Load only the applicable instructions
 
-- **After implementing ANY new features:** Update `docs/PHASE-*.md` immediately — do not wait to be asked. Check every phase whose success criteria or task table is affected and update checkboxes + status lines in the same commit as the feature work.
-- **Roadmap sync:** When `docs/PHASE-*.md` changes, update the roadmap data in `website/src/app/roadmap/RoadmapContent.tsx` to match (`✓ Complete` → `"complete"`, `🚧 In Progress` → `"current"`, else `"upcoming"`). The roadmap is public marketing surface: route the website edit through the `www` lane (`freed-build-www`), not through `dev`.
-- **Time estimates:** Machine time only ("one conversation", "~10 min"). Never quote human hours/days.
-- **IDs:** Display tail — `...${id.slice(-8)}`.
-- **Number formatting:** All user-facing numbers must use `Number.toLocaleString()` (or `Intl.NumberFormat`) — never raw `.toString()` or string interpolation. This ensures locale-appropriate grouping separators (e.g. commas in `en-US`) for counts, totals, and stats.
-- **Node toolchain:** Use the repo-pinned Node toolchain from `.nvmrc`. Shell scripts must resolve `node`, `npm`, and `npx` from the same install, never by mixing a global `npm`/`npx` with a different `node` on `PATH`.
-- **Debt deferral:** Keep the active delivery plan. Use the smallest check needed to classify an adjacent finding as blocking, deferrable, or speculative. Fix blockers. For deferrable debt, deduplicate open GitHub Issues, create or update one issue with `.github/ISSUE_TEMPLATE/debt.yml`, then resume the plan. Drop speculative findings until evidence exists. After deferral, do not audit adjacent code, implement the debt, expand tests, redesign, or start follow-up work in that delivery. Issues labeled `debt` are the sole backlog. Create a control task only after an issue is selected, and store it as `details.githubIssue: { number, url }`. Scheduled debt discovery follows the stability controller contract and never expands an active delivery. Do not use fixed follow-up quotas.
-- **Before creating any new component or hook:** `SemanticSearch` or `Grep` the package for existing code that does the same thing. Duplication is never acceptable — if two surfaces need the same UI or logic, extract a shared primitive and have both import it.
-- **Before shipping any feature:** Verify that every exported function/class you added or touched is actually _called_ from an appropriate entry point. Exported-but-never-called code is a bug. Grep for each new export name to confirm it appears in a consumer.
-- **Platform copy:** Never write "for Mac", "for Windows", or "for desktop" in user-facing strings. The correct product name is "Freed Desktop". Use that.
-- **Buttons and dialog controls:** Do not invent custom CTA styling when the repo already has an established button hierarchy. For dialogs, recovery surfaces, and other utility UI, use standard primary and secondary control treatment with the repo's usual sizing, radius, and typography. Never add hover lift, vertical motion, bounce, or "raise on hover" effects to buttons. Never introduce ad hoc glossy or gradient CTA buttons for utility UI.
-- **UI design vocabulary:** Before adding or changing UI, inspect the nearest mature product surface and shared theme primitives first. Match the established vocabulary for tokens, radius, density, typography, borders, shadows, states, and responsive behavior. Introduce new styling only when the existing vocabulary cannot express the required behavior, and keep it compatible with all active themes.
-- **Toolbar right-edge controls:** Any new control added to the right edge of a shared toolbar must also map into an existing overflow section or add a new named overflow section at the same time. The control must remain reachable at every supported desktop and mobile toolbar width. When controls collapse into a menu, form controls such as selects, radio groups, segmented controls, sliders, and toggles must fill the menu content width instead of keeping their inline toolbar width. If a control is wrapped by a tooltip or trigger element, that wrapper must also fill the menu content width. Add or update focused e2e coverage for both the inline state and the overflow state, including menu-section width assertions for collapsed form controls, before shipping.
-- **Menu scroll bounds:** Any floating menu, command palette, context menu, overflow menu, or dropdown must scroll internally and stay inside the viewport. Use the shared `theme-menu-shell` class with a top or max-height CSS variable instead of raw `overflow-hidden`. Add or update focused e2e coverage when a menu can grow beyond the visible viewport.
-- **Async-before-await is synchronous:** Code before the first `await` in an `async` function runs synchronously in the caller's microtask even if the caller doesn't await. Never put O(n) work (e.g. `Array.from(largeUint8Array)`, `A.save()`, serialization) before an `await` in a `subscribe()` callback or any other fire-and-forget async call on a hot path.
-- **Fingerprinting risk requires a stop sign:** Before implementing or enabling any feature that could increase provider fingerprinting or detection risk, stop and warn the user in plain language. This includes new authenticated WebView loads, background provider navigation, extra provider API calls, automatic reply or comment hydration, scripted scrolling or clicking, altered timing patterns, new cookies or headers, media preloads, canvas or WebGL behavior, device fingerprint masking, and anything that changes how often Freed contacts X, Facebook, Instagram, LinkedIn, or another third-party provider. The warning must name the provider, describe the new observable behavior, explain why it could make Freed easier to fingerprint, and offer the lowest-profile alternative. Gate 1 requires sufficient authorization before code. Level 5 or higher covers necessary provider-observable behavior within the stated task after the warning has been given. If the active level is lower, give the warning and ask what authorization level the task should proceed at. Permission without an authorization level is not provider approval. The canonical machine-readable provider-visible path list lives in `scripts/lib/provider-visible-paths.mjs`; add new provider surfaces there, not in per-script copies. Provider-visible branches may publish as draft after implementation and validation. Draft publication does not authorize live provider traffic. Before the human review path publishes, write the approved Gate 1 decision as a healthy `provider-risk-review` stability artifact and pass it with `--provider-risk-review-artifact`. The helper posts one GitHub review comment bound to that artifact, the provider-visible path set, and the provider-only binary diff. That comment is the audit record, not a second approval step: the Gate 1 artifact is the authority, and a provider-visible branch carrying one may publish directly with `--ready`. The artifact approves the described behavior, not one exact diff, so a later commit does not mechanically invalidate it and the helper will not block on a changed fingerprint. What the helper still enforces is classification: it detects every provider-visible path in the diff, including files renamed out of the provider tree, and posts an audit comment naming them on every publish. Enforcement of the approval itself rests on this rule and that audit record, so any change to provider request patterns, navigation, cookies, headers, timing, extractor scripts, or provider API calls beyond the approved behavior requires a new Gate 1 artifact before it is written. The optional signed `control-task` path remains available for unattended publication. It binds the same provider-only fingerprint to a governed task and approved provider authority. Any material behavior change returns to Gate 1.
+Root instructions are the always-loaded governance kernel. Skills contain task workflows. Scoped `AGENTS.md` files contain path-specific invariants.
 
-There is no reaction-based second gate. It was removed on owner instruction: on a single-maintainer repository it asked the same person to re-confirm a decision they had already made and recorded in the artifact, and it forced a draft-then-react-then-republish cycle for every provider-visible change.
+When a task starts at repository root, descendant instructions are not discovered later merely because you enter or edit that directory. Before changing a scoped path, read its linked instructions manually. Scoped files add to this file and do not weaken it.
 
-Be clear about what that removed. The reaction was the only thing binding an approval to a specific diff: a changed subdiff produced a new review comment, and the reaction had to be fresh on it. Nothing now checks the artifact against the diff, and that is deliberate. Binding to a diff SHA would require the code to exist before the artifact could be written, which contradicts Gate 1 approving behavior _before_ code. The owner chose behavior-only approval on 2026-07-24 and accepted that the remaining control is judgment rather than mechanism.
+The maintenance model and enforced budgets live in [docs/AGENT-INSTRUCTIONS.md](docs/AGENT-INSTRUCTIONS.md).
 
-Two machine checks do remain: the artifact must be healthy and record `behavior_approved` or `diff_authorized`, and its `payload.providers` must match the provider set of the current provider-visible diff. An approval scoped to Instagram cannot authorize a Facebook extractor change.
-
-Everything else rests on the rule itself. Changing provider request patterns, navigation, cookies, headers, timing, extractor scripts, or provider API calls beyond what the approved artifact describes requires a new Gate 1 approval, even though no check will stop you. This is a behavior rule, not a file rule: editing a provider-visible file without changing provider-observable behavior is fine, and changing provider-observable behavior from a file outside the list is not. When it is unclear which side a change falls on, ask before writing code. Use `./scripts/worktree-publish.sh --print-provider-subdiff` to see the provider surface a branch touches.
-
-- **Vercel deployments -- always use `--scope aubreyfs-projects`:** The only permitted Vercel team for this project is `aubreyfs-projects` (personal account). Never run `vercel deploy`, `vercel link`, or any Vercel CLI command without the `--scope aubreyfs-projects` flag. Never use the `deploy_to_vercel` MCP tool -- it accepts no arguments and silently deploys to whatever team the CLI defaults to. Never run `vercel` from the repo root.
-  - This monorepo uses local workspace packages. Raw subdirectory deploys like `vercel deploy website/` and `vercel deploy packages/pwa/` can upload an incomplete tree and fail at `npm install`.
-  - Always use the preview helper instead:
-    - Website: `./scripts/vercel-deploy-preview.sh website`
-    - PWA: `./scripts/vercel-deploy-preview.sh pwa`
-
-## Machine Preflight
+### Sequencing-critical router
 
-`node scripts/doctor.mjs` checks the machine before loop or worktree work: the pinned Node toolchain from `.nvmrc`, PATH `node` consistency, `gh` (presence, that it runs, and binary architecture on macOS), git credential helpers that point at missing binaries, `git`, `curl`, `python3`, `~/.freed/automation/`, and optional publisher trust readiness. The publisher check uses the fixed root-owned schema v2 config at `/Library/Application Support/Freed/trusted-publisher-host.json`. It validates exact config shape, ownership and modes, pinned file digests, designated broker signature, exact clean control commit, private state and public-key record, and non-secret Keychain item presence without reading the signing key. Use `--require-publisher` only when deliberately selecting that optional host profile. The trusted host repeats all use-time checks before signing a capability. `worktree-add.sh`, `worktree-publish.sh`, and the nightly runner run the doctor automatically in warn-only mode; loops and CI gates should run `node scripts/doctor.mjs --strict` and stop on failures. A surprising `node`/`npm` path or a broken `gh` is a machine issue to fix before debugging the repo.
-
-Before activating a saved Freed automation, run `npm run validate:host-automations`. It compares identity, prompt, schedule, authoritative callable model and supported reasoning effort, target, working directories, execution environment, root-owned launcher binding, pinned runtime digests, and a nonmutating live channel attestation without editing host files. An ACTIVE actor fails closed unless its trusted launcher proves the pinned launcher, Node child, verifier process chain, and one-use channel challenge before returning only the actor's short-lived canonical lease. The five general actors store no credential in Keychain. This does not change the separate optional publisher or release credentials. Missing actors remain PAUSED. Reconcile missing or drifted actors through the supported host automation controls, and never repair drift by editing `automation.toml` directly.
-
-When the owner explicitly approves one exact lifecycle operation in the current task, a private current-task owner confirmation file is the supported cooperative fallback for that operation. It may acquire only a short `freed-owner` lease bound to the named task and canonical operation intent. Store the file outside the repository. The file does not authenticate the owner, does not grant provider traffic, and does not replace the provider behavior gate or repository CODEOWNER requirements. Each different operation requires its own exact intent and confirmation record.
-
-## Versioning
-
-CalVer `YY.M.DDBUILD` — patch segment encodes the day and build number:
-
-- `patch = (day_of_month × 100) + build_number`
-- March 1, first build → `26.3.100`; fifth build → `26.3.104`
-- March 15, first build → `26.3.1500`
-
-Run `./scripts/release.sh` with no args from a fresh release-prep worktree based on `origin/main` to auto-compute the next production version. For a dev release, use `./scripts/release.sh --channel=dev` from a fresh release-prep worktree based on `origin/dev`.
-
-## Package Boundaries
-
-| Package      | Rule                                                                                                                                                                                         |
-| ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `shared/`    | Pure functions + types. Zero runtime deps. No React.                                                                                                                                         |
-| `ui/`        | Platform-agnostic React UI layer. May import `@freed/shared`. No platform stores, no Tauri APIs, no service-worker logic, no `@freed/sync` imports. Ships raw `.tsx` source — no build step. |
-| `sync/`      | Storage-agnostic. Works in browser (IndexedDB) and Node (filesystem).                                                                                                                        |
-| `pwa/`       | PWA app shell only. Imports `@freed/ui` and `@freed/shared`. Never import Tauri APIs.                                                                                                        |
-| `desktop/`   | Tauri shell. Imports `@freed/ui` and `@freed/shared`. Never import from `@freed/pwa`.                                                                                                        |
-| `capture-*/` | Isolated. Never import between capture packages.                                                                                                                                             |
-
-## URLs
-
-| Property            | URL                     |
-| ------------------- | ----------------------- |
-| Marketing site      | `https://freed.wtf`     |
-| PWA (mobile reader) | `https://app.freed.wtf` |
-| Download page       | `https://freed.wtf/get` |
+Task skills are discovered from their descriptions. These routes must happen before a risky action:
 
-**Never write `freed.wtf/app`** — the PWA lives at the subdomain `app.freed.wtf`.
-
-## Git Workflow
-
-**Never work directly on `main`.** Always create a git worktree for feature work:
-
-```bash
-./scripts/worktree-add.sh ../freed-<slug> -b <branch> origin/dev --target shared
-# work in ../freed-<slug>/
-# remove when done: git worktree remove ../freed-<slug>
-```
-
-`worktree-add.sh` is a drop-in replacement for `git worktree add`. It defaults to a full isolated install so the new worktree is ready immediately, and it still supports `--install auto` or `--install none` when you intentionally want to defer bootstrap. Never use bare `git worktree add` directly.
-Pass an explicit remote base like `origin/dev` or `origin/www` so feature work does not inherit a stale local branch by accident.
-For multi-thread or speculative worktree swarms, prefer `--swarm`. That maps to deferred bootstrap until the thread actually needs verification or a preview.
-Prefer the lightest useful local preview before opening a draft PR:
-
-- **Local-first iteration:** Build, run, and test feature work locally in its worktree. Do not push a branch, update a PR, or wait for GitHub Actions merely to obtain a test build or to see whether an ordinary implementation step works. GitHub CI validates a locally runnable final candidate. It is not the development loop.
-- Publish only when the complete intended slice is locally runnable and ready for exact-head gates. An intermediate push is justified only when the failure depends on a GitHub-hosted runner, signing, notarization, release infrastructure, or another environment that cannot be reproduced locally, or when the owner explicitly requests remote publication.
-- A local Desktop build does not require a version bump, tag, release, or GitHub workflow. Use the native worktree preview or build commands for manual testing, then publish once at the real integration boundary.
-- product work usually uses `PORT=$(node scripts/lib/find-free-port.mjs 1421) && ./scripts/worktree-preview.sh pwa --port "$PORT"`
-- website work uses `PORT=$(node scripts/lib/find-free-port.mjs 3000) && ./scripts/worktree-preview.sh website --port "$PORT"`
-- use `./scripts/worktree-preview.sh desktop --native` only when real Tauri behavior matters, and report the preview label when you do
-- for mocked Desktop preview, use `PORT=$(node scripts/lib/find-free-port.mjs 1422) && ./scripts/worktree-preview.sh desktop --port "$PORT"`
-- product previews launched through `./scripts/worktree-preview.sh` mark the app as a feature preview, auto-accept local legal gates, and populate sample data so the first screen is ready to inspect
-- never run `./scripts/dev-session-clean.sh` just to relaunch a preview. Launch on a fresh explicit port instead.
-- never run `npm run <script> --workspace=...` from the repo root in this monorepo, run from the workspace directory instead
-- **Local-first release iteration:** Do not publish a PR, tag, or GitHub release merely to test a Desktop build. Build and run the candidate locally against the relevant real fixture or local Library first. For native Desktop behavior, use `npm run tauri:build -- --bundles app` from `packages/desktop` with the pinned Node toolchain, then launch that local app bundle. Publish only after the local candidate works end to end. GitHub is the final path for exact-head CI, signing, notarization, updater metadata, and distributable artifacts. A signed installer is required for final installed-build proof, but it is not the ordinary implementation feedback loop.
-- root `npm run dev` now fails fast on purpose, use `./scripts/worktree-preview.sh <target>` or run `npm run dev` from the workspace directory you actually want
-- the root fanout scripts now fail fast if you try the dangerous workspace-dispatch pattern, treat that error as a routing mistake and re-run from the workspace
-- if a workspace command needs a hoisted binary, prefix `PATH` with the worktree root `node_modules/.bin`
-- expect the worktree helpers to print the resolved `node` and `npm` pair before they do real work, and treat a surprising path there as a machine issue to fix before debugging the repo
-- publish normal feature work with `./scripts/worktree-publish.sh` and the caller's existing GitHub authentication. A host may optionally configure the absolute signed broker path in `FREED_TRUSTED_PUBLISHER` for unattended publication. The broker lives outside the candidate worktree, validates its root-owned trust configuration and pinned tools, then invokes the same helper with a short-lived target-scoped lease. Missing broker provisioning does not block normal publication. Any partial broker handoff fails closed.
-- rerunning the publication helper should update the existing draft PR body and title, and push a ready PR back to draft when the local branch changes underneath it. At closeout, publish finished work with `--ready`. For provider-visible work, publish with a healthy `behavior_approved` Gate 1 artifact or a `diff_authorized` path-only artifact through `--provider-risk-review-artifact`. The generated provider review comment is the audit record. No reaction-based second gate exists. Draft means "still iterating, blocked, or needs discussion", not "authored by automation"
-- **Local preview surface:** Show every user-facing local preview in the task's built-in Browser. Start it with `./scripts/worktree-preview.sh`, then open the printed localhost URL with `@Browser` from the task that owns the preview. Keep that Browser tab attached to the task for review. Never open a visible local preview in Google Chrome or another external browser.
-- **External browser focus:** Keep Playwright and other browser tests headless by default. For browser work, do not launch headed Playwright, Playwright UI or debug mode, Chrome DevTools MCP, Playwright MCP, Computer Use, Google Chrome, or another external browser window unless the user explicitly asks for that external surface. A request to build, update, preview, test, inspect, or verify a UI does not grant this permission. If `@Browser` is unavailable, report that and provide the preview URL instead of silently falling back to an external browser.
-- When an explicitly approved external browser window is required, keep it in the background where the tool permits and close only that task's window at closeout.
-- after browser tooling work, do not run broad cleanup while the preview should remain open. If cleanup is needed, scope it with `./scripts/dev-session-clean.sh --worktree <worktree>`.
-- when a PR is merged, the worktree is removed, or the thread is archived, close only that thread's preview with `./scripts/worktree-processes.sh stop --worktree <worktree> --target <pwa|desktop|website>`.
-- the publication helper refuses stray untracked files unless you stage them yourself first or pass `--include-untracked`
-
-### Installed Desktop Soaks
-
-The canonical soak and trigger contract is [docs/SOAK-AND-TRIGGERS.md](docs/SOAK-AND-TRIGGERS.md). Installed soaks are terminal-driven through `open -g`, logs, `runtime-health.jsonl`, and the already authorized `node scripts/dev-sync-trigger.mjs <provider>` path. Background work does not stall overnight for a routine local click. Ask with a 10 minute response window, then continue only within authority already granted. A timeout never authorizes provider traffic, authentication, external posting, deployment, destructive state changes, or a new behavior. Ship a terminal trigger for anything recurring.
-
-### Queued UI Polish
-
-When a user queues several small UI fixes for the same product surface, keep the work in the active feature worktree and PR until the queue is done.
+- Provider-visible behavior or path classification: [freed-provider-risk-review](.agents/skills/freed-provider-risk-review/SKILL.md) before code.
+- Durable library authority, migration, storage, or Automerge: [freed-library-core](.agents/skills/freed-library-core/SKILL.md) before design or code.
+- Live rare or stateful failures: [freed-evidence-capture](.agents/skills/freed-evidence-capture/SKILL.md) before mutation.
+- Skill creation or changes: [.agents/skills/AGENTS.md](.agents/skills/AGENTS.md) before editing a skill.
 
-- For each small UI fix, implement the narrow change, then verify it in the active thread with the cheapest proof that actually answers the question: live preview, screenshot comparison, browser inspection, or a temporary geometry check.
-- When the user is reviewing UI through screenshots or a live browser, update the preview and explicitly hand the current rendered result back to the user before creating or amending a commit, running `npm run validate:feature`, or starting any broad test suite. A preview inspected only by the agent does not satisfy this checkpoint.
-- Treat the user's visual review as the commit boundary for an open UI batch. Do not commit the batch until the user says it is ready, unless the user explicitly asked for a commit earlier. Focused checks needed to keep the preview runnable are allowed before review.
-- Do not add permanent e2e coverage for exact pixels, gaps, colors, shadows, padding, or one-off toolbar geometry unless the behavior is a shared layout contract, has already regressed, or cannot be checked reliably in-thread.
-- Do not run `npm run validate:feature` after every small visual adjustment. Run it at the publish checkpoint, or earlier only when the user asks for a full validation checkpoint.
-- Do not run desktop e2e between queued UI updates in the same thread unless the user asks for that checkpoint or the change is too risky to inspect with the live preview. Prefer keeping the preview running, applying the next queued visual fix, and doing one focused e2e pass after the queue settles.
-- When the user is actively sending browser comments or screenshots, treat the queue as still open. Give a short status update, keep the preview current, and wait to spend machine time on heavier verification until the user signals that the batch is ready or asks for tests.
-- If browser automation is needed for a visual fix, use it for that fix and keep the local preview current. Do not run broad cleanup before closeout unless the user no longer needs the preview. Prefer targeted cleanup for this worktree.
-- Update the draft PR once after the queued batch is ready, unless the user asks for an interim publish.
-
-**Branch naming:** `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/` prefix followed by a short kebab-case description.
-
-**Commit messages** follow Conventional Commits:
-
-| Prefix      | When to use                                       |
-| ----------- | ------------------------------------------------- |
-| `feat:`     | New user-facing feature                           |
-| `fix:`      | Bug fix                                           |
-| `chore:`    | Tooling, deps, config — no production code change |
-| `docs:`     | Documentation only                                |
-| `refactor:` | Code restructure with no behavior change          |
-| `perf:`     | Performance improvement                           |
-| `style:`    | Formatting, whitespace, CSS-only                  |
+### Path router
 
-**Merge policy:** Squash merge only. One PR = one commit on `main`.
-
-```bash
-# From the primary worktree (not the feature worktree):
-gh pr merge <n> --squash --delete-branch
+- `docs/**`: [docs/AGENTS.md](docs/AGENTS.md)
+- `packages/shared/**`: [packages/shared/AGENTS.md](packages/shared/AGENTS.md)
+- `packages/ui/**`: [packages/ui/AGENTS.md](packages/ui/AGENTS.md)
+- `packages/pwa/**`: [packages/pwa/AGENTS.md](packages/pwa/AGENTS.md)
+- `packages/desktop/**`: [packages/desktop/AGENTS.md](packages/desktop/AGENTS.md)
+- `scripts/**`: [scripts/AGENTS.md](scripts/AGENTS.md)
 
-# Immediately after merging, tear down the feature worktree:
-git worktree remove --force ../freed-<slug>
-git branch -D <branch>   # must use -D, not -d (squash leaves commits unreachable)
-```
+## Always-on governance
 
-Or run the cleanup helper to sweep all merged worktrees at once:
-
-```bash
-./scripts/worktree-cleanup.sh        # interactive
-./scripts/worktree-cleanup.sh --yes  # non-interactive
-```
-
-Branches are deleted after merge. The squash commit message is derived from the PR title — write PR titles as if they are commit messages.
-
-### Worktree Routing
-
-Before creating a worktree, classify the requested work by destination branch.
+### Repository and tool safety
 
-- Product work targets `dev`: Desktop, PWA, shared packages, sync, capture packages, release tooling, app behavior, and product docs.
-- Public marketing work targets `www`: `website/`, marketing copy, public roadmap presentation, changelog presentation, and marketing docs.
-- Production release prep targets `main`.
-- Dev release prep targets `dev`.
-- Use `freed-build-feature` for product work targeting `dev`.
-- Use `freed-build-www` for marketing-site changes targeting `www`.
-- Use `freed-ship-build` for desktop release shipping.
-- Use `freed-ship-www` for publishing `www`, refreshing changelog, or syncing `main` into `www`.
-- Ask before creating a worktree if destination branch or path scope is unclear.
-- Never base public marketing work from `dev`.
-- Never fast-forward `www` to `dev`.
-
-### Branch Promotion
-
-Treat `dev`, `main`, and `www` as separate lanes with explicit promotion points.
+- Never edit or commit task changes directly on `dev`, `main`, or `www`. Use a task branch in an isolated worktree. A shipping skill may use a clean lane checkout for read-only proof and post-merge operations.
+- Preserve user changes. Do not clean, reset, overwrite, or incorporate unrelated work.
+- Use the Node toolchain pinned by `.nvmrc`. `node`, `npm`, and `npx` must come from the same installation.
+- Gather available evidence yourself. Ask the owner to run a diagnostic only when the required account, hardware, or live state is outside your access.
+- Keep the active delivery bounded. Fix blockers. For adjacent deferrable debt, deduplicate or create one GitHub issue with `.github/ISSUE_TEMPLATE/debt.yml`, then resume. Drop speculative findings.
+- Code before the first `await` in an async function is synchronous. Keep O(n) work such as serialization, `A.save()`, or large typed-array conversion out of fire-and-forget hot paths before the first yield.
 
-- `dev` is the default branch for ongoing product work.
-- `main` is the production release branch. Do not use it as a second development branch.
-- Promote `dev` into `main` when shipping a reviewed production release.
-- After every production release, open a dedicated reverse-integration PR that merges `main` back into `dev`.
-- If a hotfix lands on `main`, include it in that reverse-integration PR immediately after the production release is stable. Do not let `main` drift sit around.
-- `www` is the public marketing branch. Sync approved `main` changes into `www` when the website or checked-in changelog needs them. Never sync `www` from `dev`.
-- Treat the `main` back into `dev` reverse merge as part of the production release closeout, not as an optional cleanup.
-- When release tooling or deployment helpers exist on more than one long-lived branch, update the matching copies in the same sweep or document why they intentionally differ.
+### Provider fingerprinting stop sign
 
-### Validation Tiers
+Before writing code or enabling a feature that could alter behavior visible to X, Facebook, Instagram, LinkedIn, or another provider, stop. This includes authenticated WebView loads, navigation, requests, retries, cadence, cookies, headers, scripted scrolling or clicking, extraction scripts, media loading, login behavior, canvas or WebGL behavior, and fingerprint masking.
 
-- `npm run validate:feature` is the default feature-branch check. It always runs root typecheck, then scopes the rest of the checks from the changed path set.
-- `npm run validate:dev` is the full integration suite for merges and pushes to `dev`.
-- `npm run validate:release` is the heaviest lane for release-prep work on `main`.
-- Do not default feature threads to the full integration suite when the touched surface is narrow.
+Warn the owner in plain language. Name the provider, describe the observable change, explain how it could increase fingerprinting or detection risk, and offer the lowest-profile alternative. Level 5 or higher covers necessary provider-observable behavior only after that warning. At a lower level, ask for an authorization level. Ordinary permission without a numbered level is not provider approval.
 
-### Release Economy
+Read and follow [freed-provider-risk-review](.agents/skills/freed-provider-risk-review/SKILL.md). A publishable provider-visible branch requires a healthy `provider-risk-review` artifact recording `behavior_approved` or `diff_authorized`, and its provider set must match the current provider-visible diff. Approval covers the described behavior, not arbitrary later changes. Any material deviation in requests, navigation, cookies, headers, timing, extraction, or provider API use requires a new Gate 1 decision before code, even when no mechanical check would catch it.
 
-Maximize trustworthy evidence per unit of machine time. Use the shallowest loop that can actually prove the contract at risk, reuse exact green receipts, and move deeper as soon as a shallower loop cannot answer the question. Economy never means skipping unique proof for data integrity, migrations, authority, provider safety, native command admission, platform behavior, signing, installation, updating, rollback, or soak stability.
+`scripts/lib/provider-visible-paths.mjs` is the canonical path classifier. Use `./scripts/worktree-publish.sh --print-provider-subdiff` to inspect the classified surface. Editing a listed path without observable behavior change can be classified `diff_authorized`; changing behavior from an unlisted path still requires Gate 1. Draft publication never grants live provider traffic.
 
-Signed releases are normally terminal validation, not the ordinary debugging loop. Use this sequence for Desktop release work:
+### Deployment, automation, and release safety
 
-1. Prove logic, migrations, UI behavior, and deterministic sync behavior with the cheapest relevant local tests and mocked Desktop runs.
-2. Build and exercise an exact local native Desktop candidate for SQLite, command registration, OAuth callbacks, provider triggers, real-library behavior, and every changed native entry point. A frontend call is not proof that the installed binary admits it.
-3. Cut one signed dev release only after the local logic and native candidate pass. Use the signed build to prove updater identity, signing, notarization, release metadata, installation, rollback, and installed-build behavior.
+- The only permitted Vercel scope is `aubreyfs-projects`. Never use a raw Vercel command without `--scope aubreyfs-projects`, never run Vercel from repository root, and never use the argument-free `deploy_to_vercel` tool. Use the repository preview and deployment helpers.
+- Keep browser tests headless. Show visible local previews in the task's built-in Browser. Do not open Chrome, headed Playwright, Playwright UI or debug mode, Computer Use, or another external browser unless the owner explicitly requests that external surface. If the built-in Browser is unavailable, report the preview URL. Keep an approved external window in the background where possible and close only that task's window at closeout.
+- Run `node scripts/doctor.mjs --strict` before loops and CI gates. Treat a surprising Node, npm, npx, GitHub CLI, or credential path as a machine problem.
+- Before activating a saved Freed automation, run `npm run validate:host-automations`. An ACTIVE actor with drift fails closed. Reconcile it through supported host automation controls and never edit `automation.toml` directly.
+- A private current-task owner confirmation outside the repository may authorize only the exact lifecycle operation it names. It does not authenticate the owner, grant provider traffic, replace provider review, or replace CODEOWNER requirements.
+- Releases require exact source, artifact, branch, installed build, and remote-head evidence. Use the shipping skills and release scripts. Never hand-edit version files or push release commits or tags around those controls.
 
-Batch local fixes into the current candidate. Do not cut another dev release for each test or defect. Cut another only when a verified fix changes installed behavior or a release-only surface that cannot be proved locally. Promote to production only after one signed dev candidate passes installation, real-data verification, and the required soak.
+### Incidents and durable data
 
-This sequence is a routing rule, not a mandatory delay. Start at the native or signed stage when the failure exists only there. Run full dev build loops whenever the affected contract spans packaging, multiple operating systems, updater behavior, signed identity, destructive migration risk, provider-observable behavior, or long-running process state. Do not repeat a full dev build loop whose exact source, artifact, platform, and result are already covered by a healthy receipt.
+- For a rare, intermittent, long-running, stateful, or data-loss failure, preserve attributable evidence before restarting, repairing, or changing code. Use [freed-evidence-capture](.agents/skills/freed-evidence-capture/SKILL.md).
+- After capture, fix the root cause and add the smallest safe mitigation. Add bounded telemetry plus tests for the relevant state machine, thresholds, retry limits, and recovery transitions. If the root cause remains unknown, say so and state what the next telemetry will distinguish.
+- Changes to durable library authority, migrations, rollback, storage epochs, snapshots, sync journals, tombstones, or Automerge must use [freed-library-core](.agents/skills/freed-library-core/SKILL.md). Identity is not storage authority. A UI or TypeScript guard is not enough where the database or native runtime owns enforcement.
 
-### Test Economy
+## Product invariants
 
-The binding standard is [docs/TESTING-STANDARD.md](docs/TESTING-STANDARD.md). Read it before adding, moving, or deleting a permanent test.
-
-- **Admission.** A new permanent test must protect a distinct user, data-integrity, security, authority, provider, release, migration, or operational contract. Search for existing same-layer coverage first and prefer extending it. State the unique failure it detects, use the cheapest deterministic layer, assign a tier, and measure its runtime. Individual test additions do not need owner approval, they need judgment.
-- **Tiers.** Changed-path suites for ordinary PRs, one full integration proof on the latest `dev` tree, release-delta checks at tag and promotion, exhaustive coverage nightly. A test can be release-critical through an exact inherited receipt without rerunning in the release workflow.
-- **Local coverage is not automatically a release gate.** A test earns a blocking lane by protecting a contract in the universal release gate list, not by having caught something once.
-- **No real sleeps or production-duration timeouts in blocking lanes.** Use injected clocks. Tooling shards run with a 5 minute per-test timeout; anything slower in a blocking lane is a defect.
-- **Delete temporary probes before publishing.** Exact pixel offsets, one-off geometry checks, and fixture self-tests already covered by real workflows do not survive to `main`.
-- **Platform honesty.** A test that skips itself wholesale on the runner it executes on is not coverage. Route it to the lane where it actually asserts something.
-- **The tooling smoke matrix is computed, never hardcoded.** `scripts/plan-tooling-smoke.mjs` derives applicable suites from changed paths and currently caps the lane at 16 jobs while debt issue #1147 tracks the underlying control-plane runtime. Do not reintroduce a literal suite or shard list in `ci.yml`.
-- **Prune continuously.** Move expensive-but-useful tests to nightly, merge duplicate assertions, and quarantine flaky noncritical tests behind one debt issue with an owner. Never quarantine data integrity, authority, provider safety, signing, release identity, or updater protection without an equivalent deterministic blocker.
-
-**Never use `git log main..branch` to check whether a branch has been merged.** Squash merge creates a new commit hash on `main`, so the original branch commits are never reachable from `main`'s history. The branch always looks "ahead" even when its content is fully shipped. Use these instead:
-
-```bash
-gh pr list --state merged --head <branch>   # authoritative: did a PR for this branch land?
-git branch -vv | grep '\[gone\]'            # remote branch deleted = PR merged + auto-deleted
-```
-
----
+- After implementing a new feature, update every affected `docs/PHASE-*.md` file and `docs/roadmap-status.json` in the product commit, even when the phase status is unchanged. Validate the structured roadmap. Route public roadmap presentation through a separate `www` task from the approved source commit. Never edit the website from the `dev` worktree for this sync.
+- Give machine-time estimates only, such as "one conversation" or "~10 min". Never quote human hours or days.
+- Display opaque IDs by their last eight characters, prefixed with `...`.
+- Format user-facing counts and totals with `Number.toLocaleString()` or `Intl.NumberFormat`, never raw interpolation or `.toString()`.
+- In user-facing strings, use "Freed Desktop". Never write "for Mac", "for Windows", or "for desktop".
+- Before creating a component or hook, search the package for an existing equivalent. Share logic or primitives instead of duplicating them.
+- Before shipping, confirm every exported function or class you added or touched has an appropriate caller.
 
-## Writing Style (All User-Facing Copy)
-
-Copy must read like a person wrote it. When in doubt, read it aloud. If it sounds like a press release, rewrite it.
-
-- **No em dashes (—) or en dashes (–).** Standard hyphens and normal punctuation only. Em dashes are a near-universal AI tell.
-- **No AI filler phrases:** "not just X but Y", "delve into", "it's worth noting", "leverage" (verb), "in today's world", "Furthermore,", "Moreover,", "Additionally,", "at the end of the day", "game-changer", "seamlessly".
-- **No throat-clearing.** Cut the first sentence of any paragraph that just announces what the paragraph is about.
-- **Short sentences.** If a sentence needs an em dash to hold together, split it in two.
-- **Concrete over abstract.** "Stores posts on your hard drive" beats "enables local-first data persistence".
-- **Contractions are fine.** "We don't" reads warmer than "We do not". Use them.
+## Package boundaries
 
-## Desktop E2E Testing
-
-The Freed Desktop app has a Playwright test suite that runs in plain Chromium, with no Tauri binary or
-native build required. Use this to reproduce UI bugs, verify fixes, and write regression tests
-when the test protects durable behavior. For the detailed policy, see
-`packages/desktop/tests/e2e/README.md`.
-
-Permanent desktop e2e coverage should earn its cost. Add or keep it for complete workflows across
-React state, Automerge state, and the Tauri mock boundary; provider auth, sync, reconnect, pause,
-or diagnostics behavior; startup, legal gate, crash recovery, updater, and renderer health paths;
-shared layout contracts with known regression risk; performance budgets; maintained visual
-snapshots; and rare or stateful failures where the next occurrence needs better evidence.
+- `shared`: pure functions and types, zero runtime dependencies, no React.
+- `ui`: platform-agnostic React. It may import `@freed/shared`, but no platform stores, Tauri, service-worker logic, or `@freed/sync`. It ships raw TSX.
+- `sync`: storage-agnostic across browser IndexedDB and Node filesystems.
+- `pwa`: imports `@freed/ui` and `@freed/shared`, never Tauri.
+- `desktop`: imports `@freed/ui` and `@freed/shared`, never `@freed/pwa`.
+- `capture-*`: isolated. Capture packages never import one another.
 
-Do not preserve temporary implementation probes as permanent tests. Exact pixel offsets, widths,
-gaps, colors, shadows, padding, one-off toolbar geometry checks, duplicate "button exists" checks,
-and fixture self-tests that are already exercised by real workflows should be deleted before
-publishing unless they are converted into a durable user-flow assertion or an explicit visual test.
-
-### How it works
-
-`VITE_TEST_TAURI=1` swaps every `@tauri-apps/*` import for a thin mock module under
-`packages/desktop/src/__mocks__/@tauri-apps/`. Each mock tracks calls in `window.__TAURI_MOCK_*`
-globals. A self-contained init script (`tests/e2e/fixtures/tauri-init.ts`) is injected via
-`page.addInitScript()` before any page JavaScript runs. It installs `window.__TAURI_INTERNALS__`
-with default IPC handlers for every command the app calls on startup.
-
-### Running the tests
-
-```bash
-# Standard run (headless Chromium)
-cd packages/desktop
-npm run test:e2e
-
-# Playwright UI mode (visual test runner, great for writing new tests)
-npm run test:e2e:ui
-
-# Step-through debugger (pauses on each action, shows browser)
-npm run test:e2e:debug
-```
-
-All three commands start a Vite dev server automatically on port 1422 with `VITE_TEST_TAURI=1` and
-tear it down after the run. No separate server startup needed.
-
-### Writing a new test
-
-1. Add a spec file under `packages/desktop/tests/e2e/`.
-2. Import from `./fixtures/app` instead of from `@playwright/test` directly:
-
-```ts
-import { test, expect } from "./fixtures/app";
-
-test("my new behaviour", async ({ app }) => {
-  // app.page is a Playwright Page. The Tauri mock is already injected.
-  // app.waitForReady() blocks until <main> is visible (app fully init'd).
-  await expect(app.page.locator("button")).toBeVisible();
-});
-```
+## Canonical URLs
 
-3. Use the `ipc` fixture to override handlers or read mock state:
+Marketing is `https://freed.wtf`, the PWA is `https://app.freed.wtf`, and downloads are at `https://freed.wtf/get`. Never write `freed.wtf/app`.
 
-```ts
-test("invoke a command", async ({ app, ipc }) => {
-  await ipc.setHandler("my_command", (_args) => ({ ok: true }));
-
-  const result = await app.page.evaluate(async () =>
-    (window as any).__TAURI_MOCK_INVOKE__("my_command", {}),
-  );
-  expect(result).toEqual({ ok: true });
-});
-```
+## Delivery kernel
 
-4. To assert on plugin-shell `open()` calls: `await ipc.openedUrls()`.
-5. To assert on plugin-process calls: `await ipc.processCalls()`.
-6. To pre-set the updater state before page load, inject a second `addInitScript`:
+### Lanes and local proof
 
-```ts
-await page.addInitScript(tauriInitScript());  // always first
-await page.addInitScript(() => {
-  (window as any).__TAURI_MOCK_UPDATE__ = { version: "2.0.0", ... };
-});
-await page.goto("/");
-```
+- Product work targets `dev`. Public website work targets `www`. Production release preparation targets `main`. Dev release preparation targets `dev`.
+- Never base public website work on `dev`, merge `dev` into `www`, or use `main` as a second development branch.
+- Use `./scripts/worktree-add.sh` with an explicit remote base. Do not use bare `git worktree add`.
+- Build and test locally first. Publish only when the intended slice is locally runnable. GitHub CI is exact-head verification, not the development loop.
+- Use `./scripts/worktree-preview.sh <target>` for local previews. Do not run root `npm run dev`. Run workspace commands from the workspace directory, not with root workspace dispatch. If a workspace needs a hoisted binary, prefix `PATH` with the worktree root `node_modules/.bin`.
+- Keep each task's previews and cleanup scoped to its worktree. Do not run broad cleanup while the owner is reviewing a preview.
 
-### Adding a new IPC mock handler
+### Validation and publication
 
-If the app starts calling a new `invoke()` command and tests fail because the handler is missing,
-add a default response in both places:
+- `npm run validate:feature` is the normal feature-branch gate.
+- `npm run validate:dev` is the full integration gate for merges and pushes to `dev`.
+- `npm run validate:release` is the release-preparation gate on `main`.
+- Read [docs/TESTING-STANDARD.md](docs/TESTING-STANDARD.md) before adding, moving, or deleting permanent tests. Use the cheapest deterministic layer that protects a distinct contract. Delete temporary probes before publication.
+- Publish ordinary work through `./scripts/worktree-publish.sh` with existing GitHub authentication. Use `--ready` only for finished work. Missing optional broker configuration does not block the normal authenticated path.
+- Branch names use `feat/`, `fix/`, `chore/`, `docs/`, `refactor/`, `perf/`, or `style/` plus a short kebab-case description. Commit messages and PR titles use the matching Conventional Commit prefix.
+- Squash merge into the PR's destination lane. One PR becomes one commit on that lane. Use the PR title as the squash commit subject.
+- After a merge, stop only that worktree's processes, remove its worktree, and delete the local task branch. Never use branch ancestry to infer whether a squash PR merged; query the PR or remote branch state.
 
-1. `packages/desktop/tests/e2e/fixtures/tauri-init.ts`: add an entry to `_defaults` inside the
-   IIFE. This covers the init-script path (plain Chromium / CI).
-2. `packages/desktop/src/__mocks__/@tauri-apps/api/core.ts`: add to the `handlers` map in the
-   module-level mock (only hits when `VITE_TEST_TAURI=1` aliases are active, i.e. dev server runs
-   the real Vite mock modules instead of the injected init script).
+### Promotion
 
-The two are complementary. `tauri-init.ts` is the reliable one for tests; the module mocks exist
-for completeness and for any test that doesn't use `page.addInitScript`.
+`dev`, `main`, and `www` are separate lanes. Promote a reviewed immutable `dev` snapshot into `main` only through the release workflow. After a stable production release, reverse-integrate `main` into `dev`. Sync approved `main` changes into `www` only when the website or checked-in changelog needs them.
 
-### Debugging a UI bug in the desktop app
+Use [freed-ship-build](.agents/skills/freed-ship-build/SKILL.md) for release economy, CalVer, signing, installation, rollback, and reverse integration. Use [freed-ship-www](.agents/skills/freed-ship-www/SKILL.md) for website deployment. Use [docs/SOAK-AND-TRIGGERS.md](docs/SOAK-AND-TRIGGERS.md) and [freed-soak](.agents/skills/freed-soak/SKILL.md) for installed observation.
 
-1. Create a worktree as usual.
-2. Reproduce the bug with the cheapest useful tool: live preview, Playwright UI mode, a temporary
-   browser assertion, or a focused failing test when permanent coverage is justified.
-3. Use `--debug` when stepping through browser state will materially speed up the fix.
-4. Fix the code, confirm the relevant check goes green, and delete temporary probes before commit.
+## Writing
 
-Do not ask the user to click through the app to verify a fix when the repo can verify it locally.
-For simple visual polish, thread-level preview or browser verification is enough. Write a permanent
-test only when it delivers future value under the e2e policy above.
+Apply the installed `no-ai-slop` skill to substantial prose. Preserve the owner's meaning, cadence, humor, uncertainty, and edge.
 
-### Debugging rare or stateful failures
-
-When fixing a rare, intermittent, long-running, stateful, or hard-to-reproduce failure, do not ship
-only a one-off patch. Treat the work as root-cause debugging plus mitigation. The same patch should
-make the next occurrence easier to explain, prove whether the mitigation worked, and reduce the odds
-that the same class of bug escapes again. If that is impossible, document exactly why in the PR.
-
-This rule applies to freezes, hangs, blank screens, stale renderers, stuck background jobs, sync
-stalls, data loss, data corruption, runaway memory, runaway CPU, repeated retries, update failures,
-cache poisoning, crash loops, and any fix where the first explanation is "this should not happen."
-
-Before changing code, preserve live evidence while the system is still in the bad state. Choose the
-evidence that fits the failure:
-
-- process state, stack samples, memory maps, open files, child processes, network sockets, and CPU or memory pressure
-- app logs, OS logs, crash reports, failed job records, retry history, queue depth, and last-success timestamps
-- local data footprint, cache size, snapshot size, database size, schema or version markers, and largest files
-- current route, visible UI state, selected account or provider, pending operation, and recent user or system events
-- remote service status, API response shape, deployment id, release channel, updater manifest, or sync peer state when relevant
-
-For the fix itself, add lightweight telemetry that distinguishes plausible failure classes. Prefer
-structured fields that can answer "what was the system doing, how long had it been doing it, what
-resource was growing, and what dependency was waiting?" Examples include:
-
-- heartbeat or progress payloads with event loop lag, visibility, route, app phase, pending operation, and oldest pending age
-- worker state, queue state, retry counters, timeout counters, active provider, active task id, and last successful checkpoint
-- persistence state, document size, cache size, snapshot activity, schema version, migration version, and save duration
-- native process RSS, child process RSS, heap usage, DOM node count, open handles, and relevant cache sizes
-- sleep, resume, hide, show, online, offline, update check, sync start, sync finish, and recovery timestamps
-- a small rotating diagnostics file when the failure could prevent normal logs or heartbeats from being delivered
-
-Mitigation and recovery behavior should be conservative and observable:
-
-- recover quickly enough to avoid leaving the user stuck
-- avoid churn when normal background throttling, offline state, or temporary provider errors explain the symptom
-- log the recovery reason, stale age or failed duration, last known state, probe results, resource usage, and whether the system resumed normal work afterward
-- recycle or reset related background resources when they may share the failing process, connection pool, cache, worker, or queue
-
-Tests should cover the state machine, thresholds, retry limits, and telemetry fields that prove the
-new behavior. If the root cause is still unknown after the patch, say that directly in the PR and
-list exactly what the new telemetry will prove on the next occurrence.
-
-## Automerge
-
-**Schema** (`packages/shared/src/schema.ts`): backward-compatible only. Add optional fields; never delete (mark `@deprecated`).
-
-**Mutations** must use `A.change()` — direct mutation silently fails to sync:
-
-```ts
-A.change(doc, (d) => {
-  d.items.push(item);
-}); // ✅
-doc.items.push(item); // ❌ silent failure
-```
-
-**Proxy constraints inside `A.change()`:**
-
-- Never assign `undefined` — use `delete` instead
-- Never replace an existing nested object — assign fields individually or use a `deepMergeInto` helper
+- Lead with the point. Use concrete nouns and active verbs.
+- Never use em dashes, en dashes, or double hyphens as prose punctuation.
+- Cut filler, throat-clearing, puffery, vague attribution, canned contrasts, and decorative conclusions.
+- Keep public copy appropriate to its audience. Do not put agent-product authorship giveaways in external titles.

--- a/docs/AGENT-INSTRUCTIONS.md
+++ b/docs/AGENT-INSTRUCTIONS.md
@@ -1,0 +1,64 @@
+# Agent Instruction Architecture
+
+Load each rule needed for the current task once, before the relevant decision. Keep universal governance, path invariants, workflows, explanations, and enforcement in separate layers.
+
+## Layers
+
+| Layer                        | Purpose                                                                              | Loading                                                                                          |
+| ---------------------------- | ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------ |
+| Global personal instructions | Identity, voice, external-post policy, general engineering defaults                  | Every task                                                                                       |
+| Root `AGENTS.md`             | Freshness, authorization, dangerous-action stops, lane routing, universal invariants | Every repository task                                                                            |
+| Scoped `AGENTS.md`           | Hard invariants for one path                                                         | Automatically when the task starts at or below that path; otherwise through the root path router |
+| `SKILL.md`                   | A bounded task workflow and its decisions                                            | Selected from its description or invoked explicitly                                              |
+| Skill `references/`          | Detailed modes, contracts, examples, and command catalogs                            | Only when a matching trigger in `SKILL.md` says to read one                                      |
+| Canonical docs and scripts   | Tutorials, rationale, mutable technical contracts, and machine enforcement           | On demand                                                                                        |
+
+Do not copy a mutable rule into several layers. Keep one authoritative version and route to it. Repeat only a short safety stop when an agent must see it before deciding which deeper file applies.
+
+## Budgets
+
+- Root `AGENTS.md`: 16 KiB maximum.
+- Each scoped instruction file: 6 KiB maximum.
+- Any repository root-to-scope instruction chain: 28 KiB maximum.
+- Each `SKILL.md` entrypoint: 16 KiB maximum.
+- Selected references for one task mode have a 32 KiB review threshold. Above it, split the triggers more narrowly or record why the complete bundle is necessary. Never omit a matching safety or authority rule to meet the threshold.
+
+`npm run validate:agent-instructions` enforces instruction discovery, root routing, local links, punctuation, and byte budgets. `npm run validate:skills` enforces skill metadata, invocation policy, entrypoint size, direct reference links, and portable prose.
+
+`CODEOWNERS` routes instruction changes to the owner. Branch rules decide whether that review is mandatory; the validator proves only that the routing entries exist.
+
+The limits leave room below Codex's default project-instruction ceiling and make accidental growth fail in review instead of silently truncating policy.
+
+## Invocation policy
+
+Codex invocation policy belongs in `agents/openai.yaml`:
+
+```yaml
+policy:
+  allow_implicit_invocation: true
+```
+
+Freed skills use implicit selection because their descriptions are narrow routers for repository work. Explicit `$skill-name` invocation remains available.
+
+Do not use `disable-model-invocation`. It is not the Codex invocation control and created false confidence while implicit selection remained enabled.
+
+Skill selection loads instructions. It never raises the numbered authorization level, approves provider behavior, grants live traffic, satisfies a release gate, or bypasses an owner checkpoint.
+
+## Change checklist
+
+1. Decide whether the rule is universal, path-specific, workflow-specific, explanatory, or mechanically enforceable.
+2. Put it in the narrowest authoritative layer that still loads before the relevant decision.
+3. Add or update the root router when a root-started task would otherwise miss it.
+4. Remove the superseded copy instead of leaving compatibility prose behind.
+5. Test local links, byte budgets, invocation metadata, changed-path validation, and representative task routing.
+6. Preserve critical stop signs in the root or skill entrypoint even when the complete procedure moves deeper.
+
+## Long-lived branches
+
+`dev` owns current product instruction development. Normal production promotion carries reviewed policy into `main`. Port instruction-only changes to `www` deliberately through its lane when website tasks need them. Never merge `dev` into `www` to obtain instruction parity.
+
+When a safety rule changes, inspect all three long-lived versions and record every intentional difference in the pull request.
+
+## Measure the result
+
+Review this architecture after a concrete routing error, missed safety stop, or repeated-context regression. Use that evidence to change the route or budget. Do not optimize for line count alone.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,13 @@
+# Documentation Instructions
+
+Read the root `AGENTS.md` and the task's workflow skill first.
+
+- Product documentation targets `dev`. Public marketing, public roadmap presentation, legal pages, and changelog presentation target `www`.
+- A new feature must update every affected `docs/PHASE-*.md` file and `docs/roadmap-status.json` in the same product commit. Reconcile the structured roadmap even when its status is unchanged.
+- Validate roadmap data with `node scripts/validate-roadmap-status.mjs`.
+- Do not infer public roadmap state from phase prose. Hand the approved structured source commit to a separate `www` task.
+- [TESTING-STANDARD.md](TESTING-STANDARD.md) is binding for permanent test admission, tiering, runtime, and pruning.
+- [SOAK-AND-TRIGGERS.md](SOAK-AND-TRIGGERS.md) is binding for installed soaks and terminal triggers.
+- Put operational tutorials, command catalogs, historical decisions, and rationale in the canonical document for that subject. Keep root and skill instructions as short routers.
+- Update links and references when moving authoritative material. Do not leave two files claiming to own the same mutable rule.
+- Apply the installed `no-ai-slop` skill to substantial prose.

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       ],
       "devDependencies": {
         "esbuild": "0.28.2",
+        "js-yaml": "4.3.1",
         "typescript": "^5.3.0",
         "vite": "8.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "typecheck": "npm run contracts:check && node scripts/run-workspace-fanout.mjs typecheck",
     "typecheck:friends-galaxy-lab": "tsc -p packages/ui/labs/friends-galaxy/tsconfig.json",
     "typecheck:graph": "tsc --build --dry",
+    "validate:agent-instructions": "node scripts/validate-agent-instructions.mjs",
     "validate:automations": "node scripts/validate-automation-specs.mjs",
     "validate:host-automations": "node scripts/validate-host-automations.mjs",
     "validate:roadmap": "node scripts/validate-roadmap-status.mjs",
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "esbuild": "0.28.2",
+    "js-yaml": "4.3.1",
     "typescript": "^5.3.0",
     "vite": "8.2.1"
   }

--- a/packages/desktop/AGENTS.md
+++ b/packages/desktop/AGENTS.md
@@ -1,0 +1,25 @@
+# Desktop Package Instructions
+
+Apply these rules to work under `packages/desktop/` in addition to the repository instructions.
+
+## Boundaries and previews
+
+- Import shared product behavior from `@freed/ui` and `@freed/shared`. Never import from `@freed/pwa`.
+- Read the shared [visual contracts](../../.agents/skills/freed-ui-polish/references/visual-contracts.md) before changing Desktop UI.
+- Use a mocked Desktop preview for ordinary UI work. From the repository root, find a fresh port with `node scripts/lib/find-free-port.mjs 1422`, then launch `./scripts/worktree-preview.sh desktop --port <port>`.
+- Use `./scripts/worktree-preview.sh desktop --native` from the repository root only when real Tauri behavior matters, and report its preview label. A local native candidate does not require a version bump, tag, release, or GitHub workflow.
+- Show a user-facing preview in the task's built-in Browser and keep that tab attached to the task. If the built-in Browser is unavailable, report the preview URL instead of opening another browser.
+- Do not open a visible external browser unless the owner explicitly requests that surface. When an approved external window is required, keep it in the background where possible and close only that task's window at closeout.
+- Keep the preview alive while the owner reviews it. Use targeted worktree cleanup and stop only this task's preview at closeout.
+
+## Desktop testing
+
+- Read [tests/e2e/README.md](tests/e2e/README.md) before adding, removing, or debugging Desktop e2e coverage. Run its commands from `packages/desktop` and keep browser automation headless unless the owner explicitly approved an external browser window.
+- Keep permanent e2e tests for durable release risks and complete workflows. Delete one-off pixel, spacing, color, shadow, padding, and toolbar-geometry probes before publishing unless they became a shared layout contract, a demonstrated regression test, or an explicit maintained visual test.
+- When a Tauri command is added, update both the injected test fixture and the module mock described in the e2e policy.
+
+## Stateful failures
+
+- For a live, rare, intermittent, or stateful failure, use `freed-evidence-capture` before changing the system so logs, process state, build identity, and local data are preserved.
+- Route memory regressions to `freed-memory-profile`, deterministic sync or provider-lifecycle reproduction to `freed-sync-replay`, and installed-build observation to the soak policy in `../../docs/SOAK-AND-TRIGGERS.md`.
+- A mitigation for a hard-to-reproduce failure must make the next occurrence attributable. Add bounded telemetry and test the state machine, thresholds, retry limits, and recovery transitions that distinguish plausible causes.

--- a/packages/desktop/tests/e2e/README.md
+++ b/packages/desktop/tests/e2e/README.md
@@ -15,6 +15,84 @@ The permanent suite was trimmed to keep functional flows and measured
 performance budgets. Removed tests should stay removed unless the behavior is
 converted into a durable user-flow assertion or an explicit visual snapshot.
 
+## Test runtime
+
+The suite runs the Desktop React app in Chromium without launching a Tauri
+binary. The Playwright web server sets `VITE_TEST_TAURI=1`, which aliases each
+`@tauri-apps/*` import to the thin modules under
+`packages/desktop/src/__mocks__/@tauri-apps/`.
+
+Import `test` and `expect` from `./fixtures/app`, not directly from
+`@playwright/test`:
+
+```ts
+import { test, expect } from "./fixtures/app";
+
+test("renders the expected state", async ({ app, ipc }) => {
+  await app.goto();
+  await app.waitForReady();
+  await expect(app.page.locator("main")).toBeVisible();
+});
+```
+
+The shared `app` fixture injects `tauriInitScript()` with
+`page.addInitScript()` before application JavaScript runs. That script installs
+`window.__TAURI_INTERNALS__`, default IPC handlers, and the mock state used at
+startup. A test that creates its own page setup must inject `tauriInitScript()`
+first and must do so before `page.goto()`.
+
+## Running the suite
+
+Run Desktop commands from `packages/desktop/`:
+
+```bash
+npm run test:e2e
+```
+
+The standard command starts and stops its Vite server automatically and runs
+headless. `npm run test:e2e:ui` and `npm run test:e2e:debug` open external
+browser surfaces, so use them only when the owner explicitly requests that
+surface.
+
+## Test-specific state and assertions
+
+Override an IPC command after fixture injection with `ipc.setHandler()`. Use
+`ipc.invocations()` to inspect recorded command calls and `ipc.openedUrls()` to
+inspect URLs passed to the shell plugin.
+
+State that must exist before application startup belongs in another init
+script registered before navigation. For example, updater tests set
+`window.__TAURI_MOCK_UPDATE__` before `app.goto()`:
+
+```ts
+await app.page.addInitScript(() => {
+  (window as unknown as Record<string, unknown>).__TAURI_MOCK_UPDATE__ = {
+    version: "2.0.0",
+  };
+});
+await app.goto();
+```
+
+The process plugin has its own module mock at
+`src/__mocks__/@tauri-apps/plugin-process/index.ts`. Update that mock when a
+test depends on changed relaunch or exit behavior instead of inventing an IPC
+handler for a module-level plugin call.
+
+## Keeping IPC mocks complete
+
+When the app starts invoking a new Tauri command, add a safe default response
+in both places:
+
+1. `tests/e2e/fixtures/tauri-init.ts`, inside the object assigned to
+   `window.__TAURI_MOCK_HANDLERS__`. This is the reliable pre-page path used by
+   the Playwright fixture.
+2. `src/__mocks__/@tauri-apps/api/core.ts`, inside its `handlers` map. This is
+   the Vite module-alias path.
+
+These paths are complementary. Keep their defaults semantically aligned so a
+test does not pass or fail merely because it entered the mock boundary through
+a different route.
+
 ## Permanent E2E Tests
 
 Keep a Playwright test when it protects one of these surfaces:

--- a/packages/pwa/AGENTS.md
+++ b/packages/pwa/AGENTS.md
@@ -1,0 +1,17 @@
+# PWA Package Instructions
+
+Apply these rules to work under `packages/pwa/` in addition to the repository instructions.
+
+## Boundaries and authority
+
+- Keep the PWA free of Tauri APIs. Reuse platform-neutral behavior from `@freed/ui` and `@freed/shared`.
+- Read the shared [visual contracts](../../.agents/skills/freed-ui-polish/references/visual-contracts.md) before changing PWA UI.
+- Use `freed-library-core` before changing durable Library data or authority in IndexedDB, Cache API, OPFS, browser row storage, storage epochs, migration, or rollback.
+
+## Preview and validation
+
+- Run workspace commands from `packages/pwa/`. For a visible local preview, find a fresh port with `node scripts/lib/find-free-port.mjs 1421`, then launch `./scripts/worktree-preview.sh pwa --port <port>` from the repository root.
+- Show the preview in the task's built-in Browser and keep that tab attached to the task. If the built-in Browser is unavailable, report the preview URL instead of opening another browser.
+- Do not open a visible external browser unless the owner explicitly requests that surface. When an approved external window is required, keep it in the background where possible and close only that task's window at closeout.
+- Create a shareable PWA preview only when the active authorization covers it. From the repository root, use `./scripts/vercel-deploy-preview.sh pwa`, never a raw subdirectory deployment.
+- Keep the preview alive while the owner reviews it. Use targeted worktree cleanup and stop only this task's preview at closeout.

--- a/packages/shared/AGENTS.md
+++ b/packages/shared/AGENTS.md
@@ -1,0 +1,11 @@
+# Shared Package Instructions
+
+Read the root `AGENTS.md`. Use `freed-library-core` for any durable library, migration, storage, sync-journal, or Automerge change.
+
+- Keep `shared` pure. It has zero runtime dependencies and no React.
+- Schema changes in `src/schema.ts` must be backward compatible. Add optional fields. Never delete a field; mark retired fields `@deprecated`.
+- Mutate Automerge documents only through `A.change()`. Direct mutation does not sync.
+- Inside `A.change()`, never assign `undefined`; delete the field instead.
+- Inside `A.change()`, do not replace an existing nested object. Assign its fields or use the established deep-merge helper.
+- Code before the first `await` in an async function runs synchronously. Keep serialization, `A.save()`, large typed-array conversion, and other O(n) work out of fire-and-forget hot paths before the first yield.
+- Validate behavior in both browser and Node storage environments when a shared contract reaches both.

--- a/packages/ui/AGENTS.md
+++ b/packages/ui/AGENTS.md
@@ -1,0 +1,10 @@
+# Shared UI Instructions
+
+Apply these rules to work under `packages/ui/` in addition to the repository instructions.
+
+## Boundaries
+
+- Keep this package platform-agnostic. It may import `@freed/shared`, but not platform stores, Tauri APIs, service-worker logic, or `@freed/sync`.
+- Read the shared [visual contracts](../../.agents/skills/freed-ui-polish/references/visual-contracts.md) before changing UI.
+
+For an iterative queue of small visual adjustments, use `freed-ui-polish` and keep the rendered preview at the user-review checkpoint.

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -1,0 +1,13 @@
+# Tooling Instructions
+
+Read the root `AGENTS.md` and the task-specific build or ship skill first.
+
+- Use the Node version pinned by `.nvmrc`. Resolve `node`, `npm`, and `npx` from the same installation.
+- Keep shell tooling non-interactive unless interaction is the feature. Fail closed on ambiguous refs, identities, paths, authority, or publication state.
+- Use repository helpers for worktrees, previews, publication, promotion, releases, and Vercel. Do not add bypass commands to documentation or error output.
+- Changes that can alter provider-visible behavior require `freed-provider-risk-review` before code. Add provider-visible paths only to `scripts/lib/provider-visible-paths.mjs`.
+- Do not edit saved `automation.toml` files to repair drift. Validation and supported host controls own reconciliation.
+- Release scripts own CalVer, release files, tags, immutable source identity, and remote-head checks. Do not duplicate that logic in prose or a second script.
+- When release or deployment helpers exist on more than one long-lived lane, update every applicable copy in the same sweep or document why the implementations intentionally differ.
+- Add focused contract tests for tooling behavior. Route changed paths through `validate:feature` without silently dropping them or forcing unrelated suites.
+- Preserve user data and existing worktrees. Validate exact destructive targets and prefer recoverable cleanup.

--- a/scripts/lib/tooling-smoke-plan.mjs
+++ b/scripts/lib/tooling-smoke-plan.mjs
@@ -274,13 +274,20 @@ function isRepoSurface(changedFile) {
 function hasFocusedFeatureValidation(changedFile) {
   return (
     FOCUSED_FEATURE_VALIDATION_PATHS.has(changedFile) ||
+    /(?:^|\/)AGENTS(?:\.override)?\.md$/.test(changedFile) ||
+    changedFile === "docs/AGENT-INSTRUCTIONS.md" ||
+    changedFile === ".github/CODEOWNERS" ||
+    /^scripts\/validate-agent-instructions(?:\.test)?\.mjs$/.test(
+      changedFile,
+    ) ||
     /^docs\/PHASE-\d+-[^/]+\.md$/.test(changedFile) ||
     /^release-notes\/daily\/(?:dev|production)\/[^/]+\.json$/.test(
       changedFile,
     ) ||
     /^release-notes\/releases\/v[^/]+\.(?:json|md)$/.test(changedFile) ||
     /^\.agents\/skills\/[^/]+\/SKILL\.md$/.test(changedFile) ||
-    /^\.agents\/skills\/[^/]+\/agents\/openai\.yaml$/.test(changedFile)
+    /^\.agents\/skills\/[^/]+\/agents\/openai\.yaml$/.test(changedFile) ||
+    /^\.agents\/skills\/[^/]+\/references\/[^/]+\.md$/.test(changedFile)
   );
 }
 
@@ -305,9 +312,7 @@ export function selectApplicableSuites(
     });
   }
 
-  const smokeFiles = files.filter(
-    (file) => !hasFocusedFeatureValidation(file),
-  );
+  const smokeFiles = files.filter((file) => !hasFocusedFeatureValidation(file));
   if (smokeFiles.length === 0) {
     return Object.freeze({
       suites: Object.freeze([]),
@@ -481,7 +486,11 @@ export function suiteWeights({ repoRoot = REPO_ROOT, durations = null } = {}) {
     for (const testFile of suiteTestFiles(suite, repoRoot)) {
       size += readIfPresent(repoRoot, testFile)?.length ?? 0;
     }
-    weights.set(suite, { weight: Math.max(1, size), measured: false, capped: false });
+    weights.set(suite, {
+      weight: Math.max(1, size),
+      measured: false,
+      capped: false,
+    });
   }
   return weights;
 }
@@ -514,8 +523,14 @@ export function projectShardRuntime(allocation, weights, timeoutSeconds) {
       // would reproduce the bug this function exists to catch.
       fits: capped
         ? false
-        : !isSeconds || !Number.isFinite(timeoutSeconds) || perShardSeconds <= timeoutSeconds,
-      predictedFrom: capped ? "capped" : entry?.measured === true ? "measured" : "size",
+        : !isSeconds ||
+          !Number.isFinite(timeoutSeconds) ||
+          perShardSeconds <= timeoutSeconds,
+      predictedFrom: capped
+        ? "capped"
+        : entry?.measured === true
+          ? "measured"
+          : "size",
     };
   });
 }
@@ -566,7 +581,11 @@ export function buildToolingSmokeMatrix({
   const selection = selectApplicableSuites(changedFiles, { repoRoot });
   const weights = suiteWeights({ repoRoot, durations });
   const allocation = allocateShardBudget(selection.suites, maxJobs, weights);
-  const projection = projectShardRuntime(allocation, weights, shardTimeoutSeconds);
+  const projection = projectShardRuntime(
+    allocation,
+    weights,
+    shardTimeoutSeconds,
+  );
   const include = allocation.flatMap(({ suite, shardCount }) =>
     Array.from({ length: shardCount }, (_, index) => ({
       suite,
@@ -591,6 +610,8 @@ export function buildToolingSmokeMatrix({
     // Suites this plan predicts will not finish inside the job timeout. The
     // caller decides what to do about it; the point is that it is known before
     // the jobs run rather than ninety minutes later.
-    overrunSuites: projection.filter((entry) => !entry.fits).map((entry) => entry.suite),
+    overrunSuites: projection
+      .filter((entry) => !entry.fits)
+      .map((entry) => entry.suite),
   });
 }

--- a/scripts/tooling-smoke-plan.test.mjs
+++ b/scripts/tooling-smoke-plan.test.mjs
@@ -34,7 +34,9 @@ const COMPLETED = {
 };
 
 test("a capped duration is not treated as a measurement", () => {
-  const capped = suiteWeights({ durations: CAPPED }).get("outcome-ledger-repair");
+  const capped = suiteWeights({ durations: CAPPED }).get(
+    "outcome-ledger-repair",
+  );
   assert.equal(capped.capped, true);
   assert.equal(capped.measured, false);
 
@@ -255,10 +257,34 @@ test("every Freed skill path relies on its focused skill validator", () => {
   for (const filePath of [
     ".agents/skills/freed-provider-risk-review/SKILL.md",
     ".agents/skills/freed-provider-risk-review/agents/openai.yaml",
+    ".agents/skills/freed-library-core/references/storage.md",
     ".agents/skills/freed-memory-profile/SKILL.md",
     ".agents/skills/future-skill/SKILL.md",
     "scripts/validate-skills.mjs",
     "scripts/validate-skills.test.mjs",
+  ]) {
+    const selection = selectApplicableSuites([filePath]);
+    assert.deepEqual(selection.suites, [], filePath);
+    assert.match(
+      selection.reason,
+      /explicit focused feature-validation/,
+      filePath,
+    );
+  }
+});
+
+test("agent instruction paths rely on focused feature validation", () => {
+  for (const filePath of [
+    "AGENTS.md",
+    ".github/CODEOWNERS",
+    ".agents/skills/AGENTS.md",
+    "docs/AGENT-INSTRUCTIONS.md",
+    "docs/AGENTS.md",
+    "packages/desktop/AGENTS.override.md",
+    "packages/pwa/AGENTS.md",
+    "scripts/validate-agent-instructions.mjs",
+    "scripts/validate-agent-instructions.test.mjs",
+    "website/AGENTS.md",
   ]) {
     const selection = selectApplicableSuites([filePath]);
     assert.deepEqual(selection.suites, [], filePath);

--- a/scripts/validate-agent-instructions.mjs
+++ b/scripts/validate-agent-instructions.mjs
@@ -1,0 +1,391 @@
+#!/usr/bin/env node
+
+import {
+  existsSync,
+  lstatSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+export const REPO_ROOT = path.resolve(__dirname, "..");
+export const MAX_ROOT_BYTES = 16 * 1024;
+export const MAX_SCOPED_BYTES = 6 * 1024;
+export const MAX_CHAIN_BYTES = 28 * 1024;
+export const ARCHITECTURE_GUIDE = "docs/AGENT-INSTRUCTIONS.md";
+export const CODEOWNERS_FILE = ".github/CODEOWNERS";
+export const REQUIRED_SCOPED_FILES = Object.freeze([
+  ".agents/skills/AGENTS.md",
+  "docs/AGENTS.md",
+  "packages/desktop/AGENTS.md",
+  "packages/pwa/AGENTS.md",
+  "packages/shared/AGENTS.md",
+  "packages/ui/AGENTS.md",
+  "scripts/AGENTS.md",
+]);
+
+const INSTRUCTION_NAMES = new Set(["AGENTS.md", "AGENTS.override.md"]);
+const REQUIRED_CODEOWNER_RULES = Object.freeze([
+  "/AGENTS.md @AubreyF",
+  "**/AGENTS.md @AubreyF",
+  "**/AGENTS.override.md @AubreyF",
+]);
+const INVOCATION_POLICY_SNIPPET = [
+  "```yaml",
+  "policy:",
+  "  allow_implicit_invocation: true",
+  "```",
+].join("\n");
+const IGNORED_DIRECTORIES = new Set([
+  ".git",
+  ".next",
+  "coverage",
+  "dist",
+  "node_modules",
+  "target",
+]);
+
+function toPosix(filePath) {
+  return filePath.split(path.sep).join("/");
+}
+
+function collectInstructionFiles(repoRoot) {
+  const files = [];
+
+  function visit(directory, relativeDirectory = ".") {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      if (entry.isSymbolicLink() && INSTRUCTION_NAMES.has(entry.name)) {
+        throw new Error(
+          toPosix(path.join(relativeDirectory, entry.name)) +
+            ": instruction files cannot be symbolic links.",
+        );
+      }
+      if (entry.isDirectory()) {
+        if (IGNORED_DIRECTORIES.has(entry.name)) continue;
+        const childRelative =
+          relativeDirectory === "."
+            ? entry.name
+            : path.join(relativeDirectory, entry.name);
+        visit(path.join(directory, entry.name), childRelative);
+        continue;
+      }
+      if (!entry.isFile() || !INSTRUCTION_NAMES.has(entry.name)) continue;
+      files.push(
+        toPosix(
+          relativeDirectory === "."
+            ? entry.name
+            : path.join(relativeDirectory, entry.name),
+        ),
+      );
+    }
+  }
+
+  visit(repoRoot);
+  return files.sort();
+}
+
+function localLinkTargets(text) {
+  return [...String(text).matchAll(/]\(([^)]+)\)/g)]
+    .map((match) => match[1].trim().split(/\s+["']/u, 1)[0])
+    .filter(Boolean);
+}
+
+function resolveLocalLink(repoRoot, instructionFile, reference) {
+  const withoutFragment = reference.split(/[?#]/u, 1)[0];
+  if (
+    !withoutFragment ||
+    withoutFragment.startsWith("#") ||
+    /^(?:[a-z][a-z0-9+.-]*:|\/\/)/iu.test(withoutFragment)
+  ) {
+    return null;
+  }
+  const resolved = path.resolve(
+    repoRoot,
+    path.dirname(instructionFile),
+    withoutFragment,
+  );
+  const normalizedRoot = path.resolve(repoRoot);
+  if (
+    resolved !== normalizedRoot &&
+    !resolved.startsWith(normalizedRoot + path.sep)
+  ) {
+    throw new Error(
+      instructionFile +
+        ": local link escapes the repository: " +
+        reference +
+        ".",
+    );
+  }
+  return resolved;
+}
+
+function ancestorDirectories(relativeFile) {
+  const directories = [];
+  let directory = path.posix.dirname(relativeFile);
+  while (true) {
+    directories.push(directory);
+    if (directory === ".") break;
+    directory = path.posix.dirname(directory);
+  }
+  return directories.reverse();
+}
+
+function validatePortableInstructions(text, relativeFile) {
+  if (/[\u2013\u2014]/u.test(text)) {
+    throw new Error(
+      relativeFile + ": use standard punctuation instead of em or en dashes.",
+    );
+  }
+}
+
+function validateLocalLinks(repoRoot, relativeFile, text) {
+  for (const reference of localLinkTargets(text)) {
+    const resolved = resolveLocalLink(repoRoot, relativeFile, reference);
+    if (resolved && !existsSync(resolved)) {
+      throw new Error(
+        relativeFile + ": unresolved local link " + reference + ".",
+      );
+    }
+    if (!resolved) continue;
+    if (lstatSync(resolved).isSymbolicLink()) {
+      throw new Error(
+        relativeFile +
+          ": local links cannot target a symbolic link: " +
+          reference +
+          ".",
+      );
+    }
+    const realRoot = realpathSync(repoRoot);
+    const realTarget = realpathSync(resolved);
+    if (
+      realTarget !== realRoot &&
+      !realTarget.startsWith(realRoot + path.sep)
+    ) {
+      throw new Error(
+        relativeFile +
+          ": local link escapes the repository through a symbolic path: " +
+          reference +
+          ".",
+      );
+    }
+  }
+}
+
+function isHierarchicalInstructionRoute(sourceFile, targetFile) {
+  if (sourceFile === "AGENTS.md") return true;
+  const sourceDirectory = path.posix.dirname(sourceFile);
+  const targetDirectory = path.posix.dirname(targetFile);
+  return (
+    targetDirectory === sourceDirectory ||
+    targetDirectory.startsWith(sourceDirectory + "/")
+  );
+}
+
+function readRequiredFile(repoRoot, relativeFile) {
+  const absoluteFile = path.join(repoRoot, relativeFile);
+  if (!existsSync(absoluteFile)) {
+    throw new Error(repoRoot + ": missing required " + relativeFile + ".");
+  }
+  return readFileSync(absoluteFile, "utf8");
+}
+
+function validateArchitectureGuide(repoRoot) {
+  const text = readRequiredFile(repoRoot, ARCHITECTURE_GUIDE);
+  validatePortableInstructions(text, ARCHITECTURE_GUIDE);
+  validateLocalLinks(repoRoot, ARCHITECTURE_GUIDE, text);
+  const occurrences = text.split(INVOCATION_POLICY_SNIPPET).length - 1;
+  if (occurrences !== 1) {
+    throw new Error(
+      ARCHITECTURE_GUIDE +
+        ": include exactly one Codex invocation policy example with allow_implicit_invocation indented two spaces under policy.",
+    );
+  }
+  return { relativeFile: ARCHITECTURE_GUIDE, bytes: Buffer.byteLength(text) };
+}
+
+function validateCodeowners(repoRoot) {
+  const text = readRequiredFile(repoRoot, CODEOWNERS_FILE);
+  const rules = text
+    .split(/\r?\n/u)
+    .map((line) => line.trim().replace(/\s+/gu, " "))
+    .filter((line) => line && !line.startsWith("#"));
+  for (const requiredRule of REQUIRED_CODEOWNER_RULES) {
+    if (rules.filter((rule) => rule === requiredRule).length !== 1) {
+      throw new Error(
+        CODEOWNERS_FILE +
+          ": include exactly one owner rule `" +
+          requiredRule +
+          "`.",
+      );
+    }
+  }
+  return { relativeFile: CODEOWNERS_FILE, bytes: Buffer.byteLength(text) };
+}
+
+export function validateAgentInstructions({
+  repoRoot = REPO_ROOT,
+  requiredFiles = REQUIRED_SCOPED_FILES,
+  maxRootBytes = MAX_ROOT_BYTES,
+  maxScopedBytes = MAX_SCOPED_BYTES,
+  maxChainBytes = MAX_CHAIN_BYTES,
+} = {}) {
+  const files = collectInstructionFiles(repoRoot);
+  if (!files.includes("AGENTS.md")) {
+    throw new Error(repoRoot + ": missing root AGENTS.md.");
+  }
+
+  const byDirectory = new Map();
+  const records = [];
+  for (const relativeFile of files) {
+    const directory = path.posix.dirname(relativeFile);
+    if (byDirectory.has(directory)) {
+      throw new Error(
+        directory + ": keep only one of AGENTS.md or AGENTS.override.md.",
+      );
+    }
+    byDirectory.set(directory, relativeFile);
+
+    const absoluteFile = path.join(repoRoot, relativeFile);
+    const text = readFileSync(absoluteFile, "utf8");
+    const bytes = Buffer.byteLength(text);
+    const limit = relativeFile === "AGENTS.md" ? maxRootBytes : maxScopedBytes;
+    if (bytes > limit) {
+      throw new Error(
+        relativeFile +
+          ": " +
+          bytes.toLocaleString() +
+          " bytes exceeds the " +
+          limit.toLocaleString() +
+          " byte " +
+          (relativeFile === "AGENTS.md" ? "root" : "scoped") +
+          " instruction limit.",
+      );
+    }
+    validatePortableInstructions(text, relativeFile);
+    validateLocalLinks(repoRoot, relativeFile, text);
+    records.push({ relativeFile, bytes, text });
+  }
+
+  const root = records.find((record) => record.relativeFile === "AGENTS.md");
+  const linkedFiles = new Set();
+  for (const reference of localLinkTargets(root.text)) {
+    const resolved = resolveLocalLink(repoRoot, root.relativeFile, reference);
+    if (!resolved) continue;
+    linkedFiles.add(toPosix(path.relative(repoRoot, resolved)));
+  }
+
+  for (const requiredFile of requiredFiles) {
+    if (!files.includes(requiredFile)) {
+      throw new Error(repoRoot + ": missing required " + requiredFile + ".");
+    }
+    if (!linkedFiles.has(requiredFile)) {
+      throw new Error(
+        "AGENTS.md: must link required scoped instructions " +
+          requiredFile +
+          ".",
+      );
+    }
+  }
+
+  const instructionSet = new Set(files);
+  const recordsByFile = new Map(
+    records.map((record) => [record.relativeFile, record]),
+  );
+  const reachable = new Set(["AGENTS.md"]);
+  const queue = ["AGENTS.md"];
+  while (queue.length > 0) {
+    const current = queue.shift();
+    const record = recordsByFile.get(current);
+    for (const reference of localLinkTargets(record.text)) {
+      const resolved = resolveLocalLink(repoRoot, current, reference);
+      if (!resolved) continue;
+      const relativeTarget = toPosix(path.relative(repoRoot, resolved));
+      if (
+        !instructionSet.has(relativeTarget) ||
+        !isHierarchicalInstructionRoute(current, relativeTarget) ||
+        reachable.has(relativeTarget)
+      ) {
+        continue;
+      }
+      reachable.add(relativeTarget);
+      queue.push(relativeTarget);
+    }
+  }
+  const unreachable = files.filter(
+    (relativeFile) => !reachable.has(relativeFile),
+  );
+  if (unreachable.length > 0) {
+    throw new Error(
+      "Instruction files must be reachable from root AGENTS.md: " +
+        unreachable.join(", ") +
+        ".",
+    );
+  }
+
+  const bytesByFile = new Map(
+    records.map(({ relativeFile, bytes }) => [relativeFile, bytes]),
+  );
+  let largestChain = { relativeFile: "AGENTS.md", bytes: root.bytes };
+  for (const record of records) {
+    const chain = ancestorDirectories(record.relativeFile)
+      .map((directory) => byDirectory.get(directory))
+      .filter(Boolean);
+    const chainBytes = chain.reduce(
+      (total, relativeFile) => total + bytesByFile.get(relativeFile),
+      0,
+    );
+    if (chainBytes > maxChainBytes) {
+      throw new Error(
+        record.relativeFile +
+          ": instruction chain is " +
+          chainBytes.toLocaleString() +
+          " bytes and exceeds the " +
+          maxChainBytes.toLocaleString() +
+          " byte limit.",
+      );
+    }
+    if (chainBytes > largestChain.bytes) {
+      largestChain = { relativeFile: record.relativeFile, bytes: chainBytes };
+    }
+  }
+
+  const supplementalRecords = [
+    validateArchitectureGuide(repoRoot),
+    validateCodeowners(repoRoot),
+  ];
+
+  return { records, supplementalRecords, largestChain };
+}
+
+function main() {
+  const result = validateAgentInstructions();
+  process.stdout.write(
+    "Validated " +
+      result.records.length.toLocaleString() +
+      " instruction files. Root: " +
+      result.records
+        .find((record) => record.relativeFile === "AGENTS.md")
+        .bytes.toLocaleString() +
+      " bytes. Largest chain: " +
+      result.largestChain.bytes.toLocaleString() +
+      " bytes at " +
+      result.largestChain.relativeFile +
+      ". Supplemental controls: " +
+      result.supplementalRecords.length.toLocaleString() +
+      ".\n",
+  );
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(
+      (error instanceof Error ? error.message : String(error)) + "\n",
+    );
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-agent-instructions.test.mjs
+++ b/scripts/validate-agent-instructions.test.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  ARCHITECTURE_GUIDE,
+  CODEOWNERS_FILE,
+  validateAgentInstructions,
+} from "./validate-agent-instructions.mjs";
+
+const VALID_GUIDE = `# Guide
+
+\`\`\`yaml
+policy:
+  allow_implicit_invocation: true
+\`\`\`
+`;
+
+const VALID_CODEOWNERS = `
+/AGENTS.md @AubreyF
+**/AGENTS.md @AubreyF
+**/AGENTS.override.md @AubreyF
+`;
+
+function fixture(t) {
+  const repoRoot = mkdtempSync(
+    path.join(tmpdir(), "freed-agent-instructions-"),
+  );
+  t.after(() => rmSync(repoRoot, { force: true, recursive: true }));
+  write(repoRoot, ARCHITECTURE_GUIDE, VALID_GUIDE);
+  write(repoRoot, CODEOWNERS_FILE, VALID_CODEOWNERS);
+  return repoRoot;
+}
+
+function write(repoRoot, relativeFile, text) {
+  const absoluteFile = path.join(repoRoot, relativeFile);
+  mkdirSync(path.dirname(absoluteFile), { recursive: true });
+  writeFileSync(absoluteFile, text);
+}
+
+function validate(repoRoot, overrides = {}) {
+  return validateAgentInstructions({
+    repoRoot,
+    requiredFiles: [],
+    maxRootBytes: 128,
+    maxScopedBytes: 128,
+    maxChainBytes: 256,
+    ...overrides,
+  });
+}
+
+test("accepts bounded root and scoped instructions at the exact chain limit", (t) => {
+  const repoRoot = fixture(t);
+  const root = "Root\n[UI](packages/ui/AGENTS.md)\n";
+  const scoped = "UI rules\n";
+  write(repoRoot, "AGENTS.md", root);
+  write(repoRoot, "packages/ui/AGENTS.md", scoped);
+
+  const result = validate(repoRoot, {
+    requiredFiles: ["packages/ui/AGENTS.md"],
+    maxRootBytes: Buffer.byteLength(root),
+    maxScopedBytes: Buffer.byteLength(scoped),
+    maxChainBytes: Buffer.byteLength(root) + Buffer.byteLength(scoped),
+  });
+
+  assert.equal(result.records.length, 2);
+  assert.deepEqual(
+    result.supplementalRecords.map((record) => record.relativeFile),
+    [ARCHITECTURE_GUIDE, CODEOWNERS_FILE],
+  );
+  assert.deepEqual(result.largestChain, {
+    relativeFile: "packages/ui/AGENTS.md",
+    bytes: Buffer.byteLength(root) + Buffer.byteLength(scoped),
+  });
+});
+
+test("rejects an oversized root", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "12345");
+  assert.throws(
+    () => validate(repoRoot, { maxRootBytes: 4 }),
+    /exceeds the 4 byte root instruction limit/,
+  );
+});
+
+test("rejects an oversized scoped file", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "Root\n");
+  write(repoRoot, "packages/ui/AGENTS.md", "12345");
+  assert.throws(
+    () => validate(repoRoot, { maxScopedBytes: 4 }),
+    /exceeds the 4 byte scoped instruction limit/,
+  );
+});
+
+test("rejects an oversized nested instruction chain", (t) => {
+  const repoRoot = fixture(t);
+  const root = "root\n[packages](packages/AGENTS.md)\n";
+  const packages = "packages\n[ui](ui/AGENTS.md)\n";
+  const ui = "ui\n";
+  const chainBytes =
+    Buffer.byteLength(root) +
+    Buffer.byteLength(packages) +
+    Buffer.byteLength(ui);
+  write(repoRoot, "AGENTS.md", root);
+  write(repoRoot, "packages/AGENTS.md", packages);
+  write(repoRoot, "packages/ui/AGENTS.md", ui);
+  assert.throws(
+    () => validate(repoRoot, { maxChainBytes: chainBytes - 1 }),
+    new RegExp("instruction chain is " + chainBytes + " bytes"),
+  );
+});
+
+test("rejects two instruction files in one directory", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "root\n");
+  write(repoRoot, "AGENTS.override.md", "override\n");
+  assert.throws(
+    () => validate(repoRoot),
+    /keep only one of AGENTS\.md or AGENTS\.override\.md/,
+  );
+});
+
+test("requires root routing to every declared scoped file", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "root\n");
+  write(repoRoot, "packages/ui/AGENTS.md", "ui\n");
+  assert.throws(
+    () =>
+      validate(repoRoot, {
+        requiredFiles: ["packages/ui/AGENTS.md"],
+      }),
+    /must link required scoped instructions packages\/ui\/AGENTS\.md/,
+  );
+});
+
+test("rejects an orphaned scoped instruction file", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "root\n");
+  write(repoRoot, "packages/ui/AGENTS.md", "ui\n");
+  assert.throws(
+    () => validate(repoRoot),
+    /must be reachable from root AGENTS\.md: packages\/ui\/AGENTS\.md/,
+  );
+});
+
+test("does not accept instruction routing through an unrelated sibling", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "[Docs](docs/AGENTS.md)\n");
+  write(
+    repoRoot,
+    "docs/AGENTS.md",
+    "[Unrelated UI scope](../packages/ui/AGENTS.md)\n",
+  );
+  write(repoRoot, "packages/ui/AGENTS.md", "ui\n");
+  assert.throws(
+    () => validate(repoRoot),
+    /must be reachable from root AGENTS\.md: packages\/ui\/AGENTS\.md/,
+  );
+});
+
+test("rejects symlinked instruction files and local link targets", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "root\n");
+  write(repoRoot, "rules.md", "rules\n");
+  mkdirSync(path.join(repoRoot, "packages", "ui"), { recursive: true });
+  symlinkSync(
+    path.join(repoRoot, "rules.md"),
+    path.join(repoRoot, "packages", "ui", "AGENTS.md"),
+  );
+  assert.throws(
+    () => validate(repoRoot),
+    /instruction files cannot be symbolic links/,
+  );
+
+  rmSync(path.join(repoRoot, "packages", "ui", "AGENTS.md"));
+  symlinkSync(
+    path.join(repoRoot, "rules.md"),
+    path.join(repoRoot, "linked-rules.md"),
+  );
+  write(repoRoot, "AGENTS.md", "[Rules](linked-rules.md)\n");
+  assert.throws(
+    () => validate(repoRoot),
+    /local links cannot target a symbolic link/,
+  );
+});
+
+test("rejects unresolved links and prohibited punctuation", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "[missing](docs/missing.md)\n");
+  assert.throws(() => validate(repoRoot), /unresolved local link/);
+
+  write(repoRoot, "AGENTS.md", "bad \u2014 punctuation\n");
+  assert.throws(() => validate(repoRoot), /em or en dashes/);
+});
+
+test("validates the architecture guide links, punctuation, and policy example", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "root\n");
+  write(
+    repoRoot,
+    ARCHITECTURE_GUIDE,
+    VALID_GUIDE.replace("# Guide", "# Guide\n\n[Missing](missing.md)"),
+  );
+  assert.throws(() => validate(repoRoot), /unresolved local link/);
+
+  write(
+    repoRoot,
+    ARCHITECTURE_GUIDE,
+    VALID_GUIDE.replace("# Guide", "# Guide\n\nBad \u2014 punctuation."),
+  );
+  assert.throws(() => validate(repoRoot), /em or en dashes/);
+
+  write(
+    repoRoot,
+    ARCHITECTURE_GUIDE,
+    VALID_GUIDE.replace(
+      "  allow_implicit_invocation",
+      "allow_implicit_invocation",
+    ),
+  );
+  assert.throws(
+    () => validate(repoRoot),
+    /allow_implicit_invocation indented two spaces under policy/,
+  );
+});
+
+test("requires root and descendant instruction CODEOWNER rules", (t) => {
+  const repoRoot = fixture(t);
+  write(repoRoot, "AGENTS.md", "root\n");
+  for (const missingRule of [
+    "/AGENTS.md @AubreyF",
+    "**/AGENTS.md @AubreyF",
+    "**/AGENTS.override.md @AubreyF",
+  ]) {
+    write(
+      repoRoot,
+      CODEOWNERS_FILE,
+      VALID_CODEOWNERS.replace(missingRule + "\n", ""),
+    );
+    assert.throws(
+      () => validate(repoRoot),
+      new RegExp(missingRule.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")),
+    );
+  }
+});

--- a/scripts/validate-skills.mjs
+++ b/scripts/validate-skills.mjs
@@ -3,31 +3,82 @@
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import yaml from "js-yaml";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const REPO_ROOT = path.resolve(__dirname, "..");
 export const SKILLS_DIR = path.join(REPO_ROOT, ".agents", "skills");
+export const MAX_SKILL_BYTES = 16 * 1024;
+
+function parseYamlMapping(text, file, label) {
+  let value;
+  try {
+    value = yaml.load(text);
+  } catch (error) {
+    throw new Error(
+      `${file}: invalid ${label} YAML: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${file}: ${label} must be a YAML mapping.`);
+  }
+  return value;
+}
 
 function parseFrontmatter(text, file) {
   const match = String(text).match(/^---\n([\s\S]*?)\n---\n/);
   if (!match) throw new Error(`${file}: missing YAML frontmatter.`);
-  const fields = {};
-  for (const line of match[1].split("\n")) {
-    const field = line.match(/^([a-z0-9-]+):\s*(.*)$/i);
-    if (!field)
-      throw new Error(`${file}: unsupported frontmatter line ${line}.`);
-    if (Object.hasOwn(fields, field[1])) {
-      throw new Error(`${file}: duplicate frontmatter field ${field[1]}.`);
-    }
-    fields[field[1]] = field[2].trim();
-  }
-  return fields;
+  return parseYamlMapping(match[1], file, "frontmatter");
 }
 
-function checkedInPath(repoRoot, skillDir, reference) {
-  const withoutAnchor = reference.split("#", 1)[0];
-  if (!withoutAnchor || /^(?:https?:|mailto:)/.test(withoutAnchor)) return null;
-  return path.resolve(skillDir, withoutAnchor);
+function checkedInPath(sourceDir, reference) {
+  const withoutFragment = reference.split(/[?#]/, 1)[0];
+  if (!withoutFragment || /^[a-z][a-z0-9+.-]*:/i.test(withoutFragment)) {
+    return null;
+  }
+  return path.resolve(sourceDir, withoutFragment);
+}
+
+function collectMarkdownFiles(directory) {
+  if (!existsSync(directory)) return [];
+  const files = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const absolutePath = path.join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(absolutePath));
+    } else if (entry.isFile() && /\.(?:md|markdown)$/i.test(entry.name)) {
+      files.push(path.resolve(absolutePath));
+    }
+  }
+  return files.sort();
+}
+
+function validatePortableMarkdown(text, file) {
+  if (/[\u2013\u2014]/.test(text)) {
+    throw new Error(
+      `${file}: use standard punctuation instead of em or en dashes.`,
+    );
+  }
+  if (text.includes("freed.wtf/app")) {
+    throw new Error(`${file}: the PWA URL must be app.freed.wtf.`);
+  }
+}
+
+function validateLocalLinks(text, file, repoRoot) {
+  const links = [...text.matchAll(/\]\(([^)]+)\)/g)].map((match) => match[1]);
+  const resolvedLinks = [];
+  for (const reference of links) {
+    const resolved = checkedInPath(path.dirname(file), reference);
+    if (
+      resolved &&
+      (!resolved.startsWith(`${path.resolve(repoRoot)}${path.sep}`) ||
+        !existsSync(resolved))
+    ) {
+      throw new Error(`${file}: unresolved checked-in link ${reference}.`);
+    }
+    if (resolved) resolvedLinks.push(resolved);
+  }
+  return resolvedLinks;
 }
 
 export function validateSkillDirectory(
@@ -37,49 +88,101 @@ export function validateSkillDirectory(
   const skillFile = path.join(skillDir, "SKILL.md");
   if (!existsSync(skillFile)) throw new Error(`${skillDir}: missing SKILL.md.`);
   const text = readFileSync(skillFile, "utf8");
+  const skillBytes = Buffer.byteLength(text, "utf8");
+  if (skillBytes > MAX_SKILL_BYTES) {
+    throw new Error(
+      `${skillFile}: SKILL.md is ${skillBytes.toLocaleString()} bytes; entrypoints must be at most ${MAX_SKILL_BYTES.toLocaleString()} bytes. Move conditional detail into references/.`,
+    );
+  }
   const fields = parseFrontmatter(text, skillFile);
   const expectedName = path.basename(skillDir);
+  if (Object.hasOwn(fields, "disable-model-invocation")) {
+    throw new Error(
+      `${skillFile}: remove legacy disable-model-invocation and configure agents/openai.yaml policy instead.`,
+    );
+  }
+  const unsupportedFields = Object.keys(fields).filter(
+    (field) => field !== "name" && field !== "description",
+  );
+  if (unsupportedFields.length > 0) {
+    throw new Error(
+      `${skillFile}: frontmatter allows only name and description; remove ${unsupportedFields.join(", ")}.`,
+    );
+  }
+  if (
+    typeof fields.name !== "string" ||
+    typeof fields.description !== "string"
+  ) {
+    throw new Error(`${skillFile}: name and description must be strings.`);
+  }
   if (fields.name !== expectedName) {
     throw new Error(`${skillFile}: name must match directory ${expectedName}.`);
   }
-  if (!fields.description)
+  if (!fields.description.trim()) {
     throw new Error(`${skillFile}: description is required.`);
-  if (fields["disable-model-invocation"] !== "true") {
-    throw new Error(`${skillFile}: disable-model-invocation must remain true.`);
   }
-  if (/[\u2013\u2014]/.test(text)) {
-    throw new Error(
-      `${skillFile}: use standard punctuation instead of em or en dashes.`,
-    );
-  }
-  if (text.includes("freed.wtf/app")) {
-    throw new Error(`${skillFile}: the PWA URL must be app.freed.wtf.`);
-  }
+  validatePortableMarkdown(text, skillFile);
   const agentFile = path.join(skillDir, "agents", "openai.yaml");
   if (!existsSync(agentFile))
     throw new Error(`${skillDir}: missing agents/openai.yaml.`);
   const agentText = readFileSync(agentFile, "utf8");
+  const agentConfig = parseYamlMapping(agentText, agentFile, "configuration");
+  const interfaceFields = agentConfig.interface;
+  if (
+    !interfaceFields ||
+    typeof interfaceFields !== "object" ||
+    Array.isArray(interfaceFields)
+  ) {
+    throw new Error(`${agentFile}: one top-level interface block is required.`);
+  }
   for (const field of ["display_name", "short_description", "default_prompt"]) {
-    if (!new RegExp(`^\\s*${field}:\\s*.+$`, "m").test(agentText)) {
+    if (
+      typeof interfaceFields[field] !== "string" ||
+      !interfaceFields[field].trim()
+    ) {
       throw new Error(`${agentFile}: interface.${field} is required.`);
     }
   }
-  if (!agentText.includes(`$${expectedName}`)) {
+  if (!interfaceFields.default_prompt.includes(`$${expectedName}`)) {
     throw new Error(
       `${agentFile}: default_prompt must invoke $${expectedName}.`,
     );
   }
+  const policyFields = agentConfig.policy;
+  if (
+    !policyFields ||
+    typeof policyFields !== "object" ||
+    Array.isArray(policyFields)
+  ) {
+    throw new Error(`${agentFile}: one top-level policy block is required.`);
+  }
+  if (policyFields.allow_implicit_invocation !== true) {
+    throw new Error(
+      `${agentFile}: policy.allow_implicit_invocation must be explicitly true.`,
+    );
+  }
 
-  const links = [...text.matchAll(/\]\(([^)]+)\)/g)].map((match) => match[1]);
-  for (const reference of links) {
-    const resolved = checkedInPath(repoRoot, skillDir, reference);
-    if (
-      resolved &&
-      (!resolved.startsWith(`${path.resolve(repoRoot)}${path.sep}`) ||
-        !existsSync(resolved))
-    ) {
-      throw new Error(`${skillFile}: unresolved checked-in link ${reference}.`);
-    }
+  const localLinks = validateLocalLinks(text, skillFile, repoRoot);
+  const referenceFiles = [...new Set(localLinks)]
+    .filter((referenceFile) => /\.(?:md|markdown)$/i.test(referenceFile))
+    .sort();
+  const linkedReferenceFiles = new Set(
+    referenceFiles.map((referenceFile) => path.resolve(referenceFile)),
+  );
+  const orphanedReferences = collectMarkdownFiles(
+    path.join(skillDir, "references"),
+  ).filter((referenceFile) => !linkedReferenceFiles.has(referenceFile));
+  if (orphanedReferences.length > 0) {
+    throw new Error(
+      `${skillFile}: every Markdown file under references/ must be linked directly from SKILL.md: ${orphanedReferences
+        .map((referenceFile) => path.relative(skillDir, referenceFile))
+        .join(", ")}.`,
+    );
+  }
+  for (const referenceFile of referenceFiles) {
+    const referenceText = readFileSync(referenceFile, "utf8");
+    validatePortableMarkdown(referenceText, referenceFile);
+    validateLocalLinks(referenceText, referenceFile, repoRoot);
   }
   const commands = [
     ...text.matchAll(/(?:node\s+|\.\/)(scripts\/[A-Za-z0-9._/-]+)/g),
@@ -91,7 +194,7 @@ export function validateSkillDirectory(
       );
     }
   }
-  return { name: expectedName, skillFile, agentFile };
+  return { name: expectedName, skillFile, agentFile, referenceFiles };
 }
 
 export function validateSkills({

--- a/scripts/validate-skills.test.mjs
+++ b/scripts/validate-skills.test.mjs
@@ -10,7 +10,11 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
-import { validateSkillDirectory, validateSkills } from "./validate-skills.mjs";
+import {
+  MAX_SKILL_BYTES,
+  validateSkillDirectory,
+  validateSkills,
+} from "./validate-skills.mjs";
 
 test("checked-in Freed skills keep safe invocation and resolvable commands", () => {
   const skills = validateSkills();
@@ -29,6 +33,7 @@ test("checked-in Freed skills keep safe invocation and resolvable commands", () 
     "freed-stability-controller",
     "freed-sync-replay",
     "freed-triage",
+    "freed-ui-polish",
   ]) {
     assert.ok(skillNames.has(requiredName), requiredName);
   }
@@ -50,40 +55,110 @@ test("feature tasks refresh policy before owner authorization", () => {
     "startup freshness must precede the authorization policy",
   );
   assert.match(agentInstructions, /git show <remote-ref>:AGENTS\.md/);
-  assert.match(agentInstructions, /Internal actor labels[\s\S]*never replace or rename/);
+  assert.match(
+    agentInstructions,
+    /Internal (?:actor )?labels[\s\S]*never replace/,
+  );
   assert.ok(
     featureSkill.indexOf("## Start from current policy") <
       featureSkill.indexOf("## Establish the contract"),
     "the feature skill must refresh policy before establishing authority",
   );
   assert.match(featureSkill, /git show origin\/dev:AGENTS\.md/);
-  assert.match(featureSkill, /must never be presented as owner authorization choices/);
+  assert.match(
+    featureSkill,
+    /must never be presented as owner authorization choices/,
+  );
 });
 
-test("skill validation rejects automatic invocation and missing commands", () => {
+test("skill validation requires the supported implicit invocation policy", (t) => {
   const root = mkdtempSync(path.join(os.tmpdir(), "freed-skill-validator-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
   const skillDir = path.join(root, ".agents", "skills", "unsafe-skill");
   mkdirSync(path.join(skillDir, "agents"), { recursive: true });
   writeFileSync(
     path.join(skillDir, "SKILL.md"),
-    `---\nname: unsafe-skill\ndescription: Unsafe fixture\ndisable-model-invocation: false\n---\n\nRun \`node scripts/missing.mjs\`.\n`,
+    `---\nname: unsafe-skill\ndescription: Unsafe fixture\ndisable-model-invocation: true\n---\n\nRun \`node scripts/missing.mjs\`.\n`,
   );
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `interface:\n  display_name: "Unsafe"\n  short_description: "Fixture"\n  default_prompt: "Use $unsafe-skill."\n\npolicy:\n  allow_implicit_invocation: true\n`,
+  );
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /remove legacy disable-model-invocation/,
+  );
+  const skillText = readFileSync(
+    path.join(skillDir, "SKILL.md"),
+    "utf8",
+  ).replace("disable-model-invocation: true\n", "");
+  writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    skillText.replace(
+      "description: Unsafe fixture\n",
+      "description: Unsafe fixture\nallow-implicit-invocation: true\n",
+    ),
+  );
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /frontmatter allows only name and description/,
+  );
+  writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    skillText.replace(
+      "description: Unsafe fixture",
+      "description:\n  nested: value",
+    ),
+  );
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /name and description must be strings/,
+  );
+  writeFileSync(path.join(skillDir, "SKILL.md"), skillText);
   writeFileSync(
     path.join(skillDir, "agents", "openai.yaml"),
     `interface:\n  display_name: "Unsafe"\n  short_description: "Fixture"\n  default_prompt: "Use $unsafe-skill."\n`,
   );
   assert.throws(
     () => validateSkillDirectory(skillDir, { repoRoot: root }),
-    /disable-model-invocation must remain true/,
+    /one top-level policy block is required/,
   );
-  const skillText = readFileSync(
-    path.join(skillDir, "SKILL.md"),
-    "utf8",
-  ).replace(
-    "disable-model-invocation: false",
-    "disable-model-invocation: true",
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `display_name: "Misplaced"\ninterface:\n  short_description: "Fixture"\n  default_prompt: "Use $unsafe-skill."\n\npolicy:\n  allow_implicit_invocation: true\n`,
   );
-  writeFileSync(path.join(skillDir, "SKILL.md"), skillText);
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /interface\.display_name is required/,
+  );
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `interface:\n  display_name: "Unclosed\n  short_description: "Fixture"\n  default_prompt: "Use $unsafe-skill."\n\npolicy:\n  allow_implicit_invocation: true\n`,
+  );
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /invalid configuration YAML/,
+  );
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `interface:\n  display_name: "Unsafe"\n  short_description: "Fixture"\n  default_prompt: "Use $unsafe-skill."\n\npolicy:\n  allow_implicit_invocation: true\npolicy: { allow_implicit_invocation: false }\n`,
+  );
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /invalid configuration YAML/,
+  );
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `interface:\n  display_name: "Unsafe"\n  short_description: "Fixture"\n  default_prompt: "Use $unsafe-skill."\n\npolicy:\n  allow_implicit_invocation: false\n`,
+  );
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /policy\.allow_implicit_invocation must be explicitly true/,
+  );
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `interface:\n  display_name: "Unsafe"\n  short_description: "Fixture"\n  default_prompt: "Use $unsafe-skill."\n\npolicy:\n  allow_implicit_invocation: true\n`,
+  );
   assert.throws(
     () => validateSkillDirectory(skillDir, { repoRoot: root }),
     /referenced command does not exist/,
@@ -104,5 +179,83 @@ test("skill validation rejects top-level skill directories without SKILL.md", (t
   assert.throws(
     () => validateSkills({ skillsDir, repoRoot: root }),
     /missing SKILL\.md/,
+  );
+});
+
+test("skill entrypoints may reach but not exceed 16 KiB", (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-skill-size-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const skillDir = path.join(root, ".agents", "skills", "bounded-skill");
+  mkdirSync(path.join(skillDir, "agents"), { recursive: true });
+  const skillPrefix =
+    "---\nname: bounded-skill\ndescription: Boundary fixture\n---\n\n";
+  const exactLimit =
+    skillPrefix +
+    "x".repeat(MAX_SKILL_BYTES - Buffer.byteLength(skillPrefix, "utf8"));
+  writeFileSync(path.join(skillDir, "SKILL.md"), exactLimit);
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `interface:\n  display_name: "Bounded"\n  short_description: "Fixture"\n  default_prompt: "Use $bounded-skill."\n\npolicy:\n  allow_implicit_invocation: true\n`,
+  );
+
+  assert.doesNotThrow(() =>
+    validateSkillDirectory(skillDir, { repoRoot: root }),
+  );
+  writeFileSync(path.join(skillDir, "SKILL.md"), `${exactLimit}x`);
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /entrypoints must be at most .* bytes/,
+  );
+});
+
+test("direct Markdown references receive portable content and link checks", (t) => {
+  const root = mkdtempSync(path.join(os.tmpdir(), "freed-skill-reference-"));
+  t.after(() => rmSync(root, { recursive: true, force: true }));
+  const skillDir = path.join(root, ".agents", "skills", "reference-skill");
+  const referencesDir = path.join(skillDir, "references");
+  const referenceFile = path.join(referencesDir, "detail.md");
+  mkdirSync(path.join(skillDir, "agents"), { recursive: true });
+  mkdirSync(referencesDir, { recursive: true });
+  writeFileSync(
+    path.join(skillDir, "SKILL.md"),
+    `---\nname: reference-skill\ndescription: Reference fixture\n---\n\nRead [the detail](references/detail.md).\n`,
+  );
+  writeFileSync(
+    path.join(skillDir, "agents", "openai.yaml"),
+    `interface:\n  display_name: "Reference"\n  short_description: "Fixture"\n  default_prompt: "Use $reference-skill."\n\npolicy:\n  allow_implicit_invocation: true\n`,
+  );
+  writeFileSync(
+    referenceFile,
+    `# Detail\n\n[Existing file](../SKILL.md)\n\n${"x".repeat(MAX_SKILL_BYTES + 1)}\n`,
+  );
+
+  const validated = validateSkillDirectory(skillDir, { repoRoot: root });
+  assert.deepEqual(validated.referenceFiles, [referenceFile]);
+
+  const orphanedReference = path.join(referencesDir, "orphaned.md");
+  writeFileSync(orphanedReference, "# Orphaned\n");
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /every Markdown file under references\/ must be linked directly from SKILL\.md/,
+  );
+  rmSync(orphanedReference);
+
+  writeFileSync(
+    referenceFile,
+    "# Detail\n\nThis contains an em dash \u2014 here.\n",
+  );
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /use standard punctuation instead of em or en dashes/,
+  );
+  writeFileSync(referenceFile, "# Detail\n\nVisit freed.wtf/app.\n");
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /the PWA URL must be app\.freed\.wtf/,
+  );
+  writeFileSync(referenceFile, "# Detail\n\n[Missing](missing.md)\n");
+  assert.throws(
+    () => validateSkillDirectory(skillDir, { repoRoot: root }),
+    /unresolved checked-in link missing\.md/,
   );
 });

--- a/scripts/validate-worktree.mjs
+++ b/scripts/validate-worktree.mjs
@@ -322,23 +322,32 @@ export function collectChangedFiles({ mode, changedFiles }) {
 }
 
 export function isWebsiteSurface(filePath) {
-  return filePath.startsWith("website/");
+  return (
+    filePath.startsWith("website/") && !isAgentInstructionFilePath(filePath)
+  );
 }
 
 export function isSharedSurface(filePath) {
   return (
-    filePath.startsWith("packages/shared/") ||
-    filePath.startsWith("packages/sync/") ||
-    filePath.startsWith("packages/ui/")
+    !isAgentInstructionFilePath(filePath) &&
+    (filePath.startsWith("packages/shared/") ||
+      filePath.startsWith("packages/sync/") ||
+      filePath.startsWith("packages/ui/"))
   );
 }
 
 export function isDesktopSurface(filePath) {
-  return filePath.startsWith("packages/desktop/");
+  return (
+    filePath.startsWith("packages/desktop/") &&
+    !isAgentInstructionFilePath(filePath)
+  );
 }
 
 export function isPwaSurface(filePath) {
-  return filePath.startsWith("packages/pwa/");
+  return (
+    filePath.startsWith("packages/pwa/") &&
+    !isAgentInstructionFilePath(filePath)
+  );
 }
 
 export function isPwaOpfsDurabilityPath(filePath) {
@@ -453,6 +462,20 @@ export function isSkillValidationPath(filePath) {
     filePath.startsWith(".agents/skills/") ||
     filePath === "scripts/validate-skills.mjs" ||
     filePath === "scripts/validate-skills.test.mjs"
+  );
+}
+
+function isAgentInstructionFilePath(filePath) {
+  return /(?:^|\/)AGENTS(?:\.override)?\.md$/.test(filePath);
+}
+
+export function isAgentInstructionValidationPath(filePath) {
+  return (
+    isAgentInstructionFilePath(filePath) ||
+    filePath === "docs/AGENT-INSTRUCTIONS.md" ||
+    filePath === ".github/CODEOWNERS" ||
+    filePath === "scripts/validate-agent-instructions.mjs" ||
+    filePath === "scripts/validate-agent-instructions.test.mjs"
   );
 }
 
@@ -612,9 +635,7 @@ function socialProviderFocusedE2eCommand() {
 }
 
 function pwaTestCommands() {
-  return [
-    npmCommand("pwa unit tests", ["run", "test:unit"], "packages/pwa"),
-  ];
+  return [npmCommand("pwa unit tests", ["run", "test:unit"], "packages/pwa")];
 }
 
 function pwaOpfsDurabilityCommand() {
@@ -885,6 +906,11 @@ export function buildValidationPlan(mode, changedFiles) {
       npmCommand("root build", ["run", "build"]),
       npmCommand("root typecheck", ["run", "typecheck"]),
       npmCommand("root lint", ["run", "lint"]),
+      npmCommand("agent instruction validation", [
+        "run",
+        "validate:agent-instructions",
+      ]),
+      npmCommand("skill validation", ["run", "validate:skills"]),
       npmCommand("website tests", ["run", "test"], "website"),
       npmCommand("shared unit tests", ["run", "test"], "packages/shared"),
       npmCommand(
@@ -893,9 +919,7 @@ export function buildValidationPlan(mode, changedFiles) {
         "packages/library-service",
       ),
       ...pwaTestCommands(),
-      ...(shouldRunPwaOpfsDurability()
-        ? [pwaOpfsDurabilityCommand()]
-        : []),
+      ...(shouldRunPwaOpfsDurability() ? [pwaOpfsDurabilityCommand()] : []),
       npmCommand(
         "desktop unit tests",
         ["run", "test:unit"],
@@ -1040,35 +1064,41 @@ export function buildValidationPlan(mode, changedFiles) {
   }
 
   const plan = [npmCommand("root typecheck", ["run", "typecheck"])];
-  const sharedPackageChanged = changedFiles.some((filePath) =>
+  const productFiles = changedFiles.filter(
+    (filePath) => !isAgentInstructionFilePath(filePath),
+  );
+  const sharedPackageChanged = productFiles.some((filePath) =>
     filePath.startsWith("packages/shared/"),
   );
-  const syncPackageChanged = changedFiles.some((filePath) =>
+  const syncPackageChanged = productFiles.some((filePath) =>
     filePath.startsWith("packages/sync/"),
   );
-  const libraryServicePackageChanged = changedFiles.some((filePath) =>
+  const libraryServicePackageChanged = productFiles.some((filePath) =>
     filePath.startsWith("packages/library-service/"),
   );
   const sharedSurfaceChanged = changedFiles.some(isSharedSurface);
   const desktopSurfaceChanged =
     sharedSurfaceChanged || changedFiles.some(isDesktopSurface);
-  const libraryCoreNativeSurfaceChanged = changedFiles.some((filePath) =>
+  const libraryCoreNativeSurfaceChanged = productFiles.some((filePath) =>
     filePath.startsWith("packages/library-core-native/"),
   );
   const desktopNativeSurfaceChanged =
     libraryCoreNativeSurfaceChanged ||
-    changedFiles.some(isDesktopNativeSurface);
+    productFiles.some(isDesktopNativeSurface);
   const pwaSurfaceChanged =
     sharedSurfaceChanged || changedFiles.some(isPwaSurface);
-  const pwaOpfsDurabilityChanged = changedFiles.some(isPwaOpfsDurabilityPath);
+  const pwaOpfsDurabilityChanged = productFiles.some(isPwaOpfsDurabilityPath);
   const websiteSurfaceChanged = changedFiles.some(isWebsiteSurface);
-  const releaseToolingChanged = changedFiles.some(
+  const releaseToolingChanged = productFiles.some(
     (filePath) =>
       filePath.startsWith("release-notes/") ||
       RELEASE_TOOLING_PATHS.has(filePath),
   );
-  const libraryCoreReleaseActivationChanged = changedFiles.some(
+  const libraryCoreReleaseActivationChanged = productFiles.some(
     isLibraryCoreReleaseActivationPath,
+  );
+  const agentInstructionValidationChanged = changedFiles.some(
+    isAgentInstructionValidationPath,
   );
   const skillValidationChanged = changedFiles.some(isSkillValidationPath);
   const releaseAdmissionChanged = changedFiles.some(isReleaseAdmissionPath);
@@ -1091,16 +1121,16 @@ export function buildValidationPlan(mode, changedFiles) {
   const stabilityStatusChanged = changedFiles.some(isStabilityStatusPath);
   const roadmapStatusChanged = changedFiles.some(isRoadmapStatusPath);
   const captureWorkspaces = unique(
-    changedFiles.map(captureWorkspaceForFile).filter(Boolean),
+    productFiles.map(captureWorkspaceForFile).filter(Boolean),
   ).sort();
   const socialProviderOnlyChanged =
-    changedFiles.length > 0 &&
-    changedFiles.every(isSocialProviderFocusedSurface);
-  const providerVisibleChanged = changedFiles.some(isProviderVisiblePath);
-  const socialProviderVisibleChanged = changedFiles.some((filePath) =>
+    productFiles.length > 0 &&
+    productFiles.every(isSocialProviderFocusedSurface);
+  const providerVisibleChanged = productFiles.some(isProviderVisiblePath);
+  const socialProviderVisibleChanged = productFiles.some((filePath) =>
     providerIdsForPath(filePath).some((provider) => provider !== "other"),
   );
-  const desktopRustSurfaceChanged = changedFiles.some(
+  const desktopRustSurfaceChanged = productFiles.some(
     (filePath) =>
       filePath.startsWith("packages/desktop/src-tauri/") &&
       filePath.endsWith(".rs"),
@@ -1142,7 +1172,7 @@ export function buildValidationPlan(mode, changedFiles) {
         "packages/desktop",
       ),
     );
-    return plan;
+    if (!agentInstructionValidationChanged) return plan;
   }
 
   if (providerVisibleChanged && socialProviderVisibleChanged) {
@@ -1280,6 +1310,23 @@ export function buildValidationPlan(mode, changedFiles) {
         path.join("scripts", "lib", "github-release-publications.test.mjs"),
         path.join("scripts", "lib", "library-core-release-activation.test.mjs"),
         path.join("scripts", "validate-release-identity.test.mjs"),
+      ]),
+    );
+  }
+
+  if (agentInstructionValidationChanged) {
+    addCommand(
+      plan,
+      nodeCommand("agent instruction validation tests", [
+        "--test",
+        path.join("scripts", "validate-agent-instructions.test.mjs"),
+      ]),
+    );
+    addCommand(
+      plan,
+      npmCommand("agent instruction validation", [
+        "run",
+        "validate:agent-instructions",
       ]),
     );
   }

--- a/scripts/validate-worktree.test.mjs
+++ b/scripts/validate-worktree.test.mjs
@@ -8,6 +8,7 @@ import {
   collectReleaseArtifactsToValidate,
   describePlan,
   executeReleaseIdentityValidation,
+  isAgentInstructionValidationPath,
   isDesktopNativeSurface,
   isLibraryCoreReleaseActivationPath,
   isPwaOpfsDurabilityPath,
@@ -622,6 +623,8 @@ test("stability status paths route focused tests in feature and dev plans", () =
 test("dev plan runs deterministic desktop lanes and leaves raw timing to nightly", () => {
   const labels = describePlan(buildValidationPlan("dev", []));
 
+  assert.ok(labels.includes("agent instruction validation"));
+  assert.ok(labels.includes("skill validation"));
   assert.ok(labels.includes("desktop e2e smoke"));
   assert.ok(labels.includes("desktop e2e regression"));
   assert.ok(!labels.includes("desktop e2e perf"));
@@ -639,6 +642,8 @@ test("dev plan runs deterministic desktop lanes and leaves raw timing to nightly
 test("production plan includes dev desktop gates without duplicating shipped builds", () => {
   const labels = describePlan(buildValidationPlan("production", []));
 
+  assert.ok(labels.includes("agent instruction validation"));
+  assert.ok(labels.includes("skill validation"));
   assert.ok(labels.includes("desktop e2e smoke"));
   assert.ok(labels.includes("desktop e2e regression"));
   assert.ok(!labels.includes("desktop e2e perf"));
@@ -811,6 +816,79 @@ test("every Freed skill and its validator route focused skill checks", () => {
     assert.ok(labels.includes("skill validation tests"), filePath);
     assert.ok(labels.includes("skill validation"), filePath);
   }
+});
+
+test("instruction-only paths route exactly the focused instruction checks", () => {
+  for (const filePath of [
+    "AGENTS.md",
+    ".github/CODEOWNERS",
+    "docs/AGENT-INSTRUCTIONS.md",
+    "docs/AGENTS.md",
+    "packages/capture-facebook/AGENTS.md",
+    "packages/desktop/AGENTS.md",
+    "packages/desktop/AGENTS.override.md",
+    "packages/desktop/src-tauri/AGENTS.md",
+    "packages/pwa/AGENTS.md",
+    "packages/pwa/src/lib/library-core-sqlite/AGENTS.md",
+    "packages/shared/AGENTS.md",
+    "packages/shared/src/library-core/AGENTS.md",
+    "packages/ui/AGENTS.md",
+    "scripts/AGENTS.md",
+    "scripts/validate-agent-instructions.mjs",
+    "scripts/validate-agent-instructions.test.mjs",
+    "website/AGENTS.md",
+  ]) {
+    assert.equal(isAgentInstructionValidationPath(filePath), true, filePath);
+    const labels = describePlan(buildValidationPlan("feature", [filePath]));
+    assert.deepEqual(
+      labels,
+      [
+        "root typecheck",
+        "agent instruction validation tests",
+        "agent instruction validation",
+      ],
+      filePath,
+    );
+  }
+});
+
+test("skill authoring instructions route both focused validators", () => {
+  assert.deepEqual(
+    describePlan(buildValidationPlan("feature", [".agents/skills/AGENTS.md"])),
+    [
+      "root typecheck",
+      "agent instruction validation tests",
+      "agent instruction validation",
+      "skill validation tests",
+      "skill validation",
+    ],
+  );
+});
+
+test("scoped instructions do not hide product changes in the same package", () => {
+  const labels = describePlan(
+    buildValidationPlan("feature", [
+      "packages/ui/AGENTS.md",
+      "packages/ui/src/components/Example.tsx",
+    ]),
+  );
+  assert.ok(labels.includes("pwa production build"));
+  assert.ok(labels.includes("desktop e2e smoke"));
+  assert.ok(labels.includes("agent instruction validation"));
+});
+
+test("provider code cannot bypass validation of a changed instruction file", () => {
+  const labels = describePlan(
+    buildValidationPlan("feature", [
+      "packages/capture-facebook/AGENTS.md",
+      "packages/capture-facebook/src/index.ts",
+    ]),
+  );
+  assert.ok(labels.includes("desktop social provider unit tests"));
+  assert.ok(labels.includes("desktop social provider e2e"));
+  assert.ok(labels.includes("packages/capture-facebook typecheck"));
+  assert.ok(labels.includes("agent instruction validation tests"));
+  assert.ok(labels.includes("agent instruction validation"));
 });
 
 test("feature plan routes every Release Publisher surface through its full suite", () => {


### PR DESCRIPTION
(AI Generated).

## Summary

- Replace the 47,155-byte root policy with a 15,244-byte governance kernel and scoped instructions for skills, docs, scripts, Desktop, PWA, shared code, and UI.
- Replace the ignored legacy skill flag with Codex's supported implicit invocation policy for all 14 Freed skills.
- Split the Library Core workflow into a 6,419-byte entrypoint and six references that retain every operative line from the prior 52,839-byte file.
- Add a focused UI polish skill and one visual contract shared by Desktop, PWA, and UI work.
- Add checks for instruction budgets, scope routing, symlink escapes, CODEOWNER routing, skill YAML, invocation policy, reference reachability, and changed-path validation.
- Move Desktop E2E fixture and mock mechanics into the test suite's own guide.

## Validation

- `npm run validate:feature` on `d6fd4527..4410151a`
- 5 WebKit OPFS durability tests
- 793 Desktop unit tests
- 9 Desktop E2E smoke tests
- 22 release note tests
- 73 Library Core and release identity tests
- 106 instruction, skill, tooling smoke, and validation routing tests
- Exact source comparison for all six extracted Library Core sections, excluding only four old inter-section blank separators
- Prettier and `git diff --check`

## Governance and follow-up

- CODEOWNERS now routes root and nested instruction changes to `@AubreyF`. Current branch settings do not require that review, so this is review routing rather than mechanical protection.
- #1782 tracks splitting the generated 125,996-byte Library Core contract into routed normative chapters.
- Website lane instructions are intentionally absent from this product lane change. They will use a separate `www` pull request.
- Normal production promotion will carry the reviewed product policy to `main`.