### PR TITLE
chore: prepare v26.9.300-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.9.200",
+  "version": "26.9.300",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.9.200"
+version = "26.9.300"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.9.200"
+version = "26.9.300"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.9.200",
+  "version": "26.9.300",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.9.200",
+  "version": "26.9.300",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.9.3.json
+++ b/release-notes/daily/dev/26.9.3.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.9.3",
+  "date": "2026-09-03",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-09-03T13:59:47.700Z"
+}

--- a/release-notes/releases/v26.9.300-dev.json
+++ b/release-notes/releases/v26.9.300-dev.json
@@ -3,7 +3,7 @@
   "version": "26.9.300-dev",
   "channel": "dev",
   "dayKey": "26.9.3",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-09-03T13:59:47.700Z",
   "model": "heuristic",
@@ -55,10 +55,15 @@
     ]
   },
   "release": {
-    "deck": "Split and validate repository instructions and LinkedIn feed extraction restored",
+    "deck": "LinkedIn feed sync works again after reconnecting",
     "features": [],
-    "fixes": [],
-    "followUps": []
+    "fixes": [
+      "Restore LinkedIn extraction events after reconnecting the provider",
+      "Read LinkedIn's current feed markup while excluding promoted posts"
+    ],
+    "followUps": [
+      "Verify the signed build against the connected LinkedIn account on the installation machine"
+    ]
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.9.300-dev\n\nSplit and validate repository instructions and LinkedIn feed extraction restored\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.300-dev\n\nLinkedIn feed sync works again after reconnecting\n\n### Fixes\n\n- Restore LinkedIn extraction events after reconnecting the provider\n- Read LinkedIn's current feed markup while excluding promoted posts\n\n### Follow-ups\n\n- Verify the signed build against the connected LinkedIn account on the installation machine\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.9.300-dev.json
+++ b/release-notes/releases/v26.9.300-dev.json
@@ -1,0 +1,64 @@
+{
+  "tag": "v26.9.300-dev",
+  "version": "26.9.300-dev",
+  "channel": "dev",
+  "dayKey": "26.9.3",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-09-03T13:59:47.700Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.9.200-dev",
+    "previousPublishedDayTag": "v26.9.200-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "5d4cf0fb5f32f5893f6add30e8992d0be1b9b73a",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.9.200-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "cafe12fa33bc57b0f9d0f021d4e9f75b0fef983a",
+        "toInclusiveProductCommitSha": "5d4cf0fb5f32f5893f6add30e8992d0be1b9b73a"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:f50580b7d946ea27854eb4b78e7bb566b9c5f08ee07bb9ed71bab23fac04be9d",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.9.300-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.9.300-dev"
+    ],
+    "prNumbers": [
+      1783,
+      1787
+    ],
+    "commitSubjects": [
+      "fix: restore LinkedIn feed extraction (#1787)",
+      "chore: split and validate repository instructions (#1783)"
+    ]
+  },
+  "release": {
+    "deck": "Split and validate repository instructions and LinkedIn feed extraction restored",
+    "features": [],
+    "fixes": [],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.300-dev\n\nSplit and validate repository instructions and LinkedIn feed extraction restored\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.9.300-dev.md
+++ b/release-notes/releases/v26.9.300-dev.md
@@ -1,0 +1,17 @@
+(AI Generated).
+
+## Freed v26.9.300-dev
+
+Split and validate repository instructions and LinkedIn feed extraction restored
+
+### Fixes
+
+- Bug fixes and improvements
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.

--- a/release-notes/releases/v26.9.300-dev.md
+++ b/release-notes/releases/v26.9.300-dev.md
@@ -2,11 +2,16 @@
 
 ## Freed v26.9.300-dev
 
-Split and validate repository instructions and LinkedIn feed extraction restored
+LinkedIn feed sync works again after reconnecting
 
 ### Fixes
 
-- Bug fixes and improvements
+- Restore LinkedIn extraction events after reconnecting the provider
+- Read LinkedIn's current feed markup while excluding promoted posts
+
+### Follow-ups
+
+- Verify the signed build against the connected LinkedIn account on the installation machine
 
 ### Downloads
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Prepare the approved v26.9.300-dev release from product commit 5d4cf0fb5f32f5893f6add30e8992d0be1b9b73a.

## Testing
- npm run validate:feature