### PR TITLE
fix: preserve release lane controls during promotion

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -30,6 +30,14 @@ export const RELEASE_ONLY_FILES = [
 
 export const RELEASE_ONLY_PREFIXES = ["release-notes/"];
 
+// Dev retains assertions for its signed isolated verifier job. Production main
+// intentionally omits that dev-only job, so this test has a reviewed lane-specific
+// variant instead of one blob that can be reverse-integrated between branches.
+const BRANCH_SPECIFIC_RELEASE_LANE_FILES = new Set([
+  ".github/workflows/release.yml",
+  "scripts/release-governance.test.mjs",
+]);
+
 export const FORBIDDEN_MAIN_PR_PREFIXES = ["website/"];
 
 export const PROMOTION_WEBSITE_CONFIG_FILES = ["website/next.config.ts"];
@@ -40,7 +48,6 @@ export const PROMOTION_CONTROL_FILES = [
   "scripts/deploy-pwa-production-snapshot.sh",
   "scripts/promote-dev-to-main.sh",
   "scripts/promote-dev-to-main.test.mjs",
-  "scripts/release-governance.test.mjs",
   "scripts/release-promotion-shared.mjs",
   "scripts/release-promotion.test.mjs",
   "scripts/release.sh",
@@ -155,6 +162,7 @@ export function listPromotionDiffFiles({ fromRef, toRef, cwd }) {
 
   return uniqueSorted([...promotionScopeFiles, ...websiteConfigFiles]).filter(
     (filePath) => {
+      if (BRANCH_SPECIFIC_RELEASE_LANE_FILES.has(filePath)) return false;
       if (isPromotionControlFile(filePath)) return false;
       if (isReleaseOnlyFile(filePath)) return false;
       if (filePath !== CARGO_LOCK_PATH) return true;
@@ -187,7 +195,11 @@ export function listPromotionBranchDiffFiles({ fromRef, toRef, cwd }) {
     ...promotionScopeFiles,
     ...websiteConfigFiles,
     ...releaseNoteFiles,
-  ]).filter((filePath) => !isPromotionControlFile(filePath));
+  ]).filter(
+    (filePath) =>
+      !BRANCH_SPECIFIC_RELEASE_LANE_FILES.has(filePath) &&
+      !isPromotionControlFile(filePath),
+  );
 }
 
 export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
@@ -217,7 +229,11 @@ export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
     ...promotionScopeFiles,
     ...websiteConfigFiles,
     ...releaseNoteFiles,
-  ]).filter((filePath) => !isPromotionControlFile(filePath));
+  ]).filter(
+    (filePath) =>
+      !BRANCH_SPECIFIC_RELEASE_LANE_FILES.has(filePath) &&
+      !isPromotionControlFile(filePath),
+  );
 }
 
 export function listComparisonFiles({ baseRef, headRef, cwd }) {
@@ -302,6 +318,7 @@ export function listMainBackflowDiffFiles({ devRef, mainRef, cwd }) {
 
   return mainChangedFiles
     .filter((filePath) => !isReleaseOnlyFile(filePath))
+    .filter((filePath) => !BRANCH_SPECIFIC_RELEASE_LANE_FILES.has(filePath))
     .filter(
       (filePath) =>
         filePath !== CARGO_LOCK_PATH ||

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -159,6 +159,9 @@ test("the promotion control definition preserves itself", () => {
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release.sh"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/worktree-publish.sh"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/trusted-worktree-publish.sh"));
+  assert.ok(
+    !PROMOTION_CONTROL_FILES.includes("scripts/release-governance.test.mjs"),
+  );
 });
 
 test("listPromotionDiffFiles ignores release-only metadata drift", (t) => {
@@ -350,6 +353,16 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     "packages/pwa/package.json",
     '{\n  "name": "@freed/pwa",\n  "version": "26.7.700"\n}\n',
   );
+  writeRepoFile(
+    cwd,
+    ".github/workflows/release.yml",
+    "name: production-release\n",
+  );
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'production';\n",
+  );
   commitAll(cwd, "release: preserve main version");
   updateOriginRef(cwd, "main");
 
@@ -373,6 +386,16 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     cwd,
     "automation/specs/freed-runtime-observer.json",
     '{\n  "version": "dev"\n}\n',
+  );
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'dev-isolated-verifier';\n",
+  );
+  writeRepoFile(
+    cwd,
+    ".github/workflows/release.yml",
+    "name: dev-isolated-release\n",
   );
   rmSync(path.join(cwd, "docs/PHASE-1-FOUNDATION.md"));
   chmodSync(path.join(cwd, "scripts/release.sh"), 0o755);
@@ -427,6 +450,14 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     /"version": "dev"/,
   );
   assert.equal(
+    git(cwd, ["show", ":scripts/release-governance.test.mjs"]),
+    "export const releaseLane = 'production';",
+  );
+  assert.equal(
+    git(cwd, ["show", ":.github/workflows/release.yml"]),
+    "name: production-release",
+  );
+  assert.equal(
     git(cwd, ["rev-parse", ":packages/pwa/src/icon.bin"]),
     git(cwd, ["rev-parse", "origin/dev:packages/pwa/src/icon.bin"]),
   );
@@ -468,6 +499,13 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     `--snapshot-ref=${git(cwd, ["rev-parse", "origin/dev"])}`,
   ]);
   assert.equal(validated.status, 0, validated.stderr);
+
+  const releaseValidated = runNode(VALIDATE_RELEASE_PROMOTION, [
+    `--cwd=${cwd}`,
+    "--from-ref=origin/dev",
+    "--to-ref=HEAD",
+  ]);
+  assert.equal(releaseValidated.status, 0, releaseValidated.stderr);
 });
 
 test("validate-main-backflow ignores squashed promotion content already in dev history", (t) => {
@@ -1102,6 +1140,38 @@ test("validate-main-backflow ignores release-only main metadata", (t) => {
   ]);
 
   assert.equal(result.status, 0);
+  assert.match(result.stdout, /Main backflow is in sync/);
+});
+
+test("validate-main-backflow permits the reviewed branch-specific release governance test", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'dev-isolated-verifier';\n",
+  );
+  commitAll(cwd, "test: retain dev release verifier assertions");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'production';\n",
+  );
+  commitAll(cwd, "test: retain production release assertions");
+  updateOriginRef(cwd, "main");
+
+  const result = runNode(VALIDATE_MAIN_BACKFLOW, [
+    `--cwd=${cwd}`,
+    "--dev-ref=origin/dev",
+    "--main-ref=origin/main",
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
   assert.match(result.stdout, /Main backflow is in sync/);
 });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep the production release workflow and its governance assertions as a coherent lane-specific pair.
- Let promotion and reverse-integration checks compare only controls that are truly shared between dev and main.

## Testing
- node --test scripts/release-promotion.test.mjs scripts/release-governance.test.mjs (61 passed)
- node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=fix/main-governance-demo-release (passed)
- npm run validate:feature (reached the unrelated existing main website ref-during-render lint failure in RoadmapContent.tsx)