### PR TITLE
fix: treat PWA Library contention as a busy state

### DIFF
--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -40,6 +40,7 @@ import {
 } from "./lib/pwa-updater";
 import { isContactPickerAvailable, pickContactViaWebApi } from "./lib/contacts";
 import { PwaFeedEmptyState } from "./components/PwaFeedEmptyState";
+import { PwaLibraryBusyScreen } from "./components/PwaLibraryBusyScreen";
 import {
   PwaDemoSyncSettings,
   PwaSyncSettings,
@@ -219,8 +220,13 @@ function FloatingNotice({
 function App() {
   const initialize = useAppStore((state) => state.initialize);
   const isInitialized = useAppStore((state) => state.isInitialized);
+  const initializationBlocker = useAppStore(
+    (state) => state.initializationBlocker,
+  );
   const error = useAppStore((state) => state.error);
-  const setError = useAppStore((state) => state.setError);
+  const setInitializationFailure = useAppStore(
+    (state) => state.setInitializationFailure,
+  );
   const setSyncConnected = useAppStore((state) => state.setSyncConnected);
   const [showUpdateBanner, setShowUpdateBanner] = useState(false);
   const [installNotice, setInstallNotice] = useState<InstallNotice | null>(
@@ -279,15 +285,7 @@ function App() {
           return initialize();
         })
         .catch((error) => {
-          console.error(
-            "[demo] failed to activate showcase checkpoint:",
-            error,
-          );
-          setError(
-            error instanceof Error
-              ? error.message
-              : "Freed could not prepare the showcase Library",
-          );
+          setInitializationFailure(error);
         });
       return;
     }
@@ -298,17 +296,9 @@ function App() {
     void ensurePwaLibraryCoreLocalSampleState()
       .then(() => initialize())
       .catch((error) => {
-        console.error(
-          "[sample-data] failed to initialize local preview data:",
-          error,
-        );
-        setError(
-          error instanceof Error
-            ? error.message
-            : "Freed could not prepare the local preview Library",
-        );
+        setInitializationFailure(error);
       });
-  }, [initialize, legalAccepted, setError]);
+  }, [initialize, legalAccepted, setInitializationFailure]);
 
   useEffect(() => {
     if (!isInitialized || !IS_FEATURE_PREVIEW || IS_DEMO) return;
@@ -634,6 +624,10 @@ function App() {
         </p>
       </div>
     );
+  }
+
+  if (initializationBlocker === "library_busy" && !isInitialized) {
+    return <PwaLibraryBusyScreen onRetry={() => window.location.reload()} />;
   }
 
   if (error && !isInitialized) {

--- a/packages/pwa/src/components/PwaLibraryBusyScreen.test.ts
+++ b/packages/pwa/src/components/PwaLibraryBusyScreen.test.ts
@@ -1,0 +1,50 @@
+import { act, createElement } from "react";
+import { createRoot } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PwaLibraryBusyScreen } from "./PwaLibraryBusyScreen";
+
+describe("PwaLibraryBusyScreen", () => {
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+
+  afterEach(() => {
+    document.body.innerHTML = "";
+    (
+      globalThis as typeof globalThis & {
+        IS_REACT_ACT_ENVIRONMENT?: boolean;
+      }
+    ).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("explains the single-tab condition without destructive recovery", () => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+    const root = createRoot(container);
+    const onRetry = vi.fn();
+
+    act(() => {
+      root.render(createElement(PwaLibraryBusyScreen, { onRetry }));
+    });
+
+    expect(container.textContent).toContain("Freed is open in another tab");
+    expect(container.textContent).toContain("Return to the other tab");
+    expect(container.textContent).not.toContain("fatal error");
+    expect(container.textContent).not.toContain("Replace local Library");
+    expect(container.textContent).not.toContain("crash report");
+
+    const retry = Array.from(container.querySelectorAll("button")).find(
+      (button) => button.textContent === "Retry here",
+    );
+    act(() => {
+      retry?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+    expect(onRetry).toHaveBeenCalledOnce();
+
+    act(() => root.unmount());
+  });
+});

--- a/packages/pwa/src/components/PwaLibraryBusyScreen.tsx
+++ b/packages/pwa/src/components/PwaLibraryBusyScreen.tsx
@@ -1,0 +1,30 @@
+interface PwaLibraryBusyScreenProps {
+  onRetry: () => void;
+}
+
+export function PwaLibraryBusyScreen({ onRetry }: PwaLibraryBusyScreenProps) {
+  return (
+    <main className="app-theme-shell flex h-screen min-h-screen items-center px-4 py-8 text-[var(--theme-text-primary)]">
+      <section className="theme-dialog-shell mx-auto w-full max-w-2xl p-6">
+        <p className="text-xs font-semibold uppercase tracking-[0.2em] text-[var(--theme-text-muted)]">
+          Library already open
+        </p>
+        <h1 className="mt-3 text-3xl font-semibold text-[var(--theme-text-primary)]">
+          Freed is open in another tab
+        </h1>
+        <p className="mt-3 max-w-xl text-sm text-[var(--theme-text-muted)]">
+          Freed keeps one tab connected to your local Library at a time to
+          protect queued edits and offline content. Return to the other tab, or
+          close it and retry here.
+        </p>
+        <button
+          type="button"
+          onClick={onRetry}
+          className="theme-accent-button mt-5 rounded-xl px-4 py-2.5 text-sm font-medium transition-colors"
+        >
+          Retry here
+        </button>
+      </section>
+    </main>
+  );
+}

--- a/packages/pwa/src/lib/library-core-sqlite-client.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-client.test.ts
@@ -5,7 +5,10 @@ import {
   LIBRARY_CORE_SQLITE_PROTOCOL_VERSION,
   LIBRARY_CORE_SQLITE_SCHEMA_VERSION,
 } from "@freed/shared/library-core";
-import { PwaLibraryCoreSqliteClient } from "./library-core-sqlite-client";
+import {
+  PwaLibraryCoreSqliteClient,
+  isPwaLibraryCoreSqliteBusyError,
+} from "./library-core-sqlite-client";
 
 class FakeWorker {
   static latest: FakeWorker | null = null;
@@ -172,6 +175,28 @@ describe("PWA SQLite worker response boundary", () => {
     });
 
     await expect(pending).resolves.toEqual(validStatus());
+    client.dispose();
+  });
+
+  it("preserves a busy Library response as a typed startup condition", async () => {
+    const client = new PwaLibraryCoreSqliteClient();
+    const pending = client.open();
+    const worker = activeWorker();
+    worker.respond({
+      code: "library_busy",
+      message: "PWA Library SQLite is already open in another app window",
+      ok: false,
+      requestId: requestId(worker),
+    });
+
+    const error = await pending.catch((reason: unknown) => reason);
+
+    expect(isPwaLibraryCoreSqliteBusyError(error)).toBe(true);
+    expect(error).toMatchObject({
+      code: "library_busy",
+      message: "PWA Library SQLite is already open in another app window",
+      name: "PwaLibraryCoreSqliteWorkerError",
+    });
     client.dispose();
   });
 

--- a/packages/pwa/src/lib/library-core-sqlite-client.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-client.ts
@@ -147,6 +147,32 @@ const REQUEST_TIMEOUT_MS = 30_000;
 const WORKER_ERROR_MAXIMUM_UTF8_BYTES = 4_096;
 const textEncoder = new TextEncoder();
 
+type PwaLibraryCoreSqliteWorkerErrorCode =
+  | "invalid_request"
+  | "library_busy"
+  | "sqlite_initialization_failed"
+  | "sqlite_integrity_failed";
+
+export class PwaLibraryCoreSqliteWorkerError extends Error {
+  readonly code: PwaLibraryCoreSqliteWorkerErrorCode;
+
+  constructor(code: PwaLibraryCoreSqliteWorkerErrorCode, message: string) {
+    super(message);
+    this.code = code;
+    this.name = "PwaLibraryCoreSqliteWorkerError";
+  }
+}
+
+export function isPwaLibraryCoreSqliteBusyError(
+  error: unknown,
+): error is PwaLibraryCoreSqliteWorkerError &
+  Readonly<{ code: "library_busy" }> {
+  return (
+    error instanceof PwaLibraryCoreSqliteWorkerError &&
+    error.code === "library_busy"
+  );
+}
+
 export class PwaLibraryCoreSqliteWorkerUnavailableError extends Error {
   readonly code = "pwa_sqlite_worker_unavailable" as const;
 
@@ -893,7 +919,9 @@ export class PwaLibraryCoreSqliteClient {
           "PWA Library SQLite worker failure response is not closed",
         );
       }
-      pending.reject(new Error(response.message));
+      pending.reject(
+        new PwaLibraryCoreSqliteWorkerError(response.code, response.message),
+      );
     } catch (error) {
       pending.reject(
         error instanceof Error

--- a/packages/pwa/src/lib/store.ts
+++ b/packages/pwa/src/lib/store.ts
@@ -70,6 +70,7 @@ import {
   mutatePwaDeviceGraphLayout,
   queryPwaNormalizedLibrary,
 } from "./library-core-sqlite-runtime";
+import { isPwaLibraryCoreSqliteBusyError } from "./library-core-sqlite-client";
 
 let appInitializationPromise: Promise<void> | null = null;
 let documentSubscriptionTeardown: (() => void) | null = null;
@@ -93,6 +94,8 @@ function recordReadStateInfo(
 
 /** PWA-specific store state — extends the shared base with sync connection status. */
 interface AppState extends BaseAppState {
+  initializationBlocker: "library_busy" | null;
+  setInitializationFailure: (error: unknown) => void;
   syncConnected: boolean;
   setSyncConnected: (connected: boolean) => void;
 }
@@ -288,6 +291,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   isLoading: true,
   isSyncing: false,
   isInitialized: false,
+  initializationBlocker: null,
   error: null,
   activeFilter: {},
   selectedItemId: null,
@@ -313,7 +317,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     appInitializationPromise = (async () => {
       const runtimeLifecycle = capturePwaRuntimeLifecycle();
       try {
-        set({ isLoading: true });
+        set({ error: null, initializationBlocker: null, isLoading: true });
         const state = await initializePwaLibraryCoreState();
         runtimeLifecycle.assertCurrent();
         migrateLegacyDeviceDisplayPreferences(state.preferences.display as unknown);
@@ -350,20 +354,11 @@ export const useAppStore = create<AppState>((set, get) => ({
             getDeviceDisplayPreferences().feedSignalModes,
           ),
           isInitialized: true,
+          initializationBlocker: null,
           isLoading: false,
         });
       } catch (error) {
-        recordRuntimeError({ source: "pwa:initialize", error, fatal: false });
-        recordBugReportEvent(
-          "pwa:initialize",
-          "error",
-          "Initialization failed",
-        );
-        set({
-          error:
-            error instanceof Error ? error.message : "Failed to initialize",
-          isLoading: false,
-        });
+        get().setInitializationFailure(error);
       }
     })().finally(() => {
       appInitializationPromise = null;
@@ -800,6 +795,25 @@ export const useAppStore = create<AppState>((set, get) => ({
   setLoading: (isLoading) => set({ isLoading }),
   setSyncing: (isSyncing) => set({ isSyncing }),
   setError: (error) => set({ error }),
+  setInitializationFailure: (error) => {
+    const initializationBlocker = isPwaLibraryCoreSqliteBusyError(error)
+      ? "library_busy"
+      : null;
+    if (initializationBlocker === null) {
+      recordRuntimeError({ source: "pwa:initialize", error, fatal: false });
+      recordBugReportEvent("pwa:initialize", "error", "Initialization failed");
+    }
+    set({
+      error:
+        initializationBlocker === null
+          ? error instanceof Error
+            ? error.message
+            : "Failed to initialize"
+          : null,
+      initializationBlocker,
+      isLoading: false,
+    });
+  },
   setSearchQuery: (searchQuery) => set({ searchQuery }),
   setActiveView: (activeView) => set({ activeView }),
   openMapForPerson: (personId) =>

--- a/packages/pwa/tests/sqlite-opfs-durability.spec.ts
+++ b/packages/pwa/tests/sqlite-opfs-durability.spec.ts
@@ -110,6 +110,7 @@ async function openLibrary(page: Page): Promise<void> {
 
 async function launchPersistentLibraryContext(
   profileRoot: string,
+  baseURL = pwaOpfsE2eBaseUrl,
 ): Promise<BrowserContext> {
   const iphone = devices["iPhone 14"];
   return webkit.launchPersistentContext(profileRoot, {
@@ -119,7 +120,7 @@ async function launchPersistentLibraryContext(
     deviceScaleFactor: iphone.deviceScaleFactor,
     isMobile: iphone.isMobile,
     hasTouch: iphone.hasTouch,
-    baseURL: pwaOpfsE2eBaseUrl,
+    baseURL,
     headless: true,
   });
 }
@@ -641,8 +642,13 @@ test("iPhone WebKit treats a second Library tab as busy, not corrupted", async (
   let context: BrowserContext | null = null;
 
   try {
-    const opened = await openPersistentLibrary(profileRoot);
-    context = opened.context;
+    // This case interrupts sample writes when the owning tab closes. Give it
+    // its own origin as well as its own profile to isolate WebKit OPFS state.
+    const busyOrigin = new URL(pwaOpfsE2eBaseUrl);
+    busyOrigin.hostname = "localhost";
+    context = await launchPersistentLibraryContext(profileRoot, busyOrigin.origin);
+    const firstPage = context.pages()[0] ?? (await context.newPage());
+    await openLibrary(firstPage);
     const secondPage = await context.newPage();
     await secondPage.goto("/");
     await acceptLegalGate(secondPage);
@@ -662,7 +668,7 @@ test("iPhone WebKit treats a second Library tab as busy, not corrupted", async (
       secondPage.getByRole("button", { name: "Replace local Library" }),
     ).toHaveCount(0);
 
-    await opened.page.close();
+    await firstPage.close();
     await secondPage.getByRole("button", { name: "Retry here" }).click();
     await waitForLibrary(secondPage);
   } finally {

--- a/packages/pwa/tests/sqlite-opfs-durability.spec.ts
+++ b/packages/pwa/tests/sqlite-opfs-durability.spec.ts
@@ -634,6 +634,43 @@ test("iPhone WebKit reopens and signs with the same actor key", async () => {
   }
 });
 
+test("iPhone WebKit treats a second Library tab as busy, not corrupted", async () => {
+  const profileRoot = await mkdtemp(
+    join(tmpdir(), "freed-pwa-library-busy-webkit-"),
+  );
+  let context: BrowserContext | null = null;
+
+  try {
+    const opened = await openPersistentLibrary(profileRoot);
+    context = opened.context;
+    const secondPage = await context.newPage();
+    await secondPage.goto("/");
+    await acceptLegalGate(secondPage);
+
+    await expect(
+      secondPage.getByRole("heading", {
+        name: "Freed is open in another tab",
+      }),
+    ).toBeVisible({ timeout: 60_000 });
+    await expect(
+      secondPage.getByRole("button", { name: "Retry here" }),
+    ).toBeVisible();
+    await expect(
+      secondPage.getByRole("heading", { name: "Freed hit a fatal error" }),
+    ).toHaveCount(0);
+    await expect(
+      secondPage.getByRole("button", { name: "Replace local Library" }),
+    ).toHaveCount(0);
+
+    await opened.page.close();
+    await secondPage.getByRole("button", { name: "Retry here" }).click();
+    await waitForLibrary(secondPage);
+  } finally {
+    await context?.close();
+    await rm(profileRoot, { force: true, recursive: true });
+  }
+});
+
 test("iPhone WebKit rejects a corrupted accepted OPFS SQLite generation", async () => {
   test.setTimeout(180_000);
   const profileRoot = await mkdtemp(


### PR DESCRIPTION
(AI Generated).

## Summary
- Opening a second PWA tab shows a Library-already-open screen with safe retry instead of fatal recovery or Library replacement. Preserve typed library_busy errors through startup.
- Isolate the two-tab WebKit test by origin so its interrupted sample writes do not share origin storage with durability tests.

## Testing
- Full local validate:dev passed, including native tests and browser regression suites.
- After test isolation adjustment, validate:feature passed with 371 PWA unit tests and all 6 WebKit durability tests.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `a0b074fc3eca3549e82e5b6d1c3279ecac3c225d`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-library-busy-screen-20260904`
- Provider review decision: `diff_authorized`
- Provider review artifact: `038cf4224880c96115627cb8383cf7a97c3ac960a84fca95f167e9bc2bf52f48`
- Providers: other
- Observable behavior: No provider-visible behavior changes. The PWA classifies local OPFS Library lock contention and renders a non-destructive local busy screen.
- Fingerprinting risk: None. The diff does not change provider requests, navigation, timing, retries, cookies, headers, extraction, login, media loading, or background activity.
- Lowest profile alternative: Keep provider traffic disabled while validating the local cross-tab startup path.

Files bound into this provider review:
- `packages/pwa/src/App.tsx`
- `packages/pwa/src/lib/store.ts`