### PR TITLE
fix: keep snapshot exports responsive and classify writer refusals

### DIFF
--- a/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
+++ b/packages/desktop/src-tauri/src/library_core_desktop_runtime.rs
@@ -897,6 +897,15 @@ pub(super) fn read_normalized_library_checkpoint_page(
         .as_ref()
         .is_some_and(|active| active.export.snapshot() == &request.snapshot);
     if starting && !already_started {
+        // Report session loss separately from a real source revision change.
+        // Counts and revisions are bounded diagnostics, never Library contents.
+        log::warn!(
+            "[checkpoint-export] first page has no matching pinned session: present={} requested_revision={} active_revision={:?} requested_records={}",
+            guard.is_some(),
+            request.snapshot.source_revision,
+            guard.as_ref().map(|active| active.export.snapshot().source_revision),
+            request.snapshot.record_count,
+        );
         let export = freed_library_core::NormalizedCheckpointExportSessionV2::begin(
             open_normalized_database(&app)?,
             request.snapshot.clone(),
@@ -1756,26 +1765,34 @@ fn normalized_snapshot_reason(
 }
 
 #[tauri::command]
-pub(super) fn create_normalized_local_snapshot(
+pub(super) async fn create_normalized_local_snapshot(
     _app: tauri::AppHandle,
     created_at_ms: u64,
     reason: String,
 ) -> Result<freed_library_core::NormalizedLocalSnapshotSummaryV1, String> {
-    #[cfg(unix)]
-    return freed_library_core::desktop_binding()
-        .map_err(|error| error.to_string())?
-        .create_normalized_local_snapshot_v1(created_at_ms, normalized_snapshot_reason(&reason)?)
-        .map_err(|error| error.to_string());
-    #[cfg(not(unix))]
-    let mut connection = open_normalized_database(&_app)?;
-    #[cfg(not(unix))]
-    freed_library_core::create_normalized_local_snapshot_v1(
-        &mut connection,
-        &normalized_snapshot_root(&_app)?,
-        created_at_ms,
-        normalized_snapshot_reason(&reason)?,
-    )
-    .map_err(|error| error.to_string())
+    // Snapshot export can scan a large Library. Tauri synchronous commands run
+    // on the main thread, which also services provider WebViews and IPC.
+    run_normalized_query_off_main(move || {
+        #[cfg(unix)]
+        return freed_library_core::desktop_binding()
+            .map_err(|error| error.to_string())?
+            .create_normalized_local_snapshot_v1(
+                created_at_ms,
+                normalized_snapshot_reason(&reason)?,
+            )
+            .map_err(|error| error.to_string());
+        #[cfg(not(unix))]
+        let mut connection = open_normalized_database(&_app)?;
+        #[cfg(not(unix))]
+        freed_library_core::create_normalized_local_snapshot_v1(
+            &mut connection,
+            &normalized_snapshot_root(&_app)?,
+            created_at_ms,
+            normalized_snapshot_reason(&reason)?,
+        )
+        .map_err(|error| error.to_string())
+    })
+    .await
 }
 
 #[tauri::command]

--- a/packages/desktop/src/lib/capture-social-retry.test.ts
+++ b/packages/desktop/src/lib/capture-social-retry.test.ts
@@ -44,6 +44,8 @@ const mocks = vi.hoisted(() => {
     ),
     sqliteActive: false,
     writerAllowed: true,
+    writerConfigured: true,
+    writerError: null as Error | null,
   };
 });
 
@@ -102,15 +104,18 @@ vi.mock("./store", () => ({
 
 vi.mock("./sqlite-library", () => ({
   isSqliteLibraryActive: () => mocks.sqliteActive,
-  sqliteLibraryCloudWriterAdmissionStatus: vi.fn(async () => ({
-    configured: true,
-    allowed: mocks.writerAllowed,
-    localWriterId: "writer-local",
-    activeWriterId: mocks.writerAllowed ? "writer-local" : "writer-other",
-    storageEpoch: "epoch-1",
-    controlRevision: "revision-1",
-    verifiedAtMs: 1,
-  })),
+  sqliteLibraryCloudWriterAdmissionStatus: vi.fn(async () => {
+    if (mocks.writerError) throw mocks.writerError;
+    return {
+      configured: mocks.writerConfigured,
+      allowed: mocks.writerAllowed,
+      localWriterId: "writer-local",
+      activeWriterId: mocks.writerAllowed ? "writer-local" : "writer-other",
+      storageEpoch: "epoch-1",
+      controlRevision: "revision-1",
+      verifiedAtMs: 1,
+    };
+  }),
 }));
 
 let captureModule: typeof import("./capture");
@@ -148,6 +153,8 @@ describe("scheduled social capture retries", () => {
     mocks.state.ytAuth = { isAuthenticated: false };
     mocks.sqliteActive = false;
     mocks.writerAllowed = true;
+    mocks.writerConfigured = true;
+    mocks.writerError = null;
   });
 
   afterEach(() => {
@@ -200,6 +207,33 @@ describe("scheduled social capture retries", () => {
     expect(mocks.captureYouTube).not.toHaveBeenCalled();
     expect(mocks.refreshLibraryFeeds).not.toHaveBeenCalled();
   });
+
+  it.each(["linkedin", "instagram", "facebook", "youtube"] as const)(
+    "distinguishes missing and unreadable writer admission for %s without provider contact",
+    async (provider) => {
+      mocks.sqliteActive = true;
+      mocks.writerAllowed = false;
+      mocks.writerConfigured = false;
+      expect(await captureModule.refreshSocialProvider(provider)).toMatchObject(
+        {
+          status: "ignored",
+          stage: "writer_admission_missing",
+        },
+      );
+      mocks.writerError = new Error("database is locked");
+      expect(await captureModule.refreshSocialProvider(provider)).toMatchObject(
+        {
+          status: "ignored",
+          stage: "writer_admission_unavailable",
+        },
+      );
+      expect(mocks.captureLiFeed).not.toHaveBeenCalled();
+      expect(mocks.captureIgFeed).not.toHaveBeenCalled();
+      expect(mocks.captureFbFeed).not.toHaveBeenCalled();
+      expect(mocks.captureYouTube).not.toHaveBeenCalled();
+      expect(mocks.withProviderSyncing).not.toHaveBeenCalled();
+    },
+  );
 
   it("returns success details when Facebook sees posts", async () => {
     mocks.captureFbFeed.mockResolvedValueOnce({
@@ -300,12 +334,30 @@ describe("scheduled social capture retries", () => {
       "scheduled",
       onProviderContact,
     );
-    expect(mocks.captureFbFeed).toHaveBeenCalledWith("scheduled", onProviderContact);
-    expect(mocks.captureIgFeed).toHaveBeenCalledWith("scheduled", onProviderContact);
-    expect(mocks.captureLiFeed).toHaveBeenCalledWith("scheduled", onProviderContact);
-    expect(mocks.captureYouTube).toHaveBeenCalledWith("scheduled", onProviderContact);
-    expect(mocks.captureSubstackFeed).toHaveBeenCalledWith("scheduled", onProviderContact);
-    expect(mocks.captureMediumFeed).toHaveBeenCalledWith("scheduled", onProviderContact);
+    expect(mocks.captureFbFeed).toHaveBeenCalledWith(
+      "scheduled",
+      onProviderContact,
+    );
+    expect(mocks.captureIgFeed).toHaveBeenCalledWith(
+      "scheduled",
+      onProviderContact,
+    );
+    expect(mocks.captureLiFeed).toHaveBeenCalledWith(
+      "scheduled",
+      onProviderContact,
+    );
+    expect(mocks.captureYouTube).toHaveBeenCalledWith(
+      "scheduled",
+      onProviderContact,
+    );
+    expect(mocks.captureSubstackFeed).toHaveBeenCalledWith(
+      "scheduled",
+      onProviderContact,
+    );
+    expect(mocks.captureMediumFeed).toHaveBeenCalledWith(
+      "scheduled",
+      onProviderContact,
+    );
   });
 
   it("returns empty when Facebook sees no posts", async () => {
@@ -359,10 +411,7 @@ describe("scheduled social capture retries", () => {
   });
 
   it("refuses every social capture before provider contact in follower mode", async () => {
-    window.localStorage.setItem(
-      "freed.libraryCore.desktopRoleV1",
-      "follower",
-    );
+    window.localStorage.setItem("freed.libraryCore.desktopRoleV1", "follower");
 
     const result = await captureModule.refreshSocialProvider(
       "facebook",
@@ -374,7 +423,7 @@ describe("scheduled social capture retries", () => {
     expect(result).toMatchObject({
       provider: "facebook",
       status: "ignored",
-      stage: "retired_writer",
+      stage: "follower",
     });
   });
 

--- a/packages/desktop/src/lib/capture.ts
+++ b/packages/desktop/src/lib/capture.ts
@@ -78,18 +78,26 @@ export type SocialProviderRefreshResult = {
   retryAfterMs?: number;
 };
 
-async function activeLibraryWriterMayContactProviders(): Promise<boolean> {
+type ProviderWriterBlock = { stage: string; detail: string };
+
+async function providerWriterBlock(): Promise<ProviderWriterBlock | null> {
   if (readLibraryCoreDesktopRole() === "follower") {
-    addDebugEvent(
-      "change",
-      "[Capture] provider work is disabled on this follower Freed Desktop",
-    );
-    return false;
+    return {
+      stage: "follower",
+      detail: "Provider sync is disabled on this follower Freed Desktop.",
+    };
   }
-  if (!isSqliteLibraryActive()) return true;
+  if (!isSqliteLibraryActive()) return null;
   try {
     const admission = await sqliteLibraryCloudWriterAdmissionStatus();
-    if (admission.allowed) return true;
+    if (admission.allowed) return null;
+    if (!admission.configured) {
+      return {
+        stage: "writer_admission_missing",
+        detail:
+          "Library writer authority has not been verified. Complete Google Drive Library sync before syncing providers.",
+      };
+    }
   } catch (error) {
     addDebugEvent(
       "error",
@@ -97,13 +105,23 @@ async function activeLibraryWriterMayContactProviders(): Promise<boolean> {
         error instanceof Error ? error.message : String(error)
       }`,
     );
-    return false;
+    return {
+      stage: "writer_admission_unavailable",
+      detail:
+        "Library writer authority could not be read. Provider sync is paused until authority can be verified.",
+    };
   }
-  addDebugEvent(
-    "change",
-    "[Capture] provider work paused because another Freed Desktop owns Library writes",
-  );
-  return false;
+  return {
+    stage: "retired_writer",
+    detail: "Another Freed Desktop owns Library writes.",
+  };
+}
+
+async function activeLibraryWriterMayContactProviders(): Promise<boolean> {
+  const block = await providerWriterBlock();
+  if (block)
+    addDebugEvent("change", `[Capture] ${block.detail} Stage: ${block.stage}.`);
+  return block === null;
 }
 
 /**
@@ -398,13 +416,13 @@ export async function refreshSocialProvider(
     };
   }
 
-  if (!(await activeLibraryWriterMayContactProviders())) {
+  const writerBlock = await providerWriterBlock();
+  if (writerBlock) {
     clearSocialDeferredRetry(provider);
     return {
       provider,
       status: "ignored",
-      stage: "retired_writer",
-      detail: "Another Freed Desktop owns Library writes.",
+      ...writerBlock,
     };
   }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep local snapshot export off the native main thread, distinguish missing and unreadable writer admission from a competing writer, and record bounded checkpoint-session mismatch diagnostics. Positive installed LinkedIn extraction remains pending.

## Testing
- validate:feature passed: 801 Desktop unit, 23 provider e2e, 9 smoke, 173 native tests; native app compiled and launched, but unsigned candidate cannot read the installed actor key.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `6e866b7153bfc19d61c9d832ecbf6e7466fc4f4b`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `linkedin-installed-verification-20260905`
- Provider review decision: `diff_authorized`
- Provider review artifact: `f27051e1bd574d5c761000fe4b3f1661d2f6210bcb9524e7ac57a5addf7d2416`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: The capture.ts classified diff changes refusal diagnostics only. All existing follower, missing admission, denied admission and read failure paths still refuse provider contact. No navigation, extraction, requests, retries, cookies, headers or cadence change.
- Fingerprinting risk: No provider-observable change in the classified diff. The separate native change moves local snapshot work onto the existing bounded worker pool and adds bounded checkpoint session diagnostics without changing provider operations.
- Lowest profile alternative: Offline refusal tests and preserved native process evidence; no additional social provider contact to prepare this review.

Files bound into this provider review:
- `packages/desktop/src/lib/capture.ts`