### PR TITLE
fix: coalesce Drive checkpoint publication and fence cancellation

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -245,6 +245,14 @@ loads an alternate Library engine or compatibility path.
       the separately approved bounded OAuth recovery after a 401.
 - [ ] Complete installed Freed Desktop and physical iPhone acceptance evidence.
 
+Desktop publication coalesces overlapping manual and scheduled requests. A
+canceled native checkpoint export retains its local slot until the underlying
+call settles; a new request receives a bounded busy error instead of replacing
+the pinned cursor. Cancellation before export does not retain that slot. Writer
+transfer uses the same exclusion boundary. Focused production-wiring tests
+cover overlap, cancellation, late native completion, and recovery. Installed
+Drive acceptance remains required before claiming the release effective.
+
 ## Dependencies
 
 - Phase 1 and Phase 2 capture records

--- a/packages/desktop/src/lib/library-core-cloud-sync.test.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.test.ts
@@ -1415,6 +1415,59 @@ describe("SQLite Library Google Drive production wiring", () => {
     );
   });
 
+  it("coalesces overlapping publication requests before opening the singleton native export", async () => {
+    // Scheduled and manual entry points share this function. Separate exports
+    // replace the native cursor even when both describe the same revision.
+    await Promise.all([
+      publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
+      publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
+    ]);
+
+    expect(mocks.beginNormalizedExport).toHaveBeenCalledTimes(1);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps a canceled native export owned until it settles", async () => {
+    let enter!: () => void;
+    const entered = new Promise<void>((resolve) => {
+      enter = resolve;
+    });
+    let finishExport!: (value: unknown) => void;
+    const nativeExport = new Promise<unknown>((resolve) => {
+      finishExport = resolve;
+    });
+    mocks.beginNormalizedExport.mockImplementationOnce(() => {
+      enter();
+      return nativeExport;
+    });
+    const controller = new AbortController();
+    const canceled = publishCurrentSqliteLibraryToGoogleDrive({
+      accessToken: "token",
+      signal: controller.signal,
+    });
+    await entered;
+    controller.abort();
+    await expect(canceled).rejects.toMatchObject({ name: "AbortError" });
+
+    try {
+      await expect(
+        publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
+      ).rejects.toThrow("checkpoint export is still finishing");
+      expect(mocks.beginNormalizedExport).toHaveBeenCalledTimes(1);
+      expect(mocks.publish).not.toHaveBeenCalled();
+    } finally {
+      finishExport(await mocks.describeNormalizedCheckpoint());
+    }
+    // Drain the native response and its ownership-release microtasks.
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    await expect(
+      publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
+    ).resolves.toEqual({ status: "published", revision: 7 });
+    expect(mocks.beginNormalizedExport).toHaveBeenCalledTimes(2);
+    expect(mocks.publish).toHaveBeenCalledTimes(1);
+  });
+
   it("does not queue a fresh publication behind an abandoned native command", async () => {
     const controller = new AbortController();
     mocks.describeCloudIdentity
@@ -1425,6 +1478,11 @@ describe("SQLite Library Google Drive production wiring", () => {
       signal: controller.signal,
     });
     await Promise.resolve();
+
+    // An attempt is abandoned only once its owner cancels it. A still-live
+    // attempt must coalesce the manual and scheduled callers above.
+    controller.abort();
+    await expect(abandoned).rejects.toMatchObject({ name: "AbortError" });
 
     mocks.describeCloudIdentity.mockResolvedValue({
       format: "freed_normalized_checkpoint_export_v2",
@@ -1441,9 +1499,6 @@ describe("SQLite Library Google Drive production wiring", () => {
     await expect(
       publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
     ).resolves.toEqual({ status: "published", revision: 7 });
-
-    controller.abort();
-    await expect(abandoned).rejects.toMatchObject({ name: "AbortError" });
   });
 
   it("refuses cloud publication when restored state belongs to another Desktop installation", async () => {

--- a/packages/desktop/src/lib/library-core-cloud-sync.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.ts
@@ -436,13 +436,16 @@ async function tracedPublicationStage<T>(
 
 async function* normalizedCheckpointRecords(
   snapshot: LibraryCoreNormalizedCheckpointExportDescriptorV2,
+  signal?: AbortSignal,
 ): AsyncIterable<LibraryCoreNormalizedCheckpointRecordV2> {
   let after: Parameters<
     typeof readNormalizedLibraryCheckpointPage
   >[0]["after"] = null;
   let recordCount = 0;
   for (;;) {
+    throwIfPublicationCanceled(signal);
     const page = await readNormalizedLibraryCheckpointPage({ snapshot, after });
+    throwIfPublicationCanceled(signal);
     for (const record of page.records) {
       yield record;
       recordCount += 1;
@@ -874,7 +877,17 @@ async function bootstrapCloudCheckpointIntoSqlite(input: {
  * copied cloud state. A stale or independently advanced copy must bootstrap
  * from the active immutable checkpoint before it may replace authority.
  */
-export async function makeThisSqliteLibraryDesktopWriter(input: {
+export function makeThisSqliteLibraryDesktopWriter(input: {
+  readonly accessToken: string;
+  readonly googleFetch?: GoogleDriveFetch;
+  readonly signal?: AbortSignal;
+}): Promise<LibraryCoreCloudPublishResult> {
+  return withCheckpointExport(() =>
+    makeThisSqliteLibraryDesktopWriterInternal(input),
+  );
+}
+
+async function makeThisSqliteLibraryDesktopWriterInternal(input: {
   readonly accessToken: string;
   readonly googleFetch?: GoogleDriveFetch;
   readonly signal?: AbortSignal;
@@ -998,7 +1011,7 @@ export async function makeThisSqliteLibraryDesktopWriter(input: {
     }),
     expectedControl: { pointer, revision: controlRead.revision },
     generation: 0,
-    records: normalizedCheckpointRecords(normalizedTarget),
+    records: normalizedCheckpointRecords(normalizedTarget, input.signal),
     subtle: crypto.subtle,
   });
   if (result.status === "conflict") {
@@ -1049,6 +1062,7 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
     "read local SQLite revision",
     describeNormalizedLibraryCloudIdentity,
   );
+  throwIfPublicationCanceled(input.signal);
   const loaded = await tracedPublicationStage(
     "load local writer authority",
     () => loadOrCreateCloudState(descriptor),
@@ -1143,64 +1157,98 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
     libraryId: state.libraryId,
     signal: input.signal,
   });
-  const normalizedCheckpoint =
-    await beginNormalizedLibraryCheckpointExport();
-  if (
-    normalizedCheckpoint.libraryId !== state.libraryId ||
-    normalizedCheckpoint.authorityEpoch !== state.storageEpoch ||
-    normalizedCheckpoint.writerId !== state.writerId
-  ) {
-    throw new Error(
-      "Normalized SQLite checkpoint authority conflicts with cloud state",
-    );
-  }
-  if (state.lastPublishedRevision === normalizedCheckpoint.sourceRevision) {
-    const receipt = checkpointReceiptForState(state);
+  throwIfPublicationCanceled(input.signal);
+  return withCheckpointExport(async () => {
+    const normalizedCheckpoint =
+      await beginNormalizedLibraryCheckpointExport();
+    throwIfPublicationCanceled(input.signal);
     if (
-      receipt === null ||
-      pointer === null ||
-      controlRead.revision !== receipt.controlRevision ||
-      !controlPointersEqual(pointer, receipt.controlPointer)
+      normalizedCheckpoint.libraryId !== state.libraryId ||
+      normalizedCheckpoint.authorityEpoch !== state.storageEpoch ||
+      normalizedCheckpoint.writerId !== state.writerId
     ) {
       throw new Error(
-        "Stored Library Core publication receipt does not match Drive control",
+        "Normalized SQLite checkpoint authority conflicts with cloud state",
       );
     }
-    return { status: "current", revision: normalizedCheckpoint.sourceRevision };
-  }
-  const generation = pointer === null ? 0 : pointer.generation + 1;
-  const result = await publishLibraryCoreNormalizedCheckpointV2({
-    activeTransport: "google_drive_app_data_v1",
-    adapter,
-    descriptor: normalizedCheckpoint,
-    expectedControl: { revision: controlRead.revision, pointer },
-    generation,
-    records: normalizedCheckpointRecords(normalizedCheckpoint),
-    subtle: crypto.subtle,
-  });
-  if (result.status === "conflict") {
-    throw new Error("Library Core cloud authority changed during publication");
-  }
-  await setSqliteLibraryCloudWriterAdmission({
-    localWriterId: loaded.currentWriterId,
-    activeWriterId: state.writerId,
-    storageEpoch: state.storageEpoch,
-    controlRevision: result.revision,
-  });
-  state = Object.freeze({
-    ...state,
-    lastPublishedActorDigest: null,
-    lastPublishedCheckpoint: checkpointPublicationReceipt({
-      localRevision: normalizedCheckpoint.sourceRevision,
-      itemCount: normalizedCheckpoint.itemCount,
-      checkpointStoredByteLength: checkpointStoredByteLength(result),
+    if (state.lastPublishedRevision === normalizedCheckpoint.sourceRevision) {
+      const receipt = checkpointReceiptForState(state);
+      if (
+        receipt === null ||
+        pointer === null ||
+        controlRead.revision !== receipt.controlRevision ||
+        !controlPointersEqual(pointer, receipt.controlPointer)
+      ) {
+        throw new Error(
+          "Stored Library Core publication receipt does not match Drive control",
+        );
+      }
+      return { status: "current", revision: normalizedCheckpoint.sourceRevision };
+    }
+    const generation = pointer === null ? 0 : pointer.generation + 1;
+    const result = await publishLibraryCoreNormalizedCheckpointV2({
+      activeTransport: "google_drive_app_data_v1",
+      adapter,
+      descriptor: normalizedCheckpoint,
+      expectedControl: { revision: controlRead.revision, pointer },
+      generation,
+      records: normalizedCheckpointRecords(normalizedCheckpoint, input.signal),
+      subtle: crypto.subtle,
+    });
+    if (result.status === "conflict") {
+      throw new Error("Library Core cloud authority changed during publication");
+    }
+    await setSqliteLibraryCloudWriterAdmission({
+      localWriterId: loaded.currentWriterId,
+      activeWriterId: state.writerId,
+      storageEpoch: state.storageEpoch,
       controlRevision: result.revision,
-      controlPointer: result.controlPointer,
-    }),
-    lastPublishedRevision: normalizedCheckpoint.sourceRevision,
+    });
+    state = Object.freeze({
+      ...state,
+      lastPublishedActorDigest: null,
+      lastPublishedCheckpoint: checkpointPublicationReceipt({
+        localRevision: normalizedCheckpoint.sourceRevision,
+        itemCount: normalizedCheckpoint.itemCount,
+        checkpointStoredByteLength: checkpointStoredByteLength(result),
+        controlRevision: result.revision,
+        controlPointer: result.controlPointer,
+      }),
+      lastPublishedRevision: normalizedCheckpoint.sourceRevision,
+    });
+    await persistCloudState(state);
+    return { status: "published", revision: normalizedCheckpoint.sourceRevision };
   });
-  await persistCloudState(state);
-  return { status: "published", revision: normalizedCheckpoint.sourceRevision };
+}
+
+let checkpointExportInProgress = false;
+
+function checkpointExportBusyError(): Error {
+  return new Error(
+    "SQLite checkpoint export is still finishing. Try Sync now again shortly.",
+  );
+}
+
+/**
+ * Keep the native singleton owned until the underlying work settles, even
+ * when the caller's bounded UI promise has already rejected on cancellation.
+ */
+async function withCheckpointExport<T>(work: () => Promise<T>): Promise<T> {
+  if (checkpointExportInProgress) {
+    throw checkpointExportBusyError();
+  }
+  checkpointExportInProgress = true;
+  try {
+    return await work();
+  } finally {
+    checkpointExportInProgress = false;
+  }
+}
+
+function throwIfPublicationCanceled(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw publicationAbortError("SQLite Library publication was canceled.");
+  }
 }
 
 function publicationAbortError(message: string): Error {
@@ -1215,8 +1263,9 @@ function publicationAbortError(message: string): Error {
  * Native SQLite and Keychain commands cannot be interrupted after Tauri has
  * accepted them. Their result is still safe to ignore because every cloud
  * mutation below rechecks the supplied signal before the request and Drive
- * publication ends in an exact control CAS. A canceled native invoke must not
- * remain the head of a module-wide queue and wedge every later sync attempt.
+ * publication ends in an exact control CAS. Canceled preflight work may be
+ * abandoned. Once export starts, withCheckpointExport retains ownership until
+ * the underlying work settles; callers receive a bounded busy error meanwhile.
  */
 async function runBoundedPublication(input: {
   readonly accessToken: string;
@@ -1266,13 +1315,30 @@ async function runBoundedPublication(input: {
   }
 }
 
+let activePublication: Promise<LibraryCoreCloudPublishResult> | null = null;
+
 export function publishCurrentSqliteLibraryToGoogleDrive(input: {
   readonly accessToken: string;
   readonly googleFetch?: GoogleDriveFetch;
   readonly signal?: AbortSignal;
 }): Promise<LibraryCoreCloudPublishResult> {
   requirePrimaryLibraryCoreDesktopRole();
-  return runBoundedPublication(input);
+  if (input.signal?.aborted) {
+    return Promise.reject(
+      publicationAbortError("SQLite Library publication was canceled."),
+    );
+  }
+  // Manual Sync now and the periodic coordinator must not replace each other's
+  // native export cursor or race the same Drive control publication.
+  if (activePublication !== null) return activePublication;
+  if (checkpointExportInProgress) {
+    return Promise.reject(checkpointExportBusyError());
+  }
+  const publication = runBoundedPublication(input).finally(() => {
+    if (activePublication === publication) activePublication = null;
+  });
+  activePublication = publication;
+  return publication;
 }
 
 async function prepareDesktopNormalizedFollowerEnrollment() {


### PR DESCRIPTION
(AI Generated).

## Summary
- Coalesce overlapping manual and scheduled publications; retain checkpoint ownership until canceled native calls settle.

## Testing
- Refreshed validate:feature passed:803 Desktop unit tests,9 smoke tests,root typecheck,roadmap checks. Local native bundle passed on original product source; combined signed acceptance remains pending.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `c3b92ef090db3b1f0a28260ddb7cd8e7fb547ce4`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `library-closeout-20260905`
- Provider review decision: `behavior_approved`
- Provider review artifact: `1741353a4a3c02f12b90f03fdf366e2fc13b4b4cefe3d323228088a6734be3d2`
- Providers: other
- Observable behavior: Google Drive manual and scheduled publication calls coalesce into one active publication. A canceled native export retains its local slot until settlement. Requests during that interval fail locally without provider contact.
- Fingerprinting risk: Coalescing changes Google Drive request timing and reduces overlapping uploads. No endpoint, credential, scope, header, polling interval, retry schedule, or social-provider behavior changes.
- Lowest profile alternative: Offline mocked publication tests only; leave existing live publication behavior unchanged until installed verification.

Files bound into this provider review:
- `packages/desktop/src/lib/library-core-cloud-sync.ts`