### PR TITLE
docs: codify the demo corpus editorial canon

### DIFF
--- a/docs/SAMPLE-CORPUS-EDITORIAL-GUIDE.md
+++ b/docs/SAMPLE-CORPUS-EDITORIAL-GUIDE.md
@@ -1,399 +1,279 @@
 # Freed Sample Corpus Editorial Guide
 
-This document is the durable editorial contract for the sample data shown in Freed Desktop, the PWA, feature previews, and `demo.freed.wtf`. Use it whenever the corpus is expanded, regenerated, or reviewed.
+This is the canonical editorial contract for sample content shown in Freed Desktop, the PWA, feature previews, and `demo.freed.wtf`. Use it whenever the public demo corpus is written, expanded, regenerated, or reviewed.
 
-The goal is not to simulate generic social media. The goal is to make creation itself appear to have seized several social accounts and developed excellent comic timing.
+The demo is a recurring world of natural lives, told from the inside with precise facts, comic nerve, and an abiding sense that existence is very strange. Generic social copy with animal nouns inserted has no place here.
 
-## Governing idea
+## Current state and next target
 
-Every post is a first-person dispatch from a real insect, microscopic creature, undersea animal, geological formation, planet, star, nebula, or other natural subject.
+The flagship corpus currently contains 45 individually authored episodes from six recurring characters. Each episode binds to one reviewed Wikimedia Commons image. The larger generated catalog contains 1,750 attributable images, but catalog membership does not make an image or its generated fallback copy part of the public demo.
 
-The voice is universally reverent and non-sectarian. The subject regards creation as glorious, strange, excessive, ancient, and worthy of attention. The humor is sharp, specific, and occasionally merciless. Reverence is the foundation. Snark is the delivery system.
+| Character | Platform | Episodes |
+| --- | --- | ---: |
+| Manny Tis | Instagram | 9 |
+| Frogbert Angler | X | 9 |
+| Nudi Branch Manager | Facebook | 9 |
+| Cygnus Shy | Instagram | 7 |
+| Flora Mingo | LinkedIn | 4 |
+| Nova Remains | RSS | 7 |
 
-The writing should feel like an inside joke penned by a volcano or praying mantis. It must never sound like a clinical caption, a travel diary, a marketing department, or an appliance trying to pass a biology exam.
+The next corpus target is exactly 500 authored episodes. That expansion must replace formulaic fallback copy with deliberate character stories. It must not manufacture 455 interchangeable strangers.
 
-## Demo cast and continuity
+Favor a cast of roughly 24 to 36 recurring characters, including the current six. Add a character only when the subject has enough biological, geological, or cosmic substance to sustain a distinct interior life and a real sequence of events. The exact cast size follows story quality, not arithmetic convenience.
 
-The public demo is a small recurring cast, not a slot machine that manufactures strangers. Each character owns a finite sequence of individually written episodes. Those episodes form a life: appetite creates trouble, trouble changes the character, relationships deepen, fears recur, and revelations remain remembered in later posts.
+## The desired aftertaste
 
-Write the arc before writing the captions. Give every character a biological constraint, a private desire, a comic flaw, at least one relationship, and one event that changes how later episodes read. A visitor who clicks Manny Tis should find Manny's life, not eight unrelated mantis jokes wearing the same account name.
+Scrolling the feed should leave visitors with reverence for the mystery of life, curiosity about unfamiliar ways of being, delight in the planet's absurd particulars, and a felt kinship with the natural world.
 
-The runtime may reshuffle different characters through the Library on each visit. It must never scramble the chronology inside one character's timeline. Freshness comes from interleaving stable stories, not regenerating prose or changing facts after reload.
+Awe comes from precision. Show the astonishing fact and let the reader feel its scale.
 
-Public demo copy is static authored material. Do not generate it from platform wrappers, noun substitution, randomized sentence fragments, or prompt-time language model output. The large image catalog may support tests and future editorial selection, but inclusion in that catalog does not make an asset a published demo episode.
+Curiosity comes from incomplete understanding. Let narrators notice, misread, test, discover, and revise.
 
-Before accepting a character arc, read the entire timeline in order and ask:
+Delight comes from physical particularity: an awkward movement, a failed ambush, an unfamiliar sense, a tiny victory, or an absurdly large consequence.
 
-- Does each episode contain a distinct event rather than a variation on a premise?
-- Does a later episode reward knowledge from an earlier one?
-- Would the post still sound like this character if the account name disappeared?
-- Does the photograph show the event or biological behavior the prose depends on?
-- Are every title, opening, punch line, and comic structure unique across the cast?
-- Does the final episode leave the character changed, connected, endangered, wiser, or gloriously mistaken?
+Kinship comes from shared stakes such as hunger, shelter, danger, play, attachment, repair, curiosity, and mortality. Never explain that everything is connected. Show the connection doing something.
 
-## Non-negotiable rules
+The demo may imagine interiority at any scale, from cell to storm to stone to star. This is imaginative personification, not a scientific claim that every subject is conscious. It should feel generous and mysterious rather than sectarian or preachy.
 
-1. Write from first-person experience.
-   The natural subject is the narrator. A post may begin with `Apparently`, `Observed`, `Forty million years`, or another strong phrase, but the narrator's own experience and attitude must remain present.
+Surreal works such as *Everything* are structural inspiration only. Draw from shifts of scale, consciousness distributed through matter, unfamiliar embodiment, and the comic dignity of every point of view. Do not copy dialogue, recognizable phrasing, scene construction, narration, or signature metaphors from that game or any other work.
 
-2. Begin inside the joke.
-   Do not introduce the narrator, restate the title, or explain the premise before the funny part begins.
+No narrator extracts a lesson for humanity. The event, the laugh, or the changed character carries the meaning.
 
-3. Never make every post begin the same way.
-   In particular, do not use `I am the...`, `I am a...`, or any other repeated opening as a corpus template. Sentence rhythm, opening words, and comic construction must vary.
+## Character canon
 
-4. Anchor every joke in a true natural detail.
-   A mantis has raptorial forelegs. A nudibranch can appropriate stinging cells. A diatom builds a silica shell. A caldera records volcanic collapse. A galaxy may contain billions of stars. The fact gives the joke its teeth.
+The public demo uses a bounded recurring cast. Each character owns a stable, finite sequence of hand-written episodes. Together those episodes form a life.
 
-5. Preserve wonder beneath the joke.
-   The subject may be vain, territorial, professionally ambitious, scientifically pedantic, or magnificently aggrieved. It must never make nature feel cheap, cynical, cruel for its own sake, or disposable.
+Before writing posts, create a short character bible containing:
 
-6. Match the copy to the image.
-   The narrated subject, title, identity, photograph, and any map location must describe the same thing. A dragonfly post needs a dragonfly photograph. A caldera post needs a caldera photograph. Approximate thematic matching is not enough.
+- the exact natural subject and defensible facts about its body, behavior, habitat, senses, and timescale;
+- what can reach its awareness, such as vibration, pressure, chemical traces, polarized light, temperature, gravity, erosion, or orbital time;
+- what it cannot perceive or consistently misunderstands;
+- a desire, fear, comic flaw, and private theory of the world;
+- recurring relationships with prey, predators, neighbors, family, rivals, weather, terrain, or cosmic matter;
+- events that leave a scar, habit, memory, obligation, or changed expectation;
+- a platform and a voice that would remain recognizable if the account name disappeared;
+- phrases, structures, and premises already spent by that character.
 
-7. Treat uniqueness as an editorial requirement, not merely an identifier requirement.
-   Do not duplicate images, complete posts, titles, names, punch lines, factual premises, or conspicuous sentence structures. Changing one noun in a repeated template does not create a new post.
+Write the arc as events, not captions. Appetite creates trouble. Trouble changes behavior. A relationship deepens or breaks. A fear returns in a new form. A revelation alters what the character notices next. Continuity does not require a recap. A later post can reveal memory through one changed action.
 
-8. Keep titles out of body copy.
-   Titles are metadata. The narrator does not recite the title of its own post.
+Different characters may experience the same storm, migration, bloom, predator, reef disturbance, or stellar event from incompatible points of view. Shared events should deepen the world without repeating copy or explaining that the characters inhabit one universe.
 
-   Titles must also read like individually edited headlines. Vary syntax, length, punctuation, point of view, and comic construction across the corpus. Never stamp every subject into one pattern such as `Subject: Invented Place`. A unique noun inside a repeated shell is still a repeated title.
+The runtime must reshuffle how character arcs interleave on each visit. It must preserve chronology inside each character's timeline. Freshness comes from a new interleaving of stable stories, not regenerated prose, altered facts, or shuffled personal history.
 
-9. Keep the world natural.
-   Do not reference computers, software, algorithms, databases, the internet, digital technology, dashboards, roadmaps, notifications, or similar machinery. Workplace language is allowed only as satire inside the LinkedIn voice, and it should describe natural behavior rather than actual technology.
+## Nonhuman interiority
 
-10. Keep people out of the pictures.
-    Prefer pristine nature, microscopy, undersea life, geology, weather, and space. Avoid close-ups of people, travel portraits, cafes, roads, buildings, vehicles, tourist scenes, and human-centered compositions.
+Begin with the subject's body, senses, physical limits, and timescale before choosing a joke or platform voice. An octopus does not merely think like a witty person underwater. A fungus, canyon, dust grain, and supernova should not share one human nervous system with different costumes.
 
-11. Treat structure as content.
-    A new noun inside an old sentence is not new writing. Do not repeatedly open with a label followed by a colon, including `Field note:`, `My testimony:`, `Result:`, `Observed:`, `For the record:`, or `At this location:`. Do not repeatedly join one factual premise to one platform-flavored suffix. The shape of the joke must change along with its subject.
+Translate a genuinely strange experience into legible comedy. A creature may care about pressure, molt, shadow, scent, current, heat, vibration, magnetic direction, or the sudden absence of a familiar chemical trace. A geological or cosmic narrator may experience erosion, collapse, fusion, orbit, or deep time as immediate life.
 
-12. Use memes as seasoning, not scaffolding.
-    Thirst traps, soft launches, choosing violence, understanding the assignment, main-character energy, receipts, plot twists, skill issues, ratios, suspiciously humble career announcements, and other recognizable social forms are welcome when the natural fact earns them. Never repeat the same meme until it becomes the corpus's personality. Never use a meme merely because a platform is associated with it.
+Human social behavior can provide comic recognition, but the natural fact supplies the mind. The platform bends the delivery. It does not supply the character.
 
-13. Keep location metadata out of prose.
-    Coordinates, source locations, and image details belong to structured metadata. Never add an invented place to an identity, title, or body merely to make it unique. A location may appear only as a rare, explicit joke in which the narrator uses an impressive reef, meadow, crater, or other setting to inflate its own status. One location mention is the maximum. Never put the location in both the title and body.
+## Writing one episode
 
-14. Let characters recur.
-    One memorable creature may author several posts. Repetition of a stable character is more believable than manufacturing a new identity for every image. Do not append places, ordinal titles, or generic epithets to make account names unique.
+Start with one exact image and one true natural fact. Decide what physically happens, what the narrator wants, what interrupts it, and what changes afterward. Enter through action or sensation. Stop when the event and joke are complete.
 
-15. Stop when the joke lands.
-    Do not append a moral, verdict, explanation, second metaphor, or summary after the punch line. Most social posts need one or two sentences. A strong fragment may be the entire post.
+Every episode is a first-person dispatch from the pictured natural subject. The first-person presence can arrive after the opening, but the narrator must experience the event rather than describe itself from outside. Avoid repeated introductions such as `I am a` or `I am the`.
 
-16. Celebrate courtship, affection, and animal sexuality.
-    Courtship and mating are part of planetary life, not an awkward appendix to it. Include beautiful photographs that clearly show courting pairs, mating rituals, mutual grooming, touch, dance, gift giving, and shy proximity. The copy may find comedy in crushes, polyamory, changing roles, or complicated relationship structures when the joke is affectionate and grounded in the species' real behavior. Never invent a relationship the photograph does not support, project human consent claims onto animals, or use sexuality as cheap shock. Cute, bashful longing is especially welcome. Keep explicit images scientifically legible and aesthetically tasteful.
+Most social episodes need one or two sentences. Longer reading formats can breathe, but they still need a concrete event rather than an essay wearing feathers.
 
-17. Keep courtship as one strand of a much larger life.
-    The flagship demo may devote no more than seven of its 45 episodes to courtship or family, with no more than two such episodes for any character. Flora Mingo gets four episodes, only one of which may concern courtship. Every animal arc must also contain hunger, danger, weather, movement, transformation, work, play, friendship, solitude, discovery, or another event that has nothing to do with finding a mate. A beautiful pair photograph is not permission to turn the whole corpus into a dating service.
+Keep the story inside the natural world. Do not mention computers, software, algorithms, databases, dashboards, notifications, or the internet. LinkedIn workplace satire still describes survival, growth, migration, predation, geology, or another natural process. It does not turn the creature into an employee of a real organization.
 
-18. Kill performative prose.
-    Cut any line that sounds designed to become a quote card, prove the writer is clever, or make an animal deliver a content strategist's idea of profundity. `Doctrine`, `ceremonial robes`, `philosophy I had not requested`, `panel discussion`, and `review of commitment` are warning signs, not motifs. Put the creature in a physical situation. Let it act, fail, eat, flee, molt, freeze, collide, recover, or misunderstand something. End on the consequence.
+The title is metadata, not dialogue. Write it after the episode. Prefer two to seven words, put the funniest or strangest word early, and make it pay off in both image and body. Nine words is the hard maximum. Do not repeat the account name, invented location, or body copy in the title.
 
-19. Bind every episode to one exact Commons file.
-    Every authored episode must declare `mediaSha1`. That value must equal the `sha1` of exactly one row in `sample-corpus.generated.json`, and that row's `subject` must equal the episode's `subject`. The runtime must not choose the first image for a subject, fall back by array position, or silently substitute another photograph after regeneration. If an exact hash disappears, the build fails until an editor reviews the replacement and updates the binding deliberately.
+Review the draft against nearby posts and the full corpus. The opening, syntax, punctuation, reveal, factual premise, emotional turn, and ending should not feel borrowed from another episode. A new noun inside an old sentence is not new writing.
 
-20. Prove the subject from identity metadata, not description prose.
-    The generator may establish positive subject identity only from the Commons file title and category titles. Commons descriptions can mention nearby species, describe what appears inside a photographed book, or list every bird observed that day. They remain valuable rejection evidence, but they never prove that a photograph contains the requested subject. Explicitly reject band and performance metadata for Praying Mantis, grebe taxonomy in swan searches, photographed pages and books, dead or preserved birds, and comparable human-made display material. A rejection rule must remain narrow enough to preserve living animals photographed in natural behavior.
+If the draft sounds composed for a quote card, a keynote, a panel, or a brand strategist, delete the performance and return to the body in danger, weather, appetite, motion, confusion, play, or wonder.
 
-## Structural variety
+## Humor
 
-Every batch must deliberately mix narrative architecture. Select the structure after selecting the fact and comic target. Never select one wrapper and pour every subject into it.
+The humor is specific, organic, and earned by the event. A character may be vain, shy, petty, frightened, territorial, brilliant, unreliable, hungry, tender, or professionally unbearable. Its comic flaw should collide with the physical world.
 
-Approved structures include:
+Internet idioms and familiar social forms may appear once when a natural fact makes the reference inevitable. They are not a vocabulary bank. Never choose a meme first and pour several animals into it.
 
-- punchline first, explanation second;
-- an overheard line of dialogue;
-- a confession that becomes a boast;
-- a boast interrupted by an inconvenient fact;
-- a grievance addressed to one named rival;
-- mock advice that reveals terrible judgment;
-- a three-beat escalation;
-- a false correction followed by the worse truth;
-- a miniature scene with action and reaction;
-- a question answered too confidently;
-- a list whose final item breaks the list;
-- a before-and-after transformation;
-- an eyewitness account with an unreliable witness;
-- a calm observation that ends in menace;
-- a scientific result whose conclusion becomes personal;
-- a career announcement that accidentally describes geology or predation;
-- a documentary cold open;
-- a footnote that takes over the argument;
-- a parenthetical aside that contains the real joke;
-- a one-line verdict with no setup at all.
+A strong post often leaves a little air around the joke. Do not append a moral, explanatory sentence, second metaphor, summary, or synthetic flourish after it lands.
 
-Vary all of these dimensions across adjacent posts:
+Cruelty exists in nature, but the corpus does not sneer at life. Predation, fear, sex, death, and competition can be funny without making creatures disposable.
 
-- opening word and grammatical subject;
-- sentence count;
-- sentence length;
-- punctuation;
-- location of the factual reveal;
-- location of the punchline;
-- whether the narrator addresses the reader, a rival, or nobody;
-- whether the joke escalates, reverses, confesses, argues, or observes;
-- whether the first-person marker is `I`, `my`, `me`, or an implied first-person action later made explicit;
-- whether the post ends with a verdict, image, threat, concession, question, or sudden silence.
+## Platform pressure
 
-A forty-post review set should contain at least twelve visibly different openings and at least ten visibly different narrative structures. No conspicuous opening phrase or joke scaffold should appear more than twice. Label-plus-colon openings should not appear at all unless a single post has a subject-specific reason to parody a label.
-
-## Meme and feistiness standard
-
-The desired energy is playful confidence with teeth. The narrator may be vain, petty, triumphant, impatient, territorial, or professionally unbearable. The joke should punch upward at pomposity, bad reasoning, unearned confidence, weak rivals, or the absurdity of trying to contain nature in human categories.
-
-Good meme use translates a real natural fact into a familiar social situation:
-
-- a frogfish lure becomes a thirst trap with consequences;
-- a supernova remnant calls the explosion a soft launch;
-- a mantis chooses violence, but only after the bee mistakes the pose for an invitation;
-- a peacock mantis shrimp understands the assignment because its color vision and strike genuinely justify the claim;
-- a tectonic plate brings receipts measured in mountain ranges;
-- gravity calls orbital failure a skill issue;
-- a LinkedIn planet announces a promotion it received from its own mass;
-- a Facebook leaf insect invites Martin to walk around because camouflage has made the path dispute personal.
-
-Bad meme use pastes the same phrase onto unrelated photographs. If the joke would work unchanged for a jellyfish, canyon, beetle, and galaxy, it is not specific enough.
-
-## Title standard
-
-Titles should feel social, edited, and irresistible without becoming tabloid sludge.
-
-- Prefer two to seven words.
-- Put the funniest or strangest word early.
-- Use questions, imperatives, fragments, reversals, mock announcements, and direct claims.
-- Do not repeat the account name in the title.
-- Do not add an identity or place qualifier.
-- Write the title after choosing the post's comic beat. Distill the joke instead of independently generating a headline around it.
-- Keep LinkedIn astronomy titles at 58 characters or fewer.
-- Never use one repeated shell across the corpus, even when the inserted names are unique.
-- Never repeat `Against Modesty`, `Notes from`, `Field Report`, or another house phrase as a series title.
-- Do not let every title end in the same place qualifier or begin with the same identity syntax.
-- Clickbait must be paid off by the image and body. A title may tease the lure, strike, eruption, color, scale, rivalry, or reveal, but it may not promise a fact the post does not contain.
-
-## Platform voices
-
-The factual premise belongs to the subject. The comic form belongs to the platform.
+Platform voice is social pressure applied to an existing character. It is not a wrapper, phrase list, or substitute personality.
 
 ### Instagram
 
-Slightly and comically egotistical. The narrator knows the light is excellent, assumes the landscape is a supporting actor, and treats magnificence as a personal brand that fortunately happens to be justified.
-
-Useful comic ingredients include thirst traps, suspiciously candid poses, soft launches, choosing violence, understanding the assignment, main-character behavior, flattering angles, colors refusing restraint, and the horizon serving as set dressing.
-
-Do not reduce the voice to hashtags, influencer slang, repeated references to filters, or the same modesty joke. Vanity should take different forms, such as pretending the ambush was candid, treating a planetary ring as a casual accessory, accusing the horizon of photobombing, or allowing a rival into frame only for scale.
+Image-conscious, sensuous, and slightly vain. The narrator notices color, pose, light, witness, and spectacle, but must not recycle candid-photo jokes, modesty jokes, or influencer slang.
 
 ### Facebook
 
-Opinionated, adversarial, and locally aggrieved. The narrator has identified somebody who is wrong and intends to settle the matter in public. The disagreement should feel oddly specific and socially familiar.
-
-Useful comic ingredients include appeals processes, neighborhood disputes, unsolicited corrections, territorial leaves, unqualified birds, and a person named Martin who should simply walk around.
-
-The voice may also use `unpopular opinion`, `I said what I said`, receipts, community-meeting melodrama, research conducted by somebody's cousin, and a public correction that becomes more incriminating than the original claim. Vary these devices.
-
-Do not make the voice hateful, partisan, or cruel.
+Personal, relational, and willing to air a specific grievance in public. The conflict should emerge from a real neighbor, predator, family member, boundary, or recurring local event, not the same unqualified antagonist in every post.
 
 ### LinkedIn
 
-Career-oriented workplace satire. The narrator converts survival, camouflage, erosion, migration, or deep time into a suspiciously polished professional triumph. The tone is `look at me, I am so successful`, delivered with Dilbert-like corporate absurdity.
+Self-mythologizing and professionally polished enough to reveal the narrator's ego. Survival, growth, migration, deep time, or ecological advantage may become career theater, but repeated announcement language and generic corporate vocabulary are dead on arrival.
 
-Useful comic ingredients include promotions, strategic ownership, visible leadership, organic growth, stakeholder humility, mentoring, measurable impact, and taking credit before the river circulates minutes.
-
-Titles should be unusually tight. Prefer `Gravity Promoted Me`, `Scaling Wonder`, or `Synergy Goes Galactic` over a complete summary of the post.
-
-Do not reference real employers, products, software, or professional identities. Do not start every body with `Thrilled to announce` or `Proud to share`. Corporate vanity is funniest when its presentation keeps mutating.
+This is the main home for occasional philosophical citation, paraphrase, and invented riffing by characters who are already cerebral and egotistical.
 
 ### X
 
-Comically nerdy and scientific. The narrator records observations, rejects a null hypothesis, identifies uncontrolled variables, invokes sample size, and treats an ordinary rival as a threat to methodological rigor.
+Terse, argumentative, observant, and scientifically literate. The narrator may report evidence, challenge a claim, or develop an alarming private theory without turning every post into the same field note or null-hypothesis joke.
 
-The science joke must remain understandable without a degree. Viral scientific jokes such as `huge if gravitational`, `skill issue`, `source: the entire ocean`, an aggressively rejected null hypothesis, or a rival contaminating the control are welcome when earned by the fact. Keep the post within the platform character limit.
-
-Do not turn every post into the same `Observed` construction. Vary field notes, results, sample reports, and terse arguments.
+X is the only secondary home for philosophical references. Use them less often than on LinkedIn.
 
 ### Substack
 
-Long-form confidence with a grievance worth footnoting. The narrator has written far too much, interviewed colorful sources, added a diagram counsel opposed, and placed the firmest conclusion below the subscription line.
-
-The tone should suggest an intelligent naturalist with one magnificent obsession, not generic newsletter promotion.
+Patient long-form conviction with a subject worth following past the first paragraph. The narrator can investigate, remember, qualify, or obsess without defaulting to subscription jokes or footnote theater.
 
 ### Medium
 
-Reflective explanatory writing that cannot resist a framework, numbered lessons, or a provocative headline. The narrator tries to compress deep time or impossible anatomy into useful takeaways, then notices that the mystery has become suspiciously tidy.
-
-Do not let the listicle structure overpower the subject-specific joke.
+Reflective explanation shaped by one experience. A framework can emerge from the event, but the narrator should not sand mystery into generic lessons.
 
 ### YouTube
 
-Showmanship, episode framing, visual spectacle, and mild production chaos. The narrator offers a close look, a survival demonstration, an unnecessary close-up, or a wide shot that consumes the effects budget.
-
-Do not add actual calls to subscribe, manufactured outrage, or repetitive creator slang.
+Visual showmanship and embodied demonstration. The episode should reveal motion, scale, danger, transformation, or spectacle without manufactured outrage or creator catchphrases.
 
 ### RSS and saved reading
 
-Patient field reporting. These voices can be quieter, but they must remain first person, specific, and funny. Measurement and astonishment should coexist. Saved items should feel worth returning to when attention has recovered from the week.
+Quiet, attentive field reporting. Measurement and astonishment can coexist, but named philosophers and quotation riffs stay out of these channels.
 
-## Subject identities
+## Philosophers and invented quotations
 
-Every identity name should be memorable and connected to the subject. Prefer names such as `Grace Hoppergrass`, `Manny Tis`, `Nudi Branch Manager`, `Tardi Grade`, `Callie Dera`, and `Milky Waylon` over generic human names.
+Named philosophers, direct quotations, attributed paraphrases, and invented riffs may appear only on LinkedIn and X. They appear most often on LinkedIn and occasionally on X. They never appear on Instagram, Facebook, Substack, Medium, YouTube, RSS, or saved reading.
 
-The joke should be legible without becoming a random sequence of puns. The identity must still feel like a character who could have written the post. Characters should recur across several images and posts. Do not generate a new person for every asset, and never attach an invented location to the name by default.
+Across the 500-post corpus, no more than 25 episodes may name a philosopher or use a philosophical quotation. At least three LinkedIn episodes must exist for each such X episode. This is a cap, not a quota. Most characters should never cite anybody.
 
-The Friends Galaxy should distribute people across care levels 1 through 5. Five-star friends belong near the center, receive the most visual prominence, and have breathing room. Provider identities should form believable Facebook, Instagram, LinkedIn, X, and RSS neighborhoods around the social graph.
+Arthur Young, Plato, Alan Watts, Ken Wilber, and similar thinkers can enter only when the idea changes the joke, exposes ego, sharpens a misunderstanding, or advances the character's story. Philosophy cannot arrive after the punch line carrying a moral.
 
-## Image and attribution standard
+A sentence in quotation marks attributed to a real thinker must be verified word for word against a primary source or reputable edition. Record the work and a stable locator in episode provenance. Record the translator for translated work. Quote collections, social cards, and search snippets are leads, not evidence.
 
-The current corpus hotlinks attributable Wikimedia Commons thumbnails. Image binaries do not belong in the repository.
+If exact wording cannot be verified, paraphrase without quotation marks. An invented riff must be visibly and naturally identified as invented. A character can announce an unauthorized revision, imagine what a thinker might have said in its body, or quote itself. Never place invented words in quotation marks beside a real person's name as though that person wrote them. Never blend several thinkers and attribute the composite to one of them.
 
-Every selected image must:
+The 500-post implementation should add machine-readable provenance for philosophical material. A suitable episode field records the thinker, one of `verified-quote`, `attributed-paraphrase`, or `invented-riff`, the source locator when applicable, and whether the invented nature is visible in rendered copy.
 
-- show the stated subject clearly;
-- be visually strong enough for a product demonstration;
-- have a stable source page, named creator when available, and an accepted public or Creative Commons license;
-- have sufficient resolution for feed cards, stories, avatars, and map markers;
+Keep exact quotations short. Prefer original jokes built from the character's physical predicament over borrowed eloquence.
+
+## Theme balance
+
+Courtship, mating, affection, family, and fluid animal relationship structures are part of planetary life. Use photographs that clearly support the behavior. Let shy crushes, mutual display, changing roles, or biologically grounded polyamory be tender and funny without projecting human consent claims or identities onto animals.
+
+They remain a small strand of a much larger life. The current 45-episode corpus contains exactly seven courtship or family episodes, no more than two per character. Flora Mingo has exactly four episodes, only one about courtship. The completed 500-episode corpus may contain no more than 50 combined courtship and family episodes. No character's dominant theme may be mate selection.
+
+Flora needs more migration, feeding, weather, crowd life, solitude, danger, and ordinary flamingo inconvenience before she receives another courtship or family episode. More broadly, do not add romance to an arc until the rest of that life feels abundant.
+
+Across the corpus, hunger, danger, weather, movement, transformation, work, play, friendship, solitude, sleep, discovery, predation, cooperation, aging, repair, death, ecological dependence, deep time, and cosmic change should carry most of the weight.
+
+## Location policy
+
+Coordinates, source locations, and image details belong in structured metadata. Invented places do not belong in identities or titles.
+
+A body may name a place only for a rare, explicit joke in which a creature tries to look important because its reef, meadow, crater, or other setting is impressive. Use one location mention at most in that episode. Fewer than one in 40 bodies may use this exception.
+
+Do not describe where a post came from merely because the metadata contains a location. It sounds like a database trying to socialize.
+
+## Image and attribution policy
+
+The public corpus hotlinks reviewed Wikimedia Commons thumbnails. Image binaries do not belong in the repository.
+
+Each published episode declares one `mediaSha1`. It must resolve to exactly one row in `packages/shared/src/sample-corpus.generated.json`, and that row's `subject` must equal the episode's `subject`. Catalog order, generated IDs, filenames, and source URLs must never retarget an authored episode. If a hash disappears, the build fails until an editor reviews and deliberately binds a replacement.
+
+Each selected image must:
+
+- show the stated subject and the behavior on which the copy depends;
+- be visually strong enough for feed cards, stories, avatars, and map markers;
+- preserve a stable Commons source page, creator, license, alt text, and source hash;
+- use trustworthy source coordinates when map placement is appropriate;
 - avoid duplicate files and duplicate underlying hashes;
-- avoid people, buildings, vehicles, diagrams, illustrations, specimens, labels, and obvious human staging;
-- preserve canonical coordinates when Commons supplies trustworthy latitude and longitude.
+- avoid people, buildings, vehicles, diagrams, illustrations, specimens, labels, photographed pages, and obvious staging;
+- present courtship or mating behavior tastefully, clearly, and without sensational framing.
 
-An episode's `mediaSha1` is its durable editorial pointer. Catalog order, generated IDs, filenames, and source URLs may change presentation or storage details, but none of them may retarget an authored episode. The exact hash and exact subject pair is the binding.
+Positive subject identity comes from the Commons file title and category titles. Description prose can reject a false positive, but it cannot prove the subject. This distinction prevents a nearby species, photographed book, concert image, dead specimen, or keyword list from impersonating the requested animal.
 
-The source generator lives at `scripts/generate-sample-corpus.mjs`. The checked-in runtime catalog lives at `packages/shared/src/sample-corpus.generated.json` and intentionally excludes unused source prose and original dimensions to keep the PWA fast.
+The generator lives at `scripts/generate-sample-corpus.mjs`. The checked-in catalog lives at `packages/shared/src/sample-corpus.generated.json`. The runtime catalog intentionally omits unused source prose and original dimensions to keep the PWA fast.
 
-## Approved tonal examples
+## Identity and graph presentation
 
-These examples define the quality bar. They are references, not templates.
+Every identity name should be memorable, legible, and tied to the subject. Reuse a real character instead of attaching locations, ordinal titles, or generic epithets to manufacture a new identity.
 
-### Instagram, volcanic caldera
+Friends Galaxy people use importance levels 1 through 5. Importance controls only centrality, star size, and luminance. Higher-importance people belong nearer the center and appear larger and brighter. Do not add independent visual cues merely to restate importance. Provider identities still form believable Facebook, Instagram, LinkedIn, X, and RSS neighborhoods.
 
-> Forty million years on hair and makeup, and the cloud arrives late expecting equal billing. I let it stay. Generosity looks magnificent at this altitude.
+## Uniqueness and retired material
 
-### Facebook, leaf insect
+Each episode needs a distinct event, image, title, body, natural fact, comic turn, and consequence. Recurring characters and remembered facts create continuity. Repeated prose creates a content factory.
 
-> Apparently I am blocking the path. This is rich coming from a species that paved half the valley and now needs a sign to locate a waterfall. Walk around, Martin.
+Maintain a corpus-wide ledger of titles, openings, endings, conspicuous phrases, facts, image hashes, event summaries, and character consequences. Machine checks should catch literal and near-literal duplication. Human review must catch the more dangerous case where different words perform the same joke.
 
-### LinkedIn, leaf insect
+The following phrases and devices are retired. Do not revive them through light paraphrase:
 
-> Thrilled to announce my successful pivot from twig nobody noticed to Regional Camouflage Leader. Key learnings: remain motionless, let competitors get eaten, and describe survival as an organic growth strategy.
+- birds lacking credentials;
+- a tree failing to acknowledge somebody's range;
+- claims that a staged image was candid;
+- Manny Tis issuing a three a.m. doctrine;
+- falling into a philosophy the narrator did not request;
+- an ambush reframed as a conversation with a firm conclusion;
+- formulaic soft launches, null hypotheses, key learnings, or ceremonial workplace language.
 
-### X, ladybird
+`Violence, and better lighting.` is approved once as Manny Tis's title. `Crush beside the sponge` is approved once because Frogbert's shy color change belongs specifically to frogfish behavior. They are canon, not patterns.
 
-> Observed: seven spots, two elytra, zero tolerance for your aphid methodology. Null hypothesis rejected on the grounds that I ate it.
+Nova Remains establishes the desired cosmic reach: deep time, matter changing identity, death becoming other lives, and enormous events felt from within. Continue that scale and intimacy without copying Nova's sentence shapes or turning every astronomical post into the same solemn voice.
 
-### Substack, praying mantis
+Manny's near-death episode works when the bird attack, fall, altered perception, impact, and blame unfold as firsthand physical experience. Future revelations should arise from events with consequences. Abstract declarations of doctrine are not events.
 
-> The bee calls it an ambush. I prefer a conversation with an unexpectedly firm conclusion. Paid subscribers receive the full transcript and one foreleg diagram my solicitor begged me not to publish.
+## Expansion workflow to 500
 
-## Common failures
+1. Audit the current cast and preserve accepted continuity before adding material.
+2. Design the bounded roster and write a character bible for each addition.
+3. Outline each arc as a sequence of distinct events with remembered consequences.
+4. Select and visually review exact Commons images for those events.
+5. Write episodes individually from image, fact, body, and character history.
+6. Review one character's complete chronology before interleaving it with the feed.
+7. Review mixed batches for repeated structures, theme clustering, platform flattening, and emotional monotony.
+8. Bind every accepted episode to its exact image hash and provenance.
+9. Run machine checks, then perform the editorial read. A passing test cannot certify humor, truth, image fit, or soul.
 
-### Clinical exposition
+Work in reviewable batches, but keep one corpus-wide ledger. A phrase retired in the first batch remains retired in the tenth. Do not let parallel authors invent isolated canons.
 
-Weak:
+Static authored copy is the only public source. Platform wrappers, noun substitution, randomized sentence fragments, and prompt-time language generation may not write or alter demo episodes.
 
-> I am a praying mantis. I use my forelegs to catch prey.
+## Machine acceptance
 
-Better:
+The 500-post expansion is not complete until automated checks prove:
 
-> The bee calls it an ambush. I prefer a conversation with an unexpectedly firm conclusion.
-
-### Repeated narrator introduction
-
-Weak:
-
-> I am the volcano behind Morning Light Across the Dunes.
-
-Better:
-
-> Forty million years on hair and makeup, and the cloud arrives late expecting equal billing.
-
-### Generic inspiration
-
-Weak:
-
-> Nature is beautiful and reminds us to slow down.
-
-Better:
-
-> One river found my smallest weakness and spent ages turning it into magnificent interior design.
-
-### Platform costume without platform character
-
-Weak:
-
-> Amazing mantis photo. #nature #beautiful
-
-Better:
-
-> One flower objected when I copied its outfit, so I ate the complaint department.
-
-## Writing procedure for additional posts
-
-1. Identify the exact pictured subject.
-2. Find one true behavior, structure, process, scale, or ecological relationship unique to that subject.
-3. Write one first-person comic premise in the subject's own voice.
-4. Remove any opening that introduces or labels the narrator.
-5. Choose one narrative structure from the structural variety list. Check the preceding posts and choose a different shape from theirs.
-6. Choose the platform and reshape the joke using that platform's personality.
-7. Add a meme only if the natural fact makes the meme more specific and funnier.
-8. Add a distinct rival, occasion, or consequence only when it remains coherent with the subject's world.
-9. Stop at the first complete punch line. Delete any sentence that explains, summarizes, or decorates it.
-10. Keep location out of the copy unless the entire joke is the narrator bragging about the status of its setting. Flag that exception explicitly and use it rarely.
-11. Read the post aloud. Remove anything clinical, explanatory, repetitive, merely cute, or shaped like a content template.
-12. Compare it against the entire corpus for repeated images, facts, titles, punch lines, opening phrases, transitions, punctuation rhythms, and sentence structures. Recurring character names are expected.
-13. Confirm that the body never repeats its metadata title.
-14. Confirm that the title is tight, pays off honestly, and does not reuse a house pattern.
-15. Confirm that the post remains reverent even at maximum snark.
-
-## Reusable generation brief
-
-Use the following brief when drafting a new batch:
-
-> Write first-person sample posts narrated by the pictured natural subjects themselves. The world should feel like a nature documentary celebrating the glory and majesty of creation, with universally reverent, non-sectarian language and biting subject-specific humor. Begin inside the joke. Anchor each joke in a true biological, geological, oceanographic, or astronomical detail. Make the narrator feisty, specific, and socially recognizable. Use thirst traps, soft launches, choosing violence, understanding the assignment, receipts, plot twists, skill issues, suspicious career triumphs, and other viral forms only when the subject's real behavior earns the reference. Give Instagram comic vanity, Facebook opinionated neighborhood warfare, LinkedIn absurd career ambition, X nerdy scientific rigor, Substack footnoted long-form conviction, Medium reflective framework-building, YouTube visual showmanship, and RSS or saved reading patient field-report wit. Deliberately rotate narrative architecture among dialogue, confession, reversal, escalation, mock advice, eyewitness account, argument, list, scientific result, career announcement, documentary cold open, and punchline-first fragment. Use recurring characters instead of manufacturing a unique identity for every image. Keep locations in metadata. Mention one only for a rare, explicitly flagged joke about the narrator's status or impressive setting. Stop at the first complete punch line. Do not use label-plus-colon openings. Do not attach one repeated platform suffix to every factual premise. Vary opening words, sentence count, punctuation, reveal placement, punchline placement, and endings. Keep titles social, honest, compact, free of account names, and derived from the post's actual joke. Do not mention digital technology, software, computers, the internet, or generic travel experiences. Keep reverence underneath the snark.
-
-## Engineering procedure for new subjects
-
-When a new subject is added:
-
-1. Add its search phrase, category, and comic identity base to `TOPICS` in `scripts/generate-sample-corpus.mjs`.
-2. Add a strict subject requirement to `TOPIC_REQUIREMENTS` so search results cannot drift to a merely related subject.
-3. Prove positive identity from the Commons file title and category titles. Use its description only to reject false positives or staged material.
-4. Add one factual comic premise to `SUBJECT_PREMISES` in `packages/shared/src/sample-corpus.ts`.
-5. Add or refine category-specific rivals only when they remain plausible within that natural setting.
-6. Regenerate the catalog and inspect the images visually.
-7. Bind each published episode to one reviewed catalog row by exact `mediaSha1`, then verify the row's subject matches the episode subject.
-8. Run the focused generator, shared, and PWA corpus tests.
-9. Run `npm run validate:feature` before publication.
-
-## Acceptance checklist
-
-A corpus addition is not complete until all of the following are true:
-
-- every post has first-person presence without a repeated narrator introduction;
-- every post begins inside a specific joke;
-- every joke contains a defensible natural fact;
-- every platform sounds recognizably different;
-- every displayed image matches the narrated subject;
-- courtship and affection appear as a visible recurring strand of planetary life, with the photographed behavior supporting the joke;
-- jokes about polyamory or fluid roles remain rare, affectionate, and grounded in real species behavior;
-- every image URL and source hash is unique;
-- every episode `mediaSha1` resolves to exactly one catalog row with the same subject, with no positional or subject-first fallback;
-- positive subject identity comes only from Commons titles and categories, while descriptions remain rejection-only evidence;
-- Praying Mantis band imagery, grebes returned for swan searches, photographed books or pages, and dead or preserved birds are absent;
-- every full post and title is editorially coherent, while memorable character identities recur naturally;
-- title openings, punctuation, and grammatical structures remain visibly varied instead of sharing one corpus-wide template;
-- repeated subjects receive distinct opening jokes, not one premise with different trailing clauses;
-- no short label followed by a colon is being used as an opening factory;
-- no meme, rival, verdict, or platform catchphrase appears often enough to become a house tic;
-- a forty-post sample contains at least twelve distinct openings and ten distinct narrative structures;
-- LinkedIn astronomy titles remain at 58 characters or fewer;
-- every clickbait title pays off in the matching photograph and body copy;
-- no body repeats its title;
-- no identity contains an invented location;
-- no title contains an invented location;
-- fewer than 1 in 40 bodies contains an invented location, and every occurrence is an explicit status joke with one location mention;
-- no punch line is followed by an explanatory or decorative ending;
-- no banned technology language appears in rendered copy;
+- exactly 500 authored episodes and 500 uniquely bound reviewed images;
+- unique episode IDs, image hashes, image URLs, titles, and normalized bodies;
+- no repeated opening sentence, closing sentence, or long normalized phrase across unrelated episodes;
+- every `mediaSha1` resolves once and matches the episode subject;
+- all source pages, creators, licenses, alt text, and required coordinates remain present;
+- no invented location appears in an identity or title, and the body exception remains below one in 40;
+- no more than 50 episodes carry `courtship` or `family` themes;
+- no more than 25 episodes contain declared philosophical material;
+- every philosophical episode is on LinkedIn or X, with at least a three-to-one LinkedIn ratio;
+- every verified quotation has source provenance and every invented riff is visibly identified as invented;
 - all X posts remain within 280 characters;
-- all image licenses and source pages remain attributable;
-- map locations use source coordinates and photographic markers;
-- Friends Galaxy identities retain provider neighborhoods and care levels 1 through 5;
-- the demo checkpoint remains deterministic and refreshes to a pristine read-only showcase;
+- all LinkedIn astronomy titles remain within 58 characters;
+- all titles remain within nine words, distinct, honest, and absent from their own bodies;
+- feed interleaving changes between visits without changing episode prose or per-character chronology;
+- known false-positive images and all checked-in image binaries remain absent;
+- the demo checkpoint remains pristine and read-only after refresh;
+- seeded tests reproduce the same checkpoint and shuffle when given the same seed;
 - the PWA production build remains inside its offline cache policy.
+
+Machine review should also emit a report of theme counts, platform counts, character episode counts, recurring n-grams, opening patterns, ending patterns, and image provenance gaps. Treat the report as evidence for editorial review, not a text generator.
+
+## Editorial acceptance
+
+Read every character timeline in order and a large randomized feed sample aloud. For each episode, ask:
+
+- Did something happen?
+- Is the natural fact defensible and essential to the joke?
+- Does the body feel specific to this creature's senses and history?
+- Does the image show what the prose needs?
+- Has this character changed, remembered, desired, feared, or misunderstood something?
+- Does the platform affect delivery without replacing the character?
+- Is the joke new across the entire corpus?
+- Did the prose stop before it explained its own magic?
+- Does the mixed feed contain enough danger, boredom, appetite, play, weather, work, solitude, discovery, and cosmic scale to keep romance in proportion?
+- Does the reader encounter wonder through the event rather than through an instruction to feel wonder?
+
+A 40-post review should contain at least 12 visibly different openings and 10 genuinely different narrative forms. This is a diagnostic after writing, never a menu for assembling posts.
+
+## Reusable writing brief
+
+> Write one event from a recurring natural character's life. Start with a verified fact, enter through action or sensation, and let the character's history shape what happens next. Give the subject a genuinely nonhuman way of perceiving the event. Let the platform tilt the delivery without supplying a meme, sentence pattern, or personality. Make the reader laugh, then notice something astonishing. Stop there.


### PR DESCRIPTION
(AI Generated).

## Summary
- Replace the formula-prone guide with one character-first editorial system for 500 individually authored episodes.
- Limit named philosophy and clearly disclosed invented riffs to LinkedIn and X, with source provenance for real quotations.
- Codify nonhuman interiority, cosmic scale, theme balance, image fidelity, visit reshuffling, uniqueness checks, retired motifs, and Friends Galaxy importance cues.

## Testing
- npm run validate:feature
- git diff --check