### PR TITLE
fix: restore production release matrix assertions

### DIFF
--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -31,8 +31,9 @@ export const RELEASE_ONLY_FILES = [
 export const RELEASE_ONLY_PREFIXES = ["release-notes/"];
 
 // Dev retains assertions for its signed isolated verifier job. Production main
-// intentionally omits that dev-only job, so this test has a reviewed lane-specific
-// variant instead of one blob that can be reverse-integrated between branches.
+// intentionally omits that dev-only job, so the workflow and its governance
+// test have reviewed lane-specific variants instead of blobs that can be
+// promoted or reverse-integrated between branches.
 const BRANCH_SPECIFIC_RELEASE_LANE_FILES = new Set([
   ".github/workflows/release.yml",
   "scripts/release-governance.test.mjs",
@@ -50,6 +51,7 @@ export const PROMOTION_CONTROL_FILES = [
   "scripts/promote-dev-to-main.test.mjs",
   "scripts/release-promotion-shared.mjs",
   "scripts/release-promotion.test.mjs",
+  "scripts/release-workflow-matrix.test.mjs",
   "scripts/release.sh",
   "scripts/validate-main-pr.mjs",
   "scripts/trusted-worktree-publish.sh",

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -157,6 +157,11 @@ test("the promotion control definition preserves itself", () => {
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release-promotion-shared.mjs"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/deploy-pwa-production-snapshot.sh"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release.sh"));
+  assert.ok(
+    PROMOTION_CONTROL_FILES.includes(
+      "scripts/release-workflow-matrix.test.mjs",
+    ),
+  );
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/worktree-publish.sh"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/trusted-worktree-publish.sh"));
   assert.ok(
@@ -211,12 +216,22 @@ test("an old product snapshot preserves current promotion controls", (t) => {
     "packages/pwa/src/app.ts",
     "export const value = 'selected snapshot';\n",
   );
+  writeRepoFile(
+    cwd,
+    "scripts/release-workflow-matrix.test.mjs",
+    "export const control = 'selected snapshot';\n",
+  );
   commitAll(cwd, "selected product snapshot");
   const snapshotSha = git(cwd, ["rev-parse", "HEAD"]);
 
   writeRepoFile(
     cwd,
     "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
+  writeRepoFile(
+    cwd,
+    "scripts/release-workflow-matrix.test.mjs",
     "export const control = 'current';\n",
   );
   commitAll(cwd, "fix: current promotion control");
@@ -226,6 +241,11 @@ test("an old product snapshot preserves current promotion controls", (t) => {
   writeRepoFile(
     cwd,
     "scripts/validate-main-pr.mjs",
+    "export const control = 'current';\n",
+  );
+  writeRepoFile(
+    cwd,
+    "scripts/release-workflow-matrix.test.mjs",
     "export const control = 'current';\n",
   );
   commitAll(cwd, "fix: backport promotion control");
@@ -244,6 +264,10 @@ test("an old product snapshot preserves current promotion controls", (t) => {
   );
   assert.equal(
     git(cwd, ["show", ":scripts/validate-main-pr.mjs"]),
+    "export const control = 'current';",
+  );
+  assert.equal(
+    git(cwd, ["show", ":scripts/release-workflow-matrix.test.mjs"]),
     "export const control = 'current';",
   );
 });
@@ -1250,6 +1274,66 @@ test("validate-main-pr passes for a fresh promotion branch", (t) => {
 
   assert.equal(result.status, 0);
   assert.match(result.stdout, /Promotion branch matches selected dev snapshot/);
+});
+
+test("validate-main-pr backports the shared matrix test without replacing production governance", (t) => {
+  const cwd = makeTempRepo();
+  t.after(() => rmSync(cwd, { recursive: true, force: true }));
+
+  git(cwd, ["checkout", "dev"]);
+  writeRepoFile(
+    cwd,
+    "scripts/release-workflow-matrix.test.mjs",
+    "export const sharedMatrix = 'current';\n",
+  );
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'dev-isolated-verifier';\n",
+  );
+  commitAll(cwd, "test: update shared and dev release assertions");
+  updateOriginRef(cwd, "dev");
+
+  git(cwd, ["checkout", "main"]);
+  writeRepoFile(
+    cwd,
+    "scripts/release-workflow-matrix.test.mjs",
+    "export const sharedMatrix = 'stale';\n",
+  );
+  writeRepoFile(
+    cwd,
+    "scripts/release-governance.test.mjs",
+    "export const releaseLane = 'production';\n",
+  );
+  commitAll(cwd, "test: retain production release governance");
+  updateOriginRef(cwd, "main");
+  const productionGovernanceBlob = git(cwd, [
+    "rev-parse",
+    "HEAD:scripts/release-governance.test.mjs",
+  ]);
+
+  const branch = "fix/main-governance-release-matrix";
+  git(cwd, ["checkout", "-b", branch, "origin/main"]);
+  writeRepoFile(
+    cwd,
+    "scripts/release-workflow-matrix.test.mjs",
+    "export const sharedMatrix = 'current';\n",
+  );
+  commitAll(cwd, "fix: backport shared release matrix assertions");
+
+  assert.equal(
+    git(cwd, ["rev-parse", "HEAD:scripts/release-governance.test.mjs"]),
+    productionGovernanceBlob,
+  );
+  const result = runNode(VALIDATE_MAIN_PR, [
+    `--cwd=${cwd}`,
+    "--base-ref=origin/main",
+    "--head-ref=HEAD",
+    `--head-branch=${branch}`,
+  ]);
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /Governance backport matches origin\/dev/);
 });
 
 test("validate-main-pr rejects a promotion whose parent is no longer current main", (t) => {

--- a/scripts/release-workflow-matrix.test.mjs
+++ b/scripts/release-workflow-matrix.test.mjs
@@ -8,13 +8,6 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, "..");
 const releaseWorkflowPath = path.join(repoRoot, ".github", "workflows", "release.yml");
-const isolatedDesktopConfigPath = path.join(
-  repoRoot,
-  "packages",
-  "desktop",
-  "src-tauri",
-  "tauri.preview.conf.json",
-);
 
 function loadPrimaryReleaseMatrix() {
   const workflow = readFileSync(releaseWorkflowPath, "utf8");
@@ -92,51 +85,5 @@ test("desktop releases pass the reviewed channel into build metadata", () => {
     workflow,
     /FREED_BUILD_CHANNEL:\s*\$\{\{ needs\.notes\.outputs\.release_channel \}\}/,
     "release builds should stamp the reviewed release channel into runtime identity",
-  );
-});
-
-test("dev releases publish a signed isolated Apple Silicon verifier without updater artifacts", () => {
-  const workflow = readFileSync(releaseWorkflowPath, "utf8");
-  const isolatedConfig = JSON.parse(
-    readFileSync(isolatedDesktopConfigPath, "utf8"),
-  );
-  const isolatedJob = workflow.slice(
-    workflow.indexOf("\n  isolated-dev-macos:"),
-    workflow.indexOf("\n  updater-manifest:"),
-  );
-  const publishJob = workflow.slice(
-    workflow.indexOf("\n  publish:"),
-    workflow.indexOf("\n  # Redeploy the public marketing site"),
-  );
-
-  assert.equal(isolatedConfig.productName, "Freed Preview");
-  assert.equal(
-    isolatedConfig.identifier,
-    "wtf.freed.desktop.sqlite-native-preview",
-  );
-  assert.equal(isolatedConfig.bundle.createUpdaterArtifacts, false);
-
-  assert.match(isolatedJob, /release_channel == 'dev'/);
-  assert.match(isolatedJob, /runs-on: macos-latest/);
-  assert.match(isolatedJob, /--target aarch64-apple-darwin/);
-  assert.match(isolatedJob, /--bundles app/);
-  assert.match(isolatedJob, /--features isolated-preview-data-root/);
-  assert.match(isolatedJob, /--config src-tauri\/tauri\.preview\.conf\.json/);
-  assert.match(
-    isolatedJob,
-    /releaseAssetNamePattern: Freed_Preview_\[version\]_aarch64\[ext\]/,
-  );
-  assert.match(isolatedJob, /uploadUpdaterJson: false/);
-  assert.match(isolatedJob, /uploadUpdaterSignatures: false/);
-  assert.match(isolatedJob, /codesign --verify --deep --strict/);
-  assert.match(isolatedJob, /xcrun stapler validate/);
-  assert.match(
-    isolatedJob,
-    /Print:CFBundleIdentifier[\s\S]*wtf\.freed\.desktop\.sqlite-native-preview/,
-  );
-
-  assert.match(
-    publishJob,
-    /needs\.isolated-dev-macos\.result == 'success' \|\| needs\.isolated-dev-macos\.result == 'skipped'/,
   );
 });


### PR DESCRIPTION
(AI Generated).

## Summary
- Restore the shared release workflow matrix assertions on main without replacing production-specific governance.
- Keep shared promotion controls identical between dev and main.

## Testing
- 65 focused release workflow, promotion, and governance tests passed.
- Full feature validation reached the unrelated existing website roadmap ref lint failure; the backport changes only three release-control files.