### PR TITLE
feat: add in-app newsletter signup flow

### DIFF
--- a/website/.env.example
+++ b/website/.env.example
@@ -10,3 +10,9 @@ BREVO_LIST_ID=123
 # Site key is safe for the browser. Secret key must stay server-side.
 NEXT_PUBLIC_TURNSTILE_SITE_KEY=your-turnstile-site-key
 TURNSTILE_SECRET_KEY=your-turnstile-secret-key
+
+# Optional comma-separated overrides for the app origins and Turnstile hostnames
+# accepted by the newsletter endpoint. Defaults cover Freed's public, dev, and
+# demo origins. Localhost is accepted only outside production.
+NEWSLETTER_ALLOWED_ORIGINS=
+NEWSLETTER_ALLOWED_TURNSTILE_HOSTNAMES=

--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -5,8 +5,22 @@ const nextConfig: NextConfig = {
   poweredByHeader: false,
   transpilePackages: ["@freed/shared", "@freed/ui"],
   env: {
-    NEXT_PUBLIC_TURNSTILE_SITE_KEY:
-      process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
+    NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,
+  },
+
+  async headers() {
+    return [
+      {
+        source: "/newsletter/embed",
+        headers: [
+          {
+            key: "Content-Security-Policy",
+            value:
+              "frame-ancestors 'self' tauri: http://tauri.localhost https://tauri.localhost http://localhost:* https://localhost:*",
+          },
+        ],
+      },
+    ];
   },
 
   async redirects() {

--- a/website/package.json
+++ b/website/package.json
@@ -13,6 +13,7 @@
     "start": "next start",
     "generate-feed": "npx tsx scripts/generate-feed.ts",
     "lint": "eslint .",
+    "test:newsletter": "npx tsx src/app/api/subscribe/newsletter-security.test.ts",
     "test:e2e": "node ../node_modules/playwright/cli.js test -c playwright.config.ts"
   },
   "dependencies": {

--- a/website/src/app/api/subscribe/newsletter-security.test.ts
+++ b/website/src/app/api/subscribe/newsletter-security.test.ts
@@ -1,0 +1,183 @@
+import assert from "node:assert/strict";
+import nextConfig from "../../../../next.config";
+import {
+  isAllowedNewsletterOrigin,
+  isAllowedTurnstileHostname,
+  newsletterCorsHeaders,
+} from "./newsletter-security";
+import { OPTIONS, POST } from "./route";
+
+assert.equal(
+  isAllowedNewsletterOrigin("https://app.freed.wtf", { nodeEnv: "production" }),
+  true,
+);
+assert.equal(
+  isAllowedNewsletterOrigin("https://attacker.example", {
+    nodeEnv: "production",
+  }),
+  false,
+);
+assert.equal(
+  isAllowedNewsletterOrigin("http://localhost:1421", {
+    nodeEnv: "development",
+  }),
+  true,
+);
+assert.equal(
+  isAllowedNewsletterOrigin("http://localhost:1421", { nodeEnv: "production" }),
+  false,
+);
+
+assert.equal(
+  isAllowedTurnstileHostname("app.freed.wtf", { nodeEnv: "production" }),
+  true,
+);
+assert.equal(
+  isAllowedTurnstileHostname("attacker.example", { nodeEnv: "production" }),
+  false,
+);
+assert.equal(
+  isAllowedTurnstileHostname("localhost", { nodeEnv: "development" }),
+  true,
+);
+assert.equal(
+  isAllowedTurnstileHostname("localhost", { nodeEnv: "production" }),
+  false,
+);
+
+assert.deepEqual(newsletterCorsHeaders("https://app.freed.wtf"), {
+  "Access-Control-Allow-Origin": "https://app.freed.wtf",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+  "Access-Control-Allow-Headers": "Content-Type",
+  "Access-Control-Max-Age": "86400",
+  Vary: "Origin",
+});
+
+const headerRules = await nextConfig.headers?.();
+const embedFramePolicy = headerRules
+  ?.find((rule) => rule.source === "/newsletter/embed")
+  ?.headers.find((header) => header.key === "Content-Security-Policy")?.value;
+assert.match(embedFramePolicy ?? "", /(?:^|\s)http:\/\/tauri\.localhost(?:\s|$)/);
+assert.match(embedFramePolicy ?? "", /(?:^|\s)https:\/\/tauri\.localhost(?:\s|$)/);
+
+console.log("newsletter security contract passed");
+
+const originalFetch = globalThis.fetch;
+process.env.NODE_ENV = "production";
+process.env.TURNSTILE_SECRET_KEY = "server-only-secret";
+process.env.BREVO_API_KEY = "brevo-secret";
+process.env.BREVO_LIST_ID = "42";
+
+const calls: string[] = [];
+globalThis.fetch = async (input) => {
+  const url = String(input);
+  calls.push(url);
+  if (url.includes("siteverify")) {
+    return Response.json({
+      success: true,
+      hostname: "app.freed.wtf",
+      action: "newsletter_signup",
+    });
+  }
+  return new Response(null, { status: 201 });
+};
+
+const appRequest = new Request("https://freed.wtf/api/subscribe", {
+  method: "POST",
+  headers: {
+    Origin: "https://app.freed.wtf",
+    "Content-Type": "application/json",
+    "x-forwarded-for": "192.0.2.20",
+  },
+  body: JSON.stringify({
+    email: "reader@example.com",
+    name: "Reader Name",
+    turnstileToken: "verified-token",
+  }),
+});
+const appResponse = await POST(appRequest as Parameters<typeof POST>[0]);
+assert.equal(appResponse.status, 200);
+assert.equal(
+  appResponse.headers.get("access-control-allow-origin"),
+  "https://app.freed.wtf",
+);
+assert.equal(calls.length, 2);
+
+const preflightResponse = await OPTIONS(
+  new Request("https://freed.wtf/api/subscribe", {
+    method: "OPTIONS",
+    headers: { Origin: "https://app.freed.wtf" },
+  }) as Parameters<typeof OPTIONS>[0],
+);
+assert.equal(preflightResponse.status, 204);
+assert.equal(
+  preflightResponse.headers.get("access-control-allow-origin"),
+  "https://app.freed.wtf",
+);
+
+const attackerResponse = await POST(
+  new Request("https://freed.wtf/api/subscribe", {
+    method: "POST",
+    headers: {
+      Origin: "https://attacker.example",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      email: "attacker@example.com",
+      name: "Attacker",
+      turnstileToken: "verified-token",
+    }),
+  }) as Parameters<typeof POST>[0],
+);
+assert.equal(attackerResponse.status, 403);
+assert.equal(attackerResponse.headers.get("access-control-allow-origin"), null);
+assert.equal(calls.length, 2);
+
+globalThis.fetch = async (input) => {
+  calls.push(String(input));
+  return Response.json({ success: true, hostname: "app.freed.wtf" });
+};
+const actionlessResponse = await POST(
+  new Request("https://freed.wtf/api/subscribe", {
+    method: "POST",
+    headers: {
+      Origin: "https://app.freed.wtf",
+      "Content-Type": "application/json",
+      "x-forwarded-for": "192.0.2.22",
+    },
+    body: JSON.stringify({
+      email: "actionless@example.com",
+      name: "Actionless Attempt",
+      turnstileToken: "verified-token",
+    }),
+  }) as Parameters<typeof POST>[0],
+);
+assert.equal(actionlessResponse.status, 400);
+
+globalThis.fetch = async (input) => {
+  calls.push(String(input));
+  return Response.json({
+    success: false,
+    "error-codes": ["invalid-input-response"],
+  });
+};
+const bypassResponse = await POST(
+  new Request("https://freed.wtf/api/subscribe", {
+    method: "POST",
+    headers: {
+      Origin: "https://app.freed.wtf",
+      "Content-Type": "application/json",
+      "x-forwarded-for": "192.0.2.21",
+    },
+    body: JSON.stringify({
+      email: "bypass@example.com",
+      name: "Bypass Attempt",
+      turnstileToken: "turnstile-unavailable",
+    }),
+  }) as Parameters<typeof POST>[0],
+);
+assert.equal(bypassResponse.status, 400);
+assert.equal(calls.filter((url) => url.includes("siteverify")).length, 3);
+
+globalThis.fetch = originalFetch;
+console.log("newsletter route contract passed");

--- a/website/src/app/api/subscribe/newsletter-security.ts
+++ b/website/src/app/api/subscribe/newsletter-security.ts
@@ -1,0 +1,75 @@
+const DEFAULT_ALLOWED_ORIGINS = new Set([
+  "https://freed.wtf",
+  "https://www.freed.wtf",
+  "https://app.freed.wtf",
+  "https://dev-app.freed.wtf",
+  "https://demo.freed.wtf",
+]);
+
+const DEFAULT_ALLOWED_TURNSTILE_HOSTNAMES = new Set([
+  "freed.wtf",
+  "www.freed.wtf",
+  "app.freed.wtf",
+  "dev-app.freed.wtf",
+  "demo.freed.wtf",
+]);
+
+function configuredValues(value: string | undefined): Set<string> | null {
+  if (!value?.trim()) return null;
+  return new Set(
+    value
+      .split(",")
+      .map((entry) => entry.trim())
+      .filter(Boolean),
+  );
+}
+
+function isLocalDevelopmentOrigin(origin: string): boolean {
+  try {
+    const url = new URL(origin);
+    return (
+      (url.protocol === "http:" || url.protocol === "https:") &&
+      (url.hostname === "localhost" || url.hostname === "127.0.0.1")
+    );
+  } catch {
+    return false;
+  }
+}
+
+export function isAllowedNewsletterOrigin(
+  origin: string,
+  options: { configuredOrigins?: string; nodeEnv?: string } = {},
+): boolean {
+  if (!origin) return true;
+  const configured = configuredValues(options.configuredOrigins);
+  if ((configured ?? DEFAULT_ALLOWED_ORIGINS).has(origin)) return true;
+  return options.nodeEnv !== "production" && isLocalDevelopmentOrigin(origin);
+}
+
+export function isAllowedTurnstileHostname(
+  hostname: string | undefined,
+  options: { configuredHostnames?: string; nodeEnv?: string } = {},
+): boolean {
+  if (!hostname) return false;
+  const configured = configuredValues(options.configuredHostnames);
+  if ((configured ?? DEFAULT_ALLOWED_TURNSTILE_HOSTNAMES).has(hostname))
+    return true;
+  return (
+    options.nodeEnv !== "production" &&
+    (hostname === "localhost" || hostname === "127.0.0.1")
+  );
+}
+
+export function newsletterCorsHeaders(origin: string): Record<string, string> {
+  return origin
+    ? {
+        "Access-Control-Allow-Origin": origin,
+        "Access-Control-Allow-Methods": "POST, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type",
+        "Access-Control-Max-Age": "86400",
+        Vary: "Origin",
+      }
+    : {
+        Vary: "Origin",
+      };
+}

--- a/website/src/app/api/subscribe/route.ts
+++ b/website/src/app/api/subscribe/route.ts
@@ -10,6 +10,11 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
+import {
+  isAllowedNewsletterOrigin,
+  isAllowedTurnstileHostname,
+  newsletterCorsHeaders,
+} from "./newsletter-security";
 
 const BREVO_CONTACTS_ENDPOINT = "https://api.brevo.com/v3/contacts";
 const TURNSTILE_VERIFY_ENDPOINT =
@@ -17,8 +22,6 @@ const TURNSTILE_VERIFY_ENDPOINT =
 const RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
 const RATE_LIMIT_MAX_REQUESTS = 6;
 const EMAIL_COOLDOWN_MS = 60 * 1000;
-const TURNSTILE_UNAVAILABLE_TOKEN = "turnstile-unavailable";
-
 const requestBuckets = new Map<string, { count: number; resetAt: number }>();
 const recentEmailSubmissions = new Map<string, number>();
 
@@ -38,7 +41,16 @@ interface BrevoError {
 interface TurnstileVerificationResponse {
   success: boolean;
   hostname?: string;
+  action?: string;
   "error-codes"?: string[];
+}
+
+function requiresAppChallengeAction(origin: string): boolean {
+  return (
+    Boolean(origin) &&
+    origin !== "https://freed.wtf" &&
+    origin !== "https://www.freed.wtf"
+  );
 }
 
 function isValidEmail(email: string): boolean {
@@ -147,23 +159,39 @@ async function verifyTurnstileToken(
 }
 
 export async function POST(request: NextRequest) {
+  const origin = request.headers.get("origin")?.trim() ?? "";
+  const securityOptions = {
+    configuredOrigins: process.env.NEWSLETTER_ALLOWED_ORIGINS,
+    configuredHostnames: process.env.NEWSLETTER_ALLOWED_TURNSTILE_HOSTNAMES,
+    nodeEnv: process.env.NODE_ENV,
+  };
+  const respond = (body: object, status = 200) =>
+    NextResponse.json(body, {
+      status,
+      headers: newsletterCorsHeaders(origin),
+    });
+
+  if (!isAllowedNewsletterOrigin(origin, securityOptions)) {
+    return NextResponse.json({ error: "Origin not allowed" }, { status: 403 });
+  }
+
   try {
-    const body = await request.json().catch(() => null) as SubscribeRequest | null;
+    const body = (await request
+      .json()
+      .catch(() => null)) as SubscribeRequest | null;
 
     if (!body || typeof body !== "object") {
-      return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+      return respond({ error: "Invalid request body" }, 400);
     }
 
     const normalizedEmail = (body.email ?? "").trim().toLowerCase();
     const normalizedName = (body.name ?? "").trim();
     const normalizedPhoneNumber = normalizePhoneNumber(body.phoneNumber ?? "");
     const turnstileToken = (body.turnstileToken ?? "").trim();
-    const isTurnstileUnavailable =
-      turnstileToken === TURNSTILE_UNAVAILABLE_TOKEN;
     const honeypotValue = (body.company ?? "").trim();
 
     if (honeypotValue) {
-      return NextResponse.json({
+      return respond({
         success: true,
         message: "Successfully subscribed",
       });
@@ -171,64 +199,75 @@ export async function POST(request: NextRequest) {
 
     // Validate email
     if (!normalizedEmail || !isValidEmail(normalizedEmail)) {
-      return NextResponse.json(
-        { error: "Invalid email address" },
-        { status: 400 }
-      );
+      return respond({ error: "Invalid email address" }, 400);
     }
 
     if (!normalizedName) {
-      return NextResponse.json(
-        { error: "Please tell us your name." },
-        { status: 400 }
-      );
+      return respond({ error: "Please tell us your name." }, 400);
     }
 
     if (!isValidPhoneNumber(body.phoneNumber ?? "")) {
-      return NextResponse.json(
+      return respond(
         { error: "Please enter a valid phone number or leave it blank." },
-        { status: 400 }
+        400,
       );
     }
 
     if (!turnstileToken) {
-      return NextResponse.json(
+      return respond(
         { error: "Please complete the human check and try again." },
-        { status: 400 }
+        400,
       );
     }
 
     const requestIp = getRequestIp(request);
 
     if (isRateLimited(`newsletter:${requestIp}`)) {
-      return NextResponse.json(
-        { error: "Too many signup attempts. Please wait a minute and try again." },
-        { status: 429 }
+      return respond(
+        {
+          error:
+            "Too many signup attempts. Please wait a minute and try again.",
+        },
+        429,
       );
     }
 
-    if (!isTurnstileUnavailable) {
-      const turnstileResult = await verifyTurnstileToken(turnstileToken, request);
+    const turnstileResult = await verifyTurnstileToken(turnstileToken, request);
 
-      if (!turnstileResult.success) {
-        const errorCodes = turnstileResult["error-codes"] ?? [];
-        const isExpired = errorCodes.includes("timeout-or-duplicate");
+    if (!turnstileResult.success) {
+      const errorCodes = turnstileResult["error-codes"] ?? [];
+      const isExpired = errorCodes.includes("timeout-or-duplicate");
 
-        return NextResponse.json(
-          {
-            error: isExpired
-              ? "That human check expired. Please try again."
-              : "We could not verify the human check. Please try again.",
-          },
-          { status: 400 }
-        );
-      }
+      return respond(
+        {
+          error: isExpired
+            ? "That human check expired. Please try again."
+            : "We could not verify the human check. Please try again.",
+        },
+        400,
+      );
+    }
+
+    if (
+      !isAllowedTurnstileHostname(turnstileResult.hostname, securityOptions)
+    ) {
+      return respond({ error: "We could not verify the signup source." }, 400);
+    }
+
+    if (
+      requiresAppChallengeAction(origin) &&
+      turnstileResult.action !== "newsletter_signup"
+    ) {
+      return respond({ error: "We could not verify the signup action." }, 400);
     }
 
     if (isEmailCoolingDown(normalizedEmail)) {
-      return NextResponse.json(
-        { error: "Too many signup attempts. Please wait a minute and try again." },
-        { status: 429 }
+      return respond(
+        {
+          error:
+            "Too many signup attempts. Please wait a minute and try again.",
+        },
+        429,
       );
     }
 
@@ -238,22 +277,16 @@ export async function POST(request: NextRequest) {
 
     if (!apiKey || !listId) {
       console.error(
-        "Missing BREVO_API_KEY or BREVO_LIST_ID environment variables"
+        "Missing BREVO_API_KEY or BREVO_LIST_ID environment variables",
       );
-      return NextResponse.json(
-        { error: "Server configuration error" },
-        { status: 500 }
-      );
+      return respond({ error: "Server configuration error" }, 500);
     }
 
     const parsedListId = Number.parseInt(listId, 10);
 
     if (!Number.isFinite(parsedListId) || parsedListId <= 0) {
       console.error("Invalid BREVO_LIST_ID environment variable");
-      return NextResponse.json(
-        { error: "Server configuration error" },
-        { status: 500 }
-      );
+      return respond({ error: "Server configuration error" }, 500);
     }
 
     // Add contact to Brevo
@@ -277,30 +310,45 @@ export async function POST(request: NextRequest) {
 
     // Handle Brevo response
     if (brevoResponse.ok) {
-      return NextResponse.json({
+      return respond({
         success: true,
         message: "Successfully subscribed",
       });
     }
 
     // Handle specific Brevo errors
-    const brevoError = (await brevoResponse.json().catch(() => ({}))) as BrevoError;
+    const brevoError = (await brevoResponse
+      .json()
+      .catch(() => ({}))) as BrevoError;
 
     // Contact already exists (not really an error for our use case)
     if (brevoError.code === "duplicate_parameter") {
-      return NextResponse.json({
+      return respond({
         success: true,
         message: "Already subscribed",
       });
     }
 
     console.error("Brevo API error:", brevoError);
-    return NextResponse.json({ error: "Subscription failed" }, { status: 500 });
+    return respond({ error: "Subscription failed" }, 500);
   } catch (error) {
     console.error("Route handler error:", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return respond({ error: "Internal server error" }, 500);
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  const origin = request.headers.get("origin")?.trim() ?? "";
+  if (
+    !isAllowedNewsletterOrigin(origin, {
+      configuredOrigins: process.env.NEWSLETTER_ALLOWED_ORIGINS,
+      nodeEnv: process.env.NODE_ENV,
+    })
+  ) {
+    return NextResponse.json({ error: "Origin not allowed" }, { status: 403 });
+  }
+  return new NextResponse(null, {
+    status: 204,
+    headers: newsletterCorsHeaders(origin),
+  });
 }

--- a/website/src/app/newsletter/embed/page.tsx
+++ b/website/src/app/newsletter/embed/page.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import NewsletterEmbedForm from "@/components/NewsletterEmbedForm";
+
+export const metadata: Metadata = {
+  title: "Freed Newsletter",
+  robots: { index: false, follow: false },
+};
+
+export default function NewsletterEmbedPage() {
+  return <NewsletterEmbedForm />;
+}

--- a/website/src/components/NewsletterEmbedForm.tsx
+++ b/website/src/components/NewsletterEmbedForm.tsx
@@ -1,0 +1,231 @@
+"use client";
+
+import { isThemeId } from "@freed/shared/themes";
+import { applyThemeToDocument } from "@freed/ui/lib/theme";
+import { useCallback, useEffect, useState, type FormEvent } from "react";
+import TurnstileWidget from "@/components/TurnstileWidget";
+
+const TURNSTILE_SITE_KEY = process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY ?? "";
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+type SignupState = "idle" | "loading" | "success" | "error";
+
+export default function NewsletterEmbedForm() {
+  const [detailsOpen, setDetailsOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [name, setName] = useState("");
+  const [company, setCompany] = useState("");
+  const [turnstileToken, setTurnstileToken] = useState("");
+  const [turnstileResetKey, setTurnstileResetKey] = useState(0);
+  const [state, setState] = useState<SignupState>("idle");
+  const [message, setMessage] = useState("");
+
+  useEffect(() => {
+    const requestedTheme = new URLSearchParams(window.location.search).get(
+      "theme",
+    );
+    if (requestedTheme && isThemeId(requestedTheme)) {
+      window.localStorage.setItem("freed-theme", requestedTheme);
+      applyThemeToDocument(requestedTheme);
+    }
+  }, []);
+
+  const submit = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      const normalizedEmail = email.trim().toLowerCase();
+      const normalizedName = name.trim();
+
+      if (!EMAIL_PATTERN.test(normalizedEmail)) {
+        setState("error");
+        setMessage("Enter a valid email address.");
+        return;
+      }
+
+      if (!detailsOpen) {
+        setDetailsOpen(true);
+        setState("idle");
+        setMessage("");
+        return;
+      }
+
+      if (!normalizedName) {
+        setState("error");
+        setMessage("Tell us your name.");
+        return;
+      }
+
+      if (!turnstileToken) {
+        setState("error");
+        setMessage("Complete the human check.");
+        return;
+      }
+
+      setState("loading");
+      setMessage("");
+
+      try {
+        const response = await fetch("/api/subscribe", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: normalizedEmail,
+            name: normalizedName,
+            company,
+            turnstileToken,
+          }),
+        });
+        const data = (await response.json().catch(() => ({}))) as {
+          success?: boolean;
+          error?: string;
+        };
+
+        if (!response.ok || !data.success) {
+          throw new Error(data.error ?? "Signup failed. Please try again.");
+        }
+
+        setState("success");
+      } catch (error) {
+        setState("error");
+        setMessage(
+          error instanceof Error
+            ? error.message
+            : "Signup failed. Please try again.",
+        );
+        setTurnstileToken("");
+        setTurnstileResetKey((current) => current + 1);
+      }
+    },
+    [company, detailsOpen, email, name, turnstileToken],
+  );
+
+  if (state === "success") {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[var(--theme-bg-primary)] p-4">
+        <div
+          className="w-full rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-muted)] p-5"
+          role="status"
+        >
+          <p className="text-base font-semibold text-[var(--theme-text-primary)]">
+            You’re on the list.
+          </p>
+          <p className="mt-1 text-sm leading-relaxed text-[var(--theme-text-muted)]">
+            We’ll email you about new builds and major progress. No content
+            sludge.
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[var(--theme-bg-primary)] p-4 text-[var(--theme-text-primary)]">
+      <section
+        className="mx-auto max-w-xl rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-card)] p-5"
+        aria-label="Freed newsletter signup"
+      >
+        <p className="text-base font-semibold">Keep up with Freed.</p>
+        <p className="mt-1 text-sm leading-relaxed text-[var(--theme-text-muted)]">
+          New builds, real progress, and the thinking behind Freed. No spam.
+        </p>
+
+        <form
+          className="mt-4 space-y-3"
+          onSubmit={(event) => void submit(event)}
+          noValidate
+        >
+          <div
+            className={
+              detailsOpen
+                ? "grid gap-3 sm:grid-cols-2"
+                : "flex flex-col gap-2 sm:flex-row"
+            }
+          >
+            <label className="min-w-0 flex-1">
+              <span className="sr-only">Email address</span>
+              <input
+                type="email"
+                inputMode="email"
+                autoComplete="email"
+                value={email}
+                onChange={(event) => setEmail(event.target.value)}
+                placeholder="you@example.com"
+                className="theme-input w-full rounded-xl px-3 py-2.5 text-sm outline-none"
+                disabled={state === "loading"}
+                required
+              />
+            </label>
+            {detailsOpen ? (
+              <label className="min-w-0 flex-1">
+                <span className="sr-only">Name</span>
+                <input
+                  type="text"
+                  autoComplete="name"
+                  value={name}
+                  onChange={(event) => setName(event.target.value)}
+                  placeholder="Your name"
+                  className="theme-input w-full rounded-xl px-3 py-2.5 text-sm outline-none"
+                  disabled={state === "loading"}
+                  required
+                />
+              </label>
+            ) : (
+              <button
+                type="submit"
+                className="btn-secondary inline-flex min-h-10 items-center justify-center px-4 py-2 text-sm font-semibold"
+              >
+                Join the newsletter
+              </button>
+            )}
+          </div>
+
+          <input
+            type="hidden"
+            name="company"
+            value={company}
+            onChange={(event) => setCompany(event.target.value)}
+          />
+
+          {detailsOpen ? (
+            <>
+              <TurnstileWidget
+                siteKey={TURNSTILE_SITE_KEY}
+                resetKey={turnstileResetKey}
+                action="newsletter_signup"
+                disabled={state === "loading"}
+                onTokenChange={(token) => {
+                  setTurnstileToken(token);
+                  if (token && state === "error") {
+                    setState("idle");
+                    setMessage("");
+                  }
+                }}
+              />
+              <button
+                type="submit"
+                className="btn-primary inline-flex min-h-11 w-full items-center justify-center px-5 py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={state === "loading"}
+              >
+                {state === "loading" ? "Joining…" : "Join the newsletter"}
+              </button>
+            </>
+          ) : null}
+
+          {message ? (
+            <p
+              className="text-xs leading-relaxed text-[rgb(var(--theme-feedback-danger-rgb))]"
+              role="alert"
+            >
+              {message}
+            </p>
+          ) : null}
+        </form>
+
+        <p className="mt-3 text-xs leading-relaxed text-[var(--theme-text-soft)]">
+          Unsubscribe anytime. Your email goes to our newsletter provider and
+          nowhere else.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/website/src/components/SiteShell.tsx
+++ b/website/src/components/SiteShell.tsx
@@ -7,13 +7,11 @@ import Footer from "@/components/Footer";
 import NewsletterModal from "@/components/NewsletterModal";
 import BackgroundGradients from "@/components/BackgroundGradients";
 
-export default function SiteShell({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function SiteShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const isQrGallery = pathname === "/qr";
+  const isNewsletterEmbed = pathname === "/newsletter/embed";
+  const isStandaloneSurface = isQrGallery || isNewsletterEmbed;
 
   useEffect(() => {
     try {
@@ -29,22 +27,22 @@ export default function SiteShell({
 
   return (
     <>
-      {!isQrGallery && <Navigation />}
+      {!isStandaloneSurface && <Navigation />}
 
       <div className="theme-shell flex flex-col overflow-hidden relative">
         <BackgroundGradients />
 
         <main
           id="main-content"
-          className={`relative z-10 flex-grow ${isQrGallery ? "min-h-screen" : ""}`}
+          className={`relative z-10 flex-grow ${isStandaloneSurface ? "min-h-screen" : ""}`}
         >
           {children}
         </main>
 
-        {!isQrGallery && <Footer />}
+        {!isStandaloneSurface && <Footer />}
       </div>
 
-      {!isQrGallery && <NewsletterModal />}
+      {!isStandaloneSurface && <NewsletterModal />}
     </>
   );
 }

--- a/website/src/components/TurnstileWidget.tsx
+++ b/website/src/components/TurnstileWidget.tsx
@@ -3,8 +3,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import Script from "next/script";
 
-const TURNSTILE_UNAVAILABLE_TOKEN = "turnstile-unavailable";
-
 declare global {
   interface Window {
     turnstile?: {
@@ -14,6 +12,7 @@ declare global {
           sitekey: string;
           theme?: "light" | "dark" | "auto";
           size?: "normal" | "compact" | "flexible";
+          action?: string;
           callback?: (token: string) => void;
           "expired-callback"?: () => void;
           "error-callback"?: () => void;
@@ -32,6 +31,7 @@ interface TurnstileWidgetProps {
   resetKey: number;
   onTokenChange: (token: string) => void;
   disabled?: boolean;
+  action?: string;
 }
 
 export default function TurnstileWidget({
@@ -39,6 +39,7 @@ export default function TurnstileWidget({
   resetKey,
   onTokenChange,
   disabled = false,
+  action,
 }: TurnstileWidgetProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const widgetIdRef = useRef<string | null>(null);
@@ -67,7 +68,7 @@ export default function TurnstileWidget({
 
   const markFailed = useCallback(() => {
     clearVerificationTimer();
-    emitTokenChange(TURNSTILE_UNAVAILABLE_TOKEN);
+    emitTokenChange("");
     setVerificationState("failed");
   }, [clearVerificationTimer, emitTokenChange]);
 
@@ -92,7 +93,12 @@ export default function TurnstileWidget({
   }, []);
 
   useEffect(() => {
-    if (!siteKey || !scriptReady || !containerRef.current || widgetIdRef.current) {
+    if (
+      !siteKey ||
+      !scriptReady ||
+      !containerRef.current ||
+      widgetIdRef.current
+    ) {
       return;
     }
 
@@ -106,6 +112,7 @@ export default function TurnstileWidget({
       sitekey: siteKey,
       theme: "auto",
       size: "flexible",
+      action,
       callback: (token) => {
         clearVerificationTimer();
         setVerificationState("verified");
@@ -135,6 +142,7 @@ export default function TurnstileWidget({
     retryKey,
     scriptReady,
     siteKey,
+    action,
   ]);
 
   useEffect(() => {
@@ -164,7 +172,7 @@ export default function TurnstileWidget({
       <div ref={containerRef} className="min-h-[68px]" />
       {verificationState === "failed" ? (
         <div className="mt-2 flex flex-wrap items-center gap-2 text-xs leading-relaxed text-[rgb(var(--theme-feedback-danger-rgb))]">
-          <span>Human check is taking too long. Try again, or submit below.</span>
+          <span>Human check is taking too long.</span>
           <button
             type="button"
             onClick={rerenderWidget}


### PR DESCRIPTION
(AI Generated).

## Summary
- Serve a themed newsletter form inside Freed without sending readers through the download flow.
- Protect the public subscription endpoint with an origin allowlist, Turnstile hostname and action checks, rate limits, and no client-side secret.
- Allow the embedded form inside Freed Desktop, including the installed Windows Tauri origin.

## Testing
- cd website && PATH=../node_modules/.bin:$PATH npm run test:newsletter
- cd website && PATH=../node_modules/.bin:$PATH npm run lint
- cd website && PATH=../node_modules/.bin:$PATH npm run build