### PR TITLE
fix: stage website deployments from immutable sources

### DIFF
--- a/.github/workflows/website-preview.yml
+++ b/.github/workflows/website-preview.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Test instruction validators
         run: node --test scripts/validate-agent-instructions.test.mjs scripts/validate-skills.test.mjs
 
+      - name: Test manual deployment contract
+        run: bash -n scripts/vercel-deploy-preview.sh scripts/vercel-deploy-production.sh && node --test scripts/deploy-website.test.mjs
+
       - name: Validate agent instructions
         run: npm run validate:agent-instructions
 

--- a/docs/WEBSITE-MANUAL-DEPLOYMENT.md
+++ b/docs/WEBSITE-MANUAL-DEPLOYMENT.md
@@ -1,0 +1,60 @@
+# Manual website deployment fallback
+
+Vercel Git integration remains the normal publication path. This repair is
+implemented and covered by offline tests, but live qualification is blocked:
+the permitted `aubreyfs-projects` scope returns "The specified scope does not
+exist" with CLI 56.1.0 and 59.11.7. Do not treat offline tests as deployment
+proof or bypass the root's manual-fallback stop until that live qualification
+is complete.
+
+## Contract
+
+The website shell entrypoints delegate to `scripts/deploy-website.mjs`.
+The `www` copies reject PWA deployment. Product-lane copies retain their
+separate PWA implementation. This is an intentional lane difference.
+
+The helper requires the pinned Node version and a clean committed checkout
+based on fetched `origin/www`. Production requires the exact live `www` head,
+checked before staging and again after the build. It archives tracked source
+at one immutable commit into a private temporary directory. Ignored local
+credentials, `.vercel` links, `node_modules`, and build output never enter the
+archive. The source archive has a SHA-256 recorded in deployment metadata.
+
+The stage preserves the monorepo, lockfile, release-note inputs, shared
+packages, and website Next.js configuration. It does not manufacture a Vite
+configuration or install an incomplete workspace graph. Vercel commands run
+in that temporary stage, never in the user's repository root.
+
+The project binding is explicit: `freed-www`, project
+`prj_YkKRjNQXFDQ7YUU01VDc2dQZFbet`, team
+`team_SOkY8Pdbb8c1sY0pKSzczMjW`, scope `aubreyfs-projects`.
+These IDs match the existing local website link. The helper must confirm them
+against the live API, including the `website` root and `nextjs` framework,
+before pulling settings or deploying. It never creates or relinks a project.
+If the project moved, resolve identity explicitly instead of substituting an
+account or copying an unrelated ignored link.
+
+The pinned CLI pulls the selected environment, builds through Vercel, and
+deploys only the prebuilt result. It reads back READY state, project, source,
+target, deployment ID, and URL. An ambiguous response is an inspection stop,
+not permission to redeploy. Cleanup removes only the temporary stage created
+by that invocation.
+
+## Qualification and use
+
+Run `node --test scripts/deploy-website.test.mjs` with the pinned Node toolchain.
+The tests use synthetic repositories and mocked Vercel responses. They prove
+staging, exclusion, lane fencing, command sequencing, identity rejection, and
+cleanup. They do not prove credentials, provider build settings, or a live
+deployment.
+
+After access is restored, qualify a clean committed `www` task candidate with
+`./scripts/vercel-deploy-preview.sh website`. Preserve the returned source SHA,
+archive digest, deployment ID, and URL, then inspect the actual preview. Only
+after successful live qualification and review should the temporary root and
+skill fallback stops be replaced with routes to this contract.
+
+An authorized production fallback uses
+`./scripts/vercel-deploy-production.sh website` from exact clean `origin/www`.
+Level 6 or 7 is required. Prefer `VERCEL_TOKEN` in the environment over a token
+in shell history. Do not paste credentials into task evidence.

--- a/scripts/deploy-website.mjs
+++ b/scripts/deploy-website.mjs
@@ -1,0 +1,256 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+export const WEBSITE = Object.freeze({
+  scope: "aubreyfs-projects",
+  projectName: "freed-www",
+  projectId: "prj_YkKRjNQXFDQ7YUU01VDc2dQZFbet",
+  orgId: "team_SOkY8Pdbb8c1sY0pKSzczMjW",
+  cli: "vercel@59.11.7",
+});
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+export function verifyWebsiteProject(project) {
+  if (
+    project?.id !== WEBSITE.projectId ||
+    project?.accountId !== WEBSITE.orgId ||
+    project?.name !== WEBSITE.projectName ||
+    project?.rootDirectory !== "website" ||
+    project?.framework !== "nextjs"
+  ) {
+    throw new Error(
+      "Website project, team, Next.js framework, or website root identity mismatch. Do not relink or create a project.",
+    );
+  }
+}
+
+export function verifyWebsiteDeployment(deployment, { sourceSha, target, archiveSha256 }) {
+  if (
+    !/^dpl_[A-Za-z0-9]+$/.test(deployment?.id ?? "") ||
+    deployment?.projectId !== WEBSITE.projectId ||
+    deployment?.readyState !== "READY" ||
+    (deployment?.target ?? "preview") !== target ||
+    deployment?.meta?.freedSourceSha !== sourceSha ||
+    deployment?.meta?.freedArchiveSha256 !== archiveSha256 ||
+    !/^[a-f0-9]{64}$/.test(archiveSha256 ?? "") ||
+    typeof deployment?.url !== "string" ||
+    !/^[a-z0-9-]+\.vercel\.app$/.test(deployment.url)
+  ) {
+    throw new Error(
+      "Deployment is not READY for the exact website project, source, and target.",
+    );
+  }
+  return {
+    deploymentId: deployment.id,
+    url: "https://" + deployment.url,
+    sourceSha,
+    target,
+  };
+}
+
+/** Stage immutable tracked bytes only. Never include ignored credentials or local build output. */
+export function stageWebsite({ repoRoot = root, target, exec = execFileSync }) {
+  if (!["preview", "production"].includes(target))
+    throw new Error("Target must be preview or production.");
+  const git = (...args) =>
+    exec("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      maxBuffer: 16 * 1024 * 1024,
+    }).trim();
+  if (git("status", "--porcelain", "--untracked-files=all"))
+    throw new Error("Website deployment requires a clean committed worktree.");
+  const sourceSha = git("rev-parse", "--verify", "HEAD^{commit}");
+  const laneSha = git("rev-parse", "--verify", "origin/www^{commit}");
+  if (target === "production" && sourceSha !== laneSha)
+    throw new Error("Production website deployment requires exact origin/www.");
+  exec("git", ["merge-base", "--is-ancestor", laneSha, sourceSha], {
+    cwd: repoRoot,
+    stdio: "pipe",
+  });
+  if (target === "production") {
+    const remote = git(
+      "ls-remote",
+      "--exit-code",
+      "origin",
+      "refs/heads/www",
+    ).split(/\s+/)[0];
+    if (remote !== sourceSha)
+      throw new Error("Remote www moved. Refresh and review before deploying.");
+  }
+  const archive = exec("git", ["archive", "--format=tar", sourceSha], {
+    cwd: repoRoot,
+    maxBuffer: 256 * 1024 * 1024,
+  });
+  const stage = mkdtempSync(path.join(os.tmpdir(), "freed-website-deploy-"));
+  try {
+    exec("tar", ["-xf", "-", "-C", stage], {
+      input: archive,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const manifest = JSON.parse(
+      readFileSync(path.join(stage, "website/package.json"), "utf8"),
+    );
+    const config = JSON.parse(
+      readFileSync(path.join(stage, "website/vercel.json"), "utf8"),
+    );
+    if (
+      manifest.name !== "website" ||
+      !manifest.dependencies?.next ||
+      config.framework !== "nextjs"
+    )
+      throw new Error("Staged target is not the website Next.js application.");
+    mkdirSync(path.join(stage, ".vercel"), { recursive: true });
+    writeFileSync(
+      path.join(stage, ".vercel/project.json"),
+      JSON.stringify({
+        projectId: WEBSITE.projectId,
+        orgId: WEBSITE.orgId,
+        projectName: WEBSITE.projectName,
+      }) + "\n",
+    );
+    return {
+      stage,
+      sourceSha,
+      target,
+      archiveSha256: createHash("sha256").update(archive).digest("hex"),
+    };
+  } catch (error) {
+    rmSync(stage, { recursive: true, force: true });
+    throw error;
+  }
+}
+
+export function deployWebsite({
+  target,
+  repoRoot = root,
+  exec = execFileSync,
+}) {
+  const pinned = readFileSync(path.join(repoRoot, ".nvmrc"), "utf8")
+    .trim()
+    .replace(/^v/, "");
+  if (process.versions.node !== pinned)
+    throw new Error("Use Node " + pinned + " from .nvmrc before deploying.");
+  const bundle = stageWebsite({ repoRoot, target, exec });
+  const npx = path.join(path.dirname(process.execPath), "npx");
+  const env = {
+    ...process.env,
+    VERCEL_ORG_ID: WEBSITE.orgId,
+    VERCEL_PROJECT_ID: WEBSITE.projectId,
+  };
+  // Explicit IDs replace local .vercel state. The live API must confirm them
+  // before pull, build, or deploy. All commands run only in the temporary stage.
+  const vercel = (args, capture = false) =>
+    exec(
+      npx,
+      [
+        "--yes",
+        WEBSITE.cli,
+        ...args,
+        "--scope",
+        WEBSITE.scope,
+        ...(process.env.VERCEL_TOKEN
+          ? ["--token", process.env.VERCEL_TOKEN]
+          : []),
+      ],
+      {
+        cwd: bundle.stage,
+        env,
+        encoding: "utf8",
+        maxBuffer: 32 * 1024 * 1024,
+        stdio: capture ? ["ignore", "pipe", "inherit"] : "inherit",
+      },
+    );
+  try {
+    verifyWebsiteProject(
+      JSON.parse(vercel(["api", "/v9/projects/" + WEBSITE.projectId], true)),
+    );
+    vercel(["pull", "--yes", "--environment", target]);
+    const pulled = JSON.parse(
+      readFileSync(path.join(bundle.stage, ".vercel/project.json"), "utf8"),
+    );
+    if (
+      pulled.projectId !== WEBSITE.projectId ||
+      pulled.orgId !== WEBSITE.orgId ||
+      pulled.settings?.rootDirectory !== "website"
+    )
+      throw new Error(
+        "Pulled project settings do not match the verified website.",
+      );
+    vercel(["build", ...(target === "production" ? ["--prod"] : [])]);
+    if (target === "production") {
+      const latest = exec(
+        "git",
+        ["ls-remote", "--exit-code", "origin", "refs/heads/www"],
+        { cwd: repoRoot, encoding: "utf8" },
+      ).split(/\s+/)[0];
+      if (latest !== bundle.sourceSha)
+        throw new Error("Remote www moved during build. Nothing was deployed.");
+    }
+    const url = vercel(
+      [
+        "deploy",
+        "--prebuilt",
+        "--yes",
+        "--meta",
+        "freedSourceSha=" + bundle.sourceSha,
+        "--meta",
+        "freedArchiveSha256=" + bundle.archiveSha256,
+        ...(target === "production" ? ["--prod"] : []),
+      ],
+      true,
+    ).trim();
+    if (!/^https:\/\/[a-z0-9-]+\.vercel\.app$/.test(url))
+      throw new Error(
+        "Deployment returned no unambiguous Vercel URL. Inspect before retrying.",
+      );
+    const deployment = JSON.parse(
+      vercel(
+        [
+          "api",
+          "/v13/deployments/" + encodeURIComponent(new URL(url).hostname),
+        ],
+        true,
+      ),
+    );
+    if ("https://" + deployment.url !== url) throw new Error("Deployment API identity does not match the returned URL.");
+    return {
+      ...verifyWebsiteDeployment(deployment, bundle),
+      archiveSha256: bundle.archiveSha256,
+    };
+  } finally {
+    // stageWebsite created this exact private temporary directory.
+    rmSync(bundle.stage, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  try {
+    if (process.argv.length !== 3)
+      throw new Error(
+        "Usage: node scripts/deploy-website.mjs preview|production",
+      );
+    process.stdout.write(
+      JSON.stringify(deployWebsite({ target: process.argv[2] }), null, 2) +
+        "\n",
+    );
+  } catch (error) {
+    const message = process.env.VERCEL_TOKEN
+      ? error.message.replaceAll(process.env.VERCEL_TOKEN, "[redacted]")
+      : error.message;
+    process.stderr.write(message + "\n");
+    process.exitCode = 1;
+  }
+}

--- a/scripts/deploy-website.test.mjs
+++ b/scripts/deploy-website.test.mjs
@@ -1,0 +1,196 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+  rmSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import {
+  WEBSITE,
+  stageWebsite,
+  deployWebsite,
+  verifyWebsiteProject,
+  verifyWebsiteDeployment,
+} from "./deploy-website.mjs";
+
+function fixture(t) {
+  const repoRoot = mkdtempSync(
+    path.join(os.tmpdir(), "freed-website-fixture-"),
+  );
+  t.after(() => rmSync(repoRoot, { recursive: true, force: true }));
+  const git = (...args) =>
+    execFileSync("git", args, {
+      cwd: repoRoot,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    }).trim();
+  git("init", "--initial-branch=www");
+  git("config", "user.name", "Fixture");
+  git("config", "user.email", "fixture@example.invalid");
+  mkdirSync(path.join(repoRoot, "website"));
+  writeFileSync(
+    path.join(repoRoot, "website/package.json"),
+    JSON.stringify({ name: "website", dependencies: { next: "15.5.15" } }),
+  );
+  writeFileSync(
+    path.join(repoRoot, "website/vercel.json"),
+    JSON.stringify({ framework: "nextjs" }),
+  );
+  writeFileSync(
+    path.join(repoRoot, ".gitignore"),
+    ".vercel\n.env*\n.next\nnode_modules\n",
+  );
+  writeFileSync(path.join(repoRoot, ".nvmrc"), process.versions.node);
+  git("add", ".");
+  git("commit", "-m", "fixture");
+  git("update-ref", "refs/remotes/origin/www", "HEAD");
+  git("remote", "add", "origin", repoRoot);
+  writeFileSync(
+    path.join(repoRoot, "website/.env.local"),
+    "synthetic private data\n",
+  );
+  return { repoRoot, git };
+}
+
+test("archive staging is deterministic and excludes ignored credentials without local project links", (t) => {
+  const { repoRoot } = fixture(t);
+  const first = stageWebsite({ repoRoot, target: "preview" });
+  const second = stageWebsite({ repoRoot, target: "preview" });
+  t.after(() => {
+    rmSync(first.stage, { recursive: true, force: true });
+    rmSync(second.stage, { recursive: true, force: true });
+  });
+  assert.equal(first.archiveSha256, second.archiveSha256);
+  assert.equal(existsSync(path.join(first.stage, "website/.env.local")), false);
+  assert.equal(existsSync(path.join(first.stage, "vercel.json")), false);
+  assert.equal(
+    JSON.parse(readFileSync(path.join(first.stage, "website/vercel.json")))
+      .framework,
+    "nextjs",
+  );
+  assert.equal(
+    JSON.parse(readFileSync(path.join(first.stage, ".vercel/project.json")))
+      .projectId,
+    WEBSITE.projectId,
+  );
+});
+
+test("dirty sources, unrelated lanes, and unmerged production candidates fail before staging", (t) => {
+  const { repoRoot, git } = fixture(t);
+  writeFileSync(path.join(repoRoot, "untracked"), "not committed");
+  assert.throws(
+    () => stageWebsite({ repoRoot, target: "preview" }),
+    /clean committed/,
+  );
+  git("add", "untracked");
+  git("commit", "-m", "candidate");
+  assert.throws(
+    () => stageWebsite({ repoRoot, target: "production" }),
+    /exact origin\/www/,
+  );
+  git("update-ref", "refs/remotes/origin/www", "HEAD");
+  git("checkout", "--detach", "HEAD~1");
+  assert.throws(() => stageWebsite({ repoRoot, target: "preview" }));
+});
+
+test("live project and deployment verification reject wrong identities and stale source", () => {
+  const project = {
+    id: WEBSITE.projectId,
+    accountId: WEBSITE.orgId,
+    name: WEBSITE.projectName,
+    rootDirectory: "website",
+    framework: "nextjs",
+  };
+  verifyWebsiteProject(project);
+  for (const field of ["id", "accountId", "name", "rootDirectory", "framework"])
+    assert.throws(
+      () => verifyWebsiteProject({ ...project, [field]: "wrong" }),
+      /identity mismatch/,
+    );
+  const deployment = {
+    id: "dpl_fixture",
+    projectId: WEBSITE.projectId,
+    readyState: "READY",
+    target: null,
+    meta: { freedSourceSha: "a".repeat(40), freedArchiveSha256: "b".repeat(64) },
+    url: "fixture.vercel.app",
+  };
+  const expected = { sourceSha: "a".repeat(40), target: "preview", archiveSha256: "b".repeat(64) };
+  assert.equal(
+    verifyWebsiteDeployment(deployment, expected).deploymentId,
+    "dpl_fixture",
+  );
+  for (const changes of [
+    { readyState: "ERROR" },
+    { projectId: "wrong" },
+    { target: "production" },
+    { meta: {} },
+    { url: "host.invalid" },
+  ])
+    assert.throws(
+      () => verifyWebsiteDeployment({ ...deployment, ...changes }, expected),
+      /exact website project/,
+    );
+});
+
+test("deployment uses scoped temporary staging, verifies source and cleans only its own stage", (t) => {
+  const { repoRoot, git } = fixture(t);
+  const sourceSha = git("rev-parse", "HEAD");
+  const calls = [];
+  let stage;
+  let archiveSha256;
+  const exec = (command, args, options) => {
+    if (command === "git" || command === "tar")
+      return execFileSync(command, args, options);
+    stage = options.cwd;
+    assert.notEqual(stage, repoRoot);
+    assert.ok(args.includes("--scope") && args.includes(WEBSITE.scope));
+    const verb = args[2];
+    calls.push(verb);
+    if (verb === "api" && args[3].startsWith("/v9/"))
+      return JSON.stringify({
+        id: WEBSITE.projectId,
+        accountId: WEBSITE.orgId,
+        name: WEBSITE.projectName,
+        rootDirectory: "website",
+        framework: "nextjs",
+      });
+    if (verb === "pull")
+      writeFileSync(
+        path.join(stage, ".vercel/project.json"),
+        JSON.stringify({
+          projectId: WEBSITE.projectId,
+          orgId: WEBSITE.orgId,
+          settings: { rootDirectory: "website" },
+        }),
+      );
+    if (verb === "deploy") {
+      archiveSha256 = args.find((arg) => arg.startsWith("freedArchiveSha256=")).split("=")[1];
+      assert.ok(args.includes("--prebuilt"));
+      assert.ok(args.includes("freedSourceSha=" + sourceSha));
+      return "https://fixture.vercel.app\n";
+    }
+    if (verb === "api")
+      return JSON.stringify({
+        id: "dpl_fixture",
+        projectId: WEBSITE.projectId,
+        readyState: "READY",
+        meta: { freedSourceSha: sourceSha, freedArchiveSha256: archiveSha256 },
+        url: "fixture.vercel.app",
+      });
+    return "";
+  };
+  assert.equal(
+    deployWebsite({ repoRoot, target: "preview", exec }).sourceSha,
+    sourceSha,
+  );
+  assert.deepEqual(calls, ["api", "pull", "build", "deploy", "api"]);
+  assert.equal(existsSync(stage), false);
+  assert.equal(existsSync(path.join(repoRoot, "website/.env.local")), true);
+});

--- a/scripts/vercel-deploy-preview.sh
+++ b/scripts/vercel-deploy-preview.sh
@@ -1,119 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib/node-tooling.sh
-source "${SCRIPT_DIR}/lib/node-tooling.sh"
-use_resolved_node_path
-NPM_BIN="$(resolve_npm_bin)"
-NPX_BIN="$(resolve_npx_bin)"
-
-if [[ $# -lt 1 || $# -gt 2 ]]; then
-  echo "Usage: $0 website|pwa [vercel-token]" >&2
+if [[ "${1:-}" != "website" || $# -gt 2 ]]; then
+  echo "Usage: $0 website [vercel-token]. PWA deployment belongs on the product lane." >&2
   exit 1
 fi
 
-TARGET="$1"
-VERCEL_TOKEN="${2:-${VERCEL_TOKEN:-}}"
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/freed-vercel-preview.XXXXXX")"
-
-cleanup() {
-  rm -rf "$TEMP_DIR"
-}
-trap cleanup EXIT
-
-case "$TARGET" in
-  website)
-    APP_DIR="website"
-    STAGE_AT_ROOT="false"
-    DEPENDENCY_DIRS=(
-      "packages/shared"
-      "packages/ui"
-    )
-    ;;
-  pwa)
-    APP_DIR="packages/pwa"
-    STAGE_AT_ROOT="false"
-    DEPENDENCY_DIRS=(
-      "packages/shared"
-      "packages/sync"
-      "packages/ui"
-    )
-    ;;
-  *)
-    echo "Unknown target: $TARGET" >&2
-    exit 1
-    ;;
-esac
-
-mkdir -p "$TEMP_DIR/scripts" "$TEMP_DIR/.vercel"
-
-cp "$ROOT_DIR/scripts/patch-automerge.mjs" "$TEMP_DIR/scripts/patch-automerge.mjs"
-
-if [[ "$STAGE_AT_ROOT" == "true" ]]; then
-  cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
-  cp -R "$ROOT_DIR/$APP_DIR"/. "$TEMP_DIR/"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
-else
-  cp "$ROOT_DIR/package.json" "$TEMP_DIR/package.json"
-  cp "$ROOT_DIR/package-lock.json" "$TEMP_DIR/package-lock.json"
-  cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
-  mkdir -p "$TEMP_DIR/$(dirname "$APP_DIR")"
-  cp -R "$ROOT_DIR/$APP_DIR" "$TEMP_DIR/$APP_DIR"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
-
-  cat >"$TEMP_DIR/vercel.json" <<'EOF'
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "vite",
-  "buildCommand": "npm run build -w @freed/pwa",
-  "outputDirectory": "packages/pwa/dist",
-  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
-}
-EOF
-fi
-
-for dir in "${DEPENDENCY_DIRS[@]}"; do
-  mkdir -p "$TEMP_DIR/$(dirname "$dir")"
-  cp -R "$ROOT_DIR/$dir" "$TEMP_DIR/$dir"
-done
-
-if [[ "$TARGET" == "website" ]]; then
-  cp -R "$ROOT_DIR/release-notes" "$TEMP_DIR/release-notes"
-fi
-
-echo "Verifying preview bundle for $TARGET from $TEMP_DIR"
-(
-  cd "$TEMP_DIR"
-  "$NPM_BIN" ci
-  if [[ "$TARGET" == "website" ]]; then
-    "$NPM_BIN" run build --workspace=website
-  elif [[ "$STAGE_AT_ROOT" == "true" ]]; then
-    "$NPM_BIN" run build
-  else
-    "$NPM_BIN" run build -w @freed/pwa
-  fi
-)
-
-VERCEL_FLAGS=(--scope aubreyfs-projects)
-if [[ -n "$VERCEL_TOKEN" ]]; then
-  VERCEL_FLAGS+=(--token "$VERCEL_TOKEN")
-fi
-
-echo "Pulling Vercel settings for $TARGET"
-"$NPX_BIN" vercel pull --yes --environment preview --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
-
-if [[ "$TARGET" == "website" ]]; then
-  echo "Building $TARGET preview with Vercel"
-  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
-
-  echo "Deploying $TARGET preview with Vercel"
-  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y
-else
-  echo "Building $TARGET preview with Vercel"
-  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}"
-
-  echo "Deploying $TARGET preview with Vercel"
-  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" -y
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+use_resolved_node_path
+export VERCEL_TOKEN="${2:-${VERCEL_TOKEN:-}}"
+exec "$(resolve_node_bin)" "${SCRIPT_DIR}/deploy-website.mjs" preview

--- a/scripts/vercel-deploy-production.sh
+++ b/scripts/vercel-deploy-production.sh
@@ -1,129 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./lib/node-tooling.sh
-source "${SCRIPT_DIR}/lib/node-tooling.sh"
-use_resolved_node_path
-NPM_BIN="$(resolve_npm_bin)"
-NPX_BIN="$(resolve_npx_bin)"
-
-if [[ $# -lt 1 || $# -gt 2 ]]; then
-  echo "Usage: $0 website|pwa [vercel-token]" >&2
+if [[ "${1:-}" != "website" || $# -gt 2 ]]; then
+  echo "Usage: $0 website [vercel-token]. PWA deployment belongs on the product lane." >&2
   exit 1
 fi
 
-TARGET="$1"
-VERCEL_TOKEN="${2:-${VERCEL_TOKEN:-}}"
-ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-TEMP_DIR="$(mktemp -d "${TMPDIR:-/tmp}/freed-vercel-production.XXXXXX")"
-
-cleanup() {
-  rm -rf "$TEMP_DIR"
-}
-trap cleanup EXIT
-
-case "$TARGET" in
-  website)
-    APP_DIR="website"
-    STAGE_AT_ROOT="false"
-    DEPENDENCY_DIRS=(
-      "packages/shared"
-      "packages/ui"
-    )
-    ;;
-  pwa)
-    APP_DIR="packages/pwa"
-    STAGE_AT_ROOT="false"
-    DEPENDENCY_DIRS=(
-      "packages/shared"
-      "packages/sync"
-      "packages/ui"
-    )
-    ;;
-  *)
-    echo "Unknown target: $TARGET" >&2
-    exit 1
-    ;;
-esac
-
-mkdir -p "$TEMP_DIR/scripts" "$TEMP_DIR/.vercel"
-
-cp "$ROOT_DIR/scripts/patch-automerge.mjs" "$TEMP_DIR/scripts/patch-automerge.mjs"
-
-if [[ "$STAGE_AT_ROOT" == "true" ]]; then
-  cp "$ROOT_DIR/package.json" "$TEMP_DIR/package.json"
-  cp "$ROOT_DIR/package-lock.json" "$TEMP_DIR/package-lock.json"
-  cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
-  cp -R "$ROOT_DIR/$APP_DIR" "$TEMP_DIR/$APP_DIR"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
-else
-  cp "$ROOT_DIR/package.json" "$TEMP_DIR/package.json"
-  cp "$ROOT_DIR/package-lock.json" "$TEMP_DIR/package-lock.json"
-  cp "$ROOT_DIR/tsconfig.base.json" "$TEMP_DIR/tsconfig.base.json"
-  mkdir -p "$TEMP_DIR/$(dirname "$APP_DIR")"
-  cp -R "$ROOT_DIR/$APP_DIR" "$TEMP_DIR/$APP_DIR"
-  cp "$ROOT_DIR/$APP_DIR/.vercel/project.json" "$TEMP_DIR/.vercel/project.json"
-
-  if [[ "$TARGET" == "pwa" ]]; then
-    mkdir -p "$TEMP_DIR/scripts"
-    cp "$ROOT_DIR/scripts/patch-automerge.mjs" "$TEMP_DIR/scripts/patch-automerge.mjs"
-    mkdir -p "$TEMP_DIR/packages/pwa"
-    cat <<'EOF' >"$TEMP_DIR/vercel.json"
-{
-  "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "vite",
-  "buildCommand": "npm run build -w @freed/pwa",
-  "outputDirectory": "packages/pwa/dist",
-  "rewrites": [{ "source": "/((?!api/).*)", "destination": "/index.html" }]
-}
-EOF
-  fi
-fi
-
-for dir in "${DEPENDENCY_DIRS[@]}"; do
-  mkdir -p "$TEMP_DIR/$(dirname "$dir")"
-  cp -R "$ROOT_DIR/$dir" "$TEMP_DIR/$dir"
-done
-
-if [[ "$TARGET" == "website" ]]; then
-  cp -R "$ROOT_DIR/release-notes" "$TEMP_DIR/release-notes"
-fi
-
-if [[ "$STAGE_AT_ROOT" == "false" ]]; then
-  cp "$ROOT_DIR/scripts/vercel-deploy-preview.sh" "$TEMP_DIR/scripts/vercel-deploy-preview.sh"
-  cp "$ROOT_DIR/scripts/vercel-deploy-production.sh" "$TEMP_DIR/scripts/vercel-deploy-production.sh"
-fi
-
-echo "Verifying production bundle for $TARGET from $TEMP_DIR"
-(
-  cd "$TEMP_DIR"
-  "$NPM_BIN" ci
-  if [[ "$TARGET" == "website" ]]; then
-    "$NPM_BIN" run build --workspace=website
-  else
-    "$NPM_BIN" run build -w @freed/pwa
-  fi
-)
-
-VERCEL_FLAGS=(--scope aubreyfs-projects)
-if [[ -n "$VERCEL_TOKEN" ]]; then
-  VERCEL_FLAGS+=(--token "$VERCEL_TOKEN")
-fi
-
-echo "Pulling Vercel settings for $TARGET"
-"$NPX_BIN" vercel pull --yes --environment production --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}"
-
-if [[ "$TARGET" == "website" ]]; then
-  echo "Building $TARGET production bundle with Vercel"
-  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" --prod
-
-  echo "Deploying $TARGET production build to Vercel"
-  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" "${VERCEL_FLAGS[@]}" -y --prod
-else
-  echo "Building $TARGET production bundle with Vercel"
-  "$NPX_BIN" vercel build --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" --prod
-
-  echo "Deploying $TARGET production build to Vercel"
-  "$NPX_BIN" vercel deploy --prebuilt --cwd "$TEMP_DIR" --local-config "$TEMP_DIR/vercel.json" "${VERCEL_FLAGS[@]}" -y --prod
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/lib/node-tooling.sh"
+use_resolved_node_path
+export VERCEL_TOKEN="${2:-${VERCEL_TOKEN:-}}"
+exec "$(resolve_node_bin)" "${SCRIPT_DIR}/deploy-website.mjs" production


### PR DESCRIPTION
(AI Generated).

## Summary

Stage exact committed website source in a private temporary directory, preserve the workspace graph, verify project and source identity, and test lane and cleanup boundaries. Product PWA behavior is unchanged.

## Validation

Website production build, deployment contract tests, instruction validators, skill validator, and shell syntax checks passed locally. Required Build website CI passed at head 54825e957618c6aeb0b0deef102dadebcd947b4a.

## Delivery decision

The owner explicitly directed normal Vercel Git-integrated deployment and accepted deferring live manual-fallback qualification. Merge to www is authorized at Level 7. Do not invoke the manual helper. Existing root and skill manual-fallback stops remain intact. Part of #1784, which remains open for future manual qualification. The companion dev changes merged in #1798 with all post-merge checks passing.