### PR TITLE
fix: preserve Library Core activation history across releases

### DIFF
--- a/scripts/lib/library-core-release-activation.mjs
+++ b/scripts/lib/library-core-release-activation.mjs
@@ -1,8 +1,9 @@
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import { closeSync, openSync, rmSync } from "node:fs";
 
 import { resolveGithubReadToken } from "./github-release-publications.mjs";
+import { readGitPathAtRef } from "./git-path-at-ref.mjs";
 
 const FULL_COMMIT_SHA_PATTERN = /^[0-9a-f]{40,64}$/;
 const RELEASE_TAG_PATTERN = /^v\d+\.\d+\.\d+(?:-dev)?$/;
@@ -696,6 +697,224 @@ export function inspectLibraryCoreActivationManifest({
       currentDigest: inspectionDigest(current),
     },
     transitions,
+  };
+}
+
+function manifestEndpointEvidence(contents, label) {
+  const present = contents !== null && contents !== undefined;
+  const manifest = parseActivationManifest(contents, {
+    allowAbsent: true,
+    label,
+  });
+  return {
+    present,
+    digest: inspectionDigest(manifest),
+  };
+}
+
+function runManifestChainGit(spawn, cwd, args, label) {
+  const result = spawn("git", args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  if (result.status !== 0) {
+    const detail =
+      String(result.stderr ?? "").trim() ||
+      result.error?.message ||
+      (result.signal ? `terminated by ${result.signal}` : "git failed");
+    throw new Error(`${label}: ${detail}.`);
+  }
+  return String(result.stdout ?? "").trim();
+}
+
+/**
+ * Resolves one release's activation delta. Production releases with two
+ * promoted dev receipts can recover manifest schema changes that crossed an
+ * unpublished intermediate dev state. Other release ranges retain the direct
+ * endpoint comparison.
+ */
+export function resolveLibraryCoreActivationManifestInspection({
+  channel,
+  previousContents = null,
+  currentContents,
+  previousPromotedDevCommitSha = null,
+  currentPromotedDevCommitSha = null,
+  cwd = null,
+  spawn = spawnSync,
+}) {
+  if (channel !== "dev" && channel !== "production") {
+    throw new Error("Library Core activation channel is invalid.");
+  }
+
+  const hasPromotedDevRange =
+    channel === "production" &&
+    previousPromotedDevCommitSha !== null &&
+    previousPromotedDevCommitSha !== undefined &&
+    currentPromotedDevCommitSha !== null &&
+    currentPromotedDevCommitSha !== undefined;
+  if (!hasPromotedDevRange) {
+    return inspectLibraryCoreActivationManifest({
+      previousContents,
+      currentContents,
+    });
+  }
+
+  const previousPromotedDevSha = requireFullCommitSha(
+    previousPromotedDevCommitSha,
+    "Previous promoted dev commit",
+  );
+  const currentPromotedDevSha = requireFullCommitSha(
+    currentPromotedDevCommitSha,
+    "Current promoted dev commit",
+  );
+  if (typeof cwd !== "string" || cwd.length === 0) {
+    throw new Error(
+      "Production Library Core manifest recovery requires a repository path.",
+    );
+  }
+
+  const ancestry = spawn(
+    "git",
+    [
+      "merge-base",
+      "--is-ancestor",
+      previousPromotedDevSha,
+      currentPromotedDevSha,
+    ],
+    { cwd, encoding: "utf8" },
+  );
+  if (ancestry.status !== 0) {
+    if (ancestry.status === 1) {
+      throw new Error(
+        `Previous promoted dev commit ${previousPromotedDevSha} is not an ancestor of current promoted dev commit ${currentPromotedDevSha}.`,
+      );
+    }
+    const detail =
+      String(ancestry.stderr ?? "").trim() ||
+      ancestry.error?.message ||
+      (ancestry.signal ? `terminated by ${ancestry.signal}` : "git failed");
+    throw new Error(
+      `Could not verify promoted dev ancestry ${previousPromotedDevSha} to ${currentPromotedDevSha}: ${detail}.`,
+    );
+  }
+
+  const previousPromotedManifest = readGitPathAtRef({
+    cwd,
+    ref: previousPromotedDevSha,
+    filePath: LIBRARY_CORE_ACTIVATION_MANIFEST_PATH,
+    spawn,
+  });
+  const currentPromotedManifest = readGitPathAtRef({
+    cwd,
+    ref: currentPromotedDevSha,
+    filePath: LIBRARY_CORE_ACTIVATION_MANIFEST_PATH,
+    spawn,
+  });
+  const previousMainEndpoint = manifestEndpointEvidence(
+    previousContents,
+    "Previous main Library Core activation manifest",
+  );
+  const currentMainEndpoint = manifestEndpointEvidence(
+    currentContents,
+    "Current main Library Core activation manifest",
+  );
+  const previousDevEndpoint = manifestEndpointEvidence(
+    previousPromotedManifest.state === "present"
+      ? previousPromotedManifest.contents
+      : null,
+    "Previous promoted dev Library Core activation manifest",
+  );
+  const currentDevEndpoint = manifestEndpointEvidence(
+    currentPromotedManifest.state === "present"
+      ? currentPromotedManifest.contents
+      : null,
+    "Current promoted dev Library Core activation manifest",
+  );
+
+  for (const [label, mainEndpoint, devEndpoint] of [
+    ["Previous", previousMainEndpoint, previousDevEndpoint],
+    ["Current", currentMainEndpoint, currentDevEndpoint],
+  ]) {
+    if (
+      mainEndpoint.present !== devEndpoint.present ||
+      mainEndpoint.digest !== devEndpoint.digest
+    ) {
+      throw new Error(
+        `${label} promoted dev Library Core manifest does not match the corresponding main release boundary.`,
+      );
+    }
+  }
+
+  const manifestChangingCommits = runManifestChainGit(
+    spawn,
+    cwd,
+    [
+      "rev-list",
+      "--first-parent",
+      "--reverse",
+      `${previousPromotedDevSha}..${currentPromotedDevSha}`,
+      "--",
+      LIBRARY_CORE_ACTIVATION_MANIFEST_PATH,
+    ],
+    "Could not read first-parent Library Core manifest history",
+  )
+    .split("\n")
+    .filter(Boolean);
+  for (const commitSha of manifestChangingCommits) {
+    requireFullCommitSha(commitSha, "Library Core manifest history commit");
+  }
+  if (manifestChangingCommits.at(-1) !== currentPromotedDevSha) {
+    manifestChangingCommits.push(currentPromotedDevSha);
+  }
+
+  const transitions = [];
+  let previousState = {
+    commitSha: previousPromotedDevSha,
+    contents:
+      previousPromotedManifest.state === "present"
+        ? previousPromotedManifest.contents
+        : null,
+  };
+  for (const commitSha of manifestChangingCommits) {
+    const read =
+      commitSha === currentPromotedDevSha
+        ? currentPromotedManifest
+        : readGitPathAtRef({
+            cwd,
+            ref: commitSha,
+            filePath: LIBRARY_CORE_ACTIVATION_MANIFEST_PATH,
+            spawn,
+          });
+    const currentState = {
+      commitSha,
+      contents: read.state === "present" ? read.contents : null,
+    };
+    let inspection;
+    try {
+      inspection = inspectLibraryCoreActivationManifest({
+        previousContents: previousState.contents,
+        currentContents: currentState.contents,
+      });
+    } catch (error) {
+      throw new Error(
+        `Library Core activation manifest chain ${previousState.commitSha} to ${currentState.commitSha} is invalid: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    transitions.push(...inspection.transitions);
+    previousState = currentState;
+  }
+
+  return {
+    manifest: {
+      path: LIBRARY_CORE_ACTIVATION_MANIFEST_PATH,
+      previousPresent: previousMainEndpoint.present,
+      previousDigest: previousMainEndpoint.digest,
+      currentDigest: currentMainEndpoint.digest,
+    },
+    transitions: validateTransitions(transitions),
   };
 }
 

--- a/scripts/lib/library-core-release-activation.test.mjs
+++ b/scripts/lib/library-core-release-activation.test.mjs
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
 import { createHash } from "node:crypto";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -14,6 +18,7 @@ import {
   libraryCoreOwnerApprovalIntent,
   libraryCoreReleaseArtifactProposalDigest,
   prepareLibraryCoreReleaseActivation,
+  resolveLibraryCoreActivationManifestInspection,
   validateLibraryCoreReleaseActivation,
   validatePreviousLibraryCoreActivationContinuity,
 } from "./library-core-release-activation.mjs";
@@ -101,6 +106,54 @@ function manifestV2Contents({ previousTransitions = [], transitions = [] }) {
     null,
     2,
   )}\n`;
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function makeManifestHistory(t, contentsByCommit) {
+  const cwd = mkdtempSync(
+    path.join(tmpdir(), "freed-library-core-manifest-chain-"),
+  );
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+  git(cwd, ["init", "-b", "dev"]);
+  git(cwd, ["config", "user.name", "Freed Test"]);
+  git(cwd, ["config", "user.email", "test@freed.invalid"]);
+  const manifestPath = path.join(
+    cwd,
+    "docs/library-core-activation-manifest.json",
+  );
+  mkdirSync(path.dirname(manifestPath), { recursive: true });
+  const commits = [];
+  for (const [index, contents] of contentsByCommit.entries()) {
+    writeFileSync(manifestPath, contents);
+    git(cwd, ["add", "docs/library-core-activation-manifest.json"]);
+    git(cwd, ["commit", "-m", `test: manifest state ${index + 1}`]);
+    commits.push(git(cwd, ["rev-parse", "HEAD"]));
+  }
+  return { cwd, commits };
+}
+
+function resolveProductionManifestHistory({
+  cwd,
+  previousCommitSha,
+  currentCommitSha,
+  previousContents,
+  currentContents,
+}) {
+  return resolveLibraryCoreActivationManifestInspection({
+    channel: "production",
+    previousContents,
+    currentContents,
+    previousPromotedDevCommitSha: previousCommitSha,
+    currentPromotedDevCommitSha: currentCommitSha,
+    cwd,
+  });
 }
 
 const EMPTY_MANIFEST_INSPECTION = inspectLibraryCoreActivationManifest({
@@ -795,6 +848,292 @@ test("release declarations must equal the exact manifest delta", () => {
         requireReviewed: false,
       }),
     /manifest evidence does not match/,
+  );
+});
+
+test("non-production manifest inspection keeps the direct endpoint comparison", () => {
+  const previousContents = manifestContents();
+  const currentContents = manifestContents([
+    migrationTransition({ activationId: "activation-001" }),
+  ]);
+
+  assert.deepEqual(
+    resolveLibraryCoreActivationManifestInspection({
+      channel: "dev",
+      previousContents,
+      currentContents,
+    }),
+    inspectLibraryCoreActivationManifest({
+      previousContents,
+      currentContents,
+    }),
+  );
+});
+
+test("production manifest inspection recovers an exact v1 to intermediate v1 to v2 chain", (t) => {
+  const previousTransitions = [
+    migrationTransition({ activationId: "activation-000" }),
+  ];
+  const intermediateTransition = migrationTransition({
+    activationId: "activation-001",
+  });
+  const intermediateTransitions = [
+    ...previousTransitions,
+    intermediateTransition,
+  ];
+  const currentTransition = sqliteEpochTransition({
+    activationId: "activation-002",
+  });
+  const previousContents = manifestContents(previousTransitions);
+  const intermediateContents = manifestContents(intermediateTransitions);
+  const currentContents = manifestV2Contents({
+    previousTransitions: intermediateTransitions,
+    transitions: [currentTransition],
+  });
+  const { cwd, commits } = makeManifestHistory(t, [
+    previousContents,
+    intermediateContents,
+    currentContents,
+  ]);
+
+  const inspection = resolveProductionManifestHistory({
+    cwd,
+    previousCommitSha: commits[0],
+    currentCommitSha: commits[2],
+    previousContents,
+    currentContents,
+  });
+
+  assert.deepEqual(inspection.transitions, [
+    intermediateTransition,
+    currentTransition,
+  ]);
+  assert.equal(inspection.manifest.previousPresent, true);
+  assert.equal(
+    inspection.manifest.previousDigest,
+    inspectLibraryCoreActivationManifest({
+      previousContents,
+      currentContents: previousContents,
+    }).manifest.currentDigest,
+  );
+  assert.equal(
+    inspection.manifest.currentDigest,
+    inspectLibraryCoreActivationManifest({
+      previousContents: currentContents,
+      currentContents,
+    }).manifest.currentDigest,
+  );
+});
+
+test("production manifest inspection rejects a missing or wrong intermediate digest", (t) => {
+  const intermediateTransition = migrationTransition({
+    activationId: "activation-001",
+  });
+  const currentTransition = sqliteEpochTransition({
+    activationId: "activation-002",
+  });
+  const previousContents = manifestContents();
+  const intermediateContents = manifestContents([intermediateTransition]);
+  const wrongDigestContents = manifestV2Contents({
+    previousTransitions: [],
+    transitions: [currentTransition],
+  });
+  const wrongDigestHistory = makeManifestHistory(t, [
+    previousContents,
+    intermediateContents,
+    wrongDigestContents,
+  ]);
+
+  assert.throws(
+    () =>
+      resolveProductionManifestHistory({
+        cwd: wrongDigestHistory.cwd,
+        previousCommitSha: wrongDigestHistory.commits[0],
+        currentCommitSha: wrongDigestHistory.commits[2],
+        previousContents,
+        currentContents: wrongDigestContents,
+      }),
+    /must bind the exact superseded v1 history/,
+  );
+
+  const missingDigestContents = `${JSON.stringify(
+    {
+      schemaVersion: 2,
+      supersedes: { schemaVersion: 1 },
+      transitions: [currentTransition],
+    },
+    null,
+    2,
+  )}\n`;
+  const missingDigestHistory = makeManifestHistory(t, [
+    previousContents,
+    intermediateContents,
+    missingDigestContents,
+  ]);
+  assert.throws(
+    () =>
+      resolveProductionManifestHistory({
+        cwd: missingDigestHistory.cwd,
+        previousCommitSha: missingDigestHistory.commits[0],
+        currentCommitSha: missingDigestHistory.commits[2],
+        previousContents,
+        currentContents: missingDigestContents,
+      }),
+    /unsupported or missing fields/,
+  );
+});
+
+test("production manifest inspection rejects non-ancestor promoted dev receipts", (t) => {
+  const baseContents = manifestContents();
+  const currentContents = manifestContents([
+    migrationTransition({ activationId: "activation-002" }),
+  ]);
+  const history = makeManifestHistory(t, [baseContents, currentContents]);
+  git(history.cwd, ["checkout", "-b", "previous-sibling", history.commits[0]]);
+  const previousContents = manifestContents([
+    migrationTransition({ activationId: "activation-001" }),
+  ]);
+  const manifestPath = path.join(
+    history.cwd,
+    "docs/library-core-activation-manifest.json",
+  );
+  writeFileSync(manifestPath, previousContents);
+  git(history.cwd, ["add", "docs/library-core-activation-manifest.json"]);
+  git(history.cwd, ["commit", "-m", "test: sibling previous receipt"]);
+  const previousCommitSha = git(history.cwd, ["rev-parse", "HEAD"]);
+
+  assert.throws(
+    () =>
+      resolveProductionManifestHistory({
+        cwd: history.cwd,
+        previousCommitSha,
+        currentCommitSha: history.commits[1],
+        previousContents,
+        currentContents,
+      }),
+    /is not an ancestor of current promoted dev commit/,
+  );
+});
+
+test("production manifest inspection rejects dev and main endpoint mismatch", (t) => {
+  const previousContents = manifestContents();
+  const currentDevContents = manifestContents([
+    migrationTransition({ activationId: "activation-001" }),
+  ]);
+  const currentMainContents = manifestContents([
+    migrationTransition({ activationId: "activation-002" }),
+  ]);
+  const history = makeManifestHistory(t, [
+    previousContents,
+    currentDevContents,
+  ]);
+
+  assert.throws(
+    () =>
+      resolveProductionManifestHistory({
+        cwd: history.cwd,
+        previousCommitSha: history.commits[0],
+        currentCommitSha: history.commits[1],
+        previousContents,
+        currentContents: currentMainContents,
+      }),
+    /Current promoted dev Library Core manifest does not match the corresponding main release boundary/,
+  );
+});
+
+test("production manifest inspection rejects duplicate or out-of-order IDs across recovered edges", (t) => {
+  const duplicateId = "activation-001";
+  const previousContents = manifestContents();
+  const duplicateIntermediateTransitions = [
+    migrationTransition({ activationId: duplicateId }),
+  ];
+  const duplicateIntermediateContents = manifestContents(
+    duplicateIntermediateTransitions,
+  );
+  const duplicateCurrentContents = manifestV2Contents({
+    previousTransitions: duplicateIntermediateTransitions,
+    transitions: [sqliteEpochTransition({ activationId: duplicateId })],
+  });
+  const duplicateHistory = makeManifestHistory(t, [
+    previousContents,
+    duplicateIntermediateContents,
+    duplicateCurrentContents,
+  ]);
+  assert.throws(
+    () =>
+      resolveProductionManifestHistory({
+        cwd: duplicateHistory.cwd,
+        previousCommitSha: duplicateHistory.commits[0],
+        currentCommitSha: duplicateHistory.commits[2],
+        previousContents,
+        currentContents: duplicateCurrentContents,
+      }),
+    /unique ASCII-sorted activation IDs/,
+  );
+
+  const outOfOrderIntermediateTransitions = [
+    migrationTransition({ activationId: "activation-200" }),
+  ];
+  const outOfOrderIntermediateContents = manifestContents(
+    outOfOrderIntermediateTransitions,
+  );
+  const outOfOrderCurrentContents = manifestV2Contents({
+    previousTransitions: outOfOrderIntermediateTransitions,
+    transitions: [
+      sqliteEpochTransition({ activationId: "activation-100" }),
+    ],
+  });
+  const outOfOrderHistory = makeManifestHistory(t, [
+    previousContents,
+    outOfOrderIntermediateContents,
+    outOfOrderCurrentContents,
+  ]);
+  assert.throws(
+    () =>
+      resolveProductionManifestHistory({
+        cwd: outOfOrderHistory.cwd,
+        previousCommitSha: outOfOrderHistory.commits[0],
+        currentCommitSha: outOfOrderHistory.commits[2],
+        previousContents,
+        currentContents: outOfOrderCurrentContents,
+      }),
+    /unique ASCII-sorted activation IDs/,
+  );
+});
+
+test("production manifest inspection caps combined recovered transitions at 64", (t) => {
+  const previousContents = manifestContents();
+  const intermediateTransitions = Array.from({ length: 40 }, (_, index) =>
+    migrationTransition({
+      activationId: `activation-${String(index).padStart(3, "0")}`,
+    }),
+  );
+  const intermediateContents = manifestContents(intermediateTransitions);
+  const currentTransitions = Array.from({ length: 25 }, (_, index) =>
+    sqliteEpochTransition({
+      activationId: `activation-${String(index + 40).padStart(3, "0")}`,
+    }),
+  );
+  const currentContents = manifestV2Contents({
+    previousTransitions: intermediateTransitions,
+    transitions: currentTransitions,
+  });
+  const history = makeManifestHistory(t, [
+    previousContents,
+    intermediateContents,
+    currentContents,
+  ]);
+
+  assert.throws(
+    () =>
+      resolveProductionManifestHistory({
+        cwd: history.cwd,
+        previousCommitSha: history.commits[0],
+        currentCommitSha: history.commits[2],
+        previousContents,
+        currentContents,
+      }),
+    /at most 64 entries/,
   );
 });
 

--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -31,9 +31,9 @@ import {
 } from "./release-receipt.mjs";
 import {
   LIBRARY_CORE_ACTIVATION_MANIFEST_PATH,
-  inspectLibraryCoreActivationManifest,
   inspectPreviousLibraryCoreActivationWitness,
   prepareLibraryCoreReleaseActivation,
+  resolveLibraryCoreActivationManifestInspection,
   validatePreviousLibraryCoreActivationContinuity,
   withReleaseArtifactWriteLock,
 } from "./lib/library-core-release-activation.mjs";
@@ -1004,12 +1004,17 @@ async function collectReleaseContext(
         `${LIBRARY_CORE_ACTIVATION_MANIFEST_PATH} is missing from exact release source ${releaseReceipt.productCommitSha}.`,
       );
     }
-    const manifestInspection = inspectLibraryCoreActivationManifest({
+    const manifestInspection = resolveLibraryCoreActivationManifestInspection({
+      channel,
       previousContents:
         previousManifestRead.state === "present"
           ? previousManifestRead.contents
           : null,
       currentContents: currentManifestRead.contents,
+      previousPromotedDevCommitSha:
+        previousSource?.promotedDevCommitSha ?? null,
+      currentPromotedDevCommitSha: releaseReceipt.promotedDevCommitSha,
+      cwd: REPO_ROOT,
     });
     validatePreviousLibraryCoreActivationContinuity({
       witness: previousActivationWitness,

--- a/scripts/validate-release-identity.mjs
+++ b/scripts/validate-release-identity.mjs
@@ -9,8 +9,8 @@ import { inspectCargoLockReleaseChange } from "./lib/cargo-lock-release.mjs";
 import {
   LIBRARY_CORE_ACTIVATION_DECISION_STATES,
   LIBRARY_CORE_ACTIVATION_MANIFEST_PATH,
-  inspectLibraryCoreActivationManifest,
   inspectPreviousLibraryCoreActivationWitness,
+  resolveLibraryCoreActivationManifestInspection,
   validateLibraryCoreReleaseActivation,
   validatePreviousLibraryCoreActivationContinuity,
 } from "./lib/library-core-release-activation.mjs";
@@ -296,6 +296,7 @@ function expectedLibraryCoreActivationRange({
       isAncestor: (fromRef, toRef) => gitIsAncestor(cwd, fromRef, toRef),
     }),
     previousArtifact,
+    previousSource,
     previousTagCommitSha,
   };
 }
@@ -855,6 +856,7 @@ export function validateReleaseIdentity({
       const {
         range: expectedRange,
         previousArtifact,
+        previousSource,
         previousTagCommitSha,
       } = expectedLibraryCoreActivationRange({
         cwd,
@@ -895,12 +897,17 @@ export function validateReleaseIdentity({
           `${LIBRARY_CORE_ACTIVATION_MANIFEST_PATH} is missing from exact release source ${productCommitSha}.`,
         );
       }
-      const manifestInspection = inspectLibraryCoreActivationManifest({
+      const manifestInspection = resolveLibraryCoreActivationManifestInspection({
+        channel: expected.channel,
         previousContents:
           previousManifestRead.state === "present"
             ? previousManifestRead.contents
             : null,
         currentContents: currentManifestRead.contents,
+        previousPromotedDevCommitSha:
+          previousSource?.promotedDevCommitSha ?? null,
+        currentPromotedDevCommitSha: promotedDevCommitSha,
+        cwd,
       });
       validatePreviousLibraryCoreActivationContinuity({
         witness: previousActivationWitness,


### PR DESCRIPTION
(AI Generated).

## Summary
- Reconstructs production activation history from immutable promoted dev receipts when a squash hides an intermediate manifest state.
- Validates each adjacent manifest pair and keeps main and dev release boundaries digest-bound.
- Rejects non-ancestor receipts, endpoint drift, duplicate transition IDs, and combined deltas above the 64-transition cap.

## Testing
- npm run validate:feature
- 51 focused release activation and release identity tests