### PR TITLE
fix: wire headless inbound sync and recover staged intents

### DIFF
--- a/docs/PHASE-11-OPENCLAW.md
+++ b/docs/PHASE-11-OPENCLAW.md
@@ -1,6 +1,6 @@
 # Phase 11: Headless Library Authority and Agent Integrations
 
-> **Status:** 🚧 In Progress (the shared transport-neutral Primary scheduler, normalized native SQLite authority, local process lease, native and PWA actor capability enforcement with separate signed mutation and query grants, authority-signed actor enrollment and retirement, fail-closed service supervisor, descriptor-bound normalized sidecar startup, bounded checkpoint and query ingress, native mutation and signed agent query admission, exact local writer reassignment, production macOS and Linux ACL proofs, deterministic service definitions, macOS Drive PKCE and Keychain custody, installed immutable checkpoint publication, and provider-neutral bounded enrollment, intent, and result orchestration have landed; installed inbound transport binding, Linux and Windows Drive secret custody, Windows service transport, and capture workers remain open)
+> **Status:** 🚧 In Progress. Native SQLite authority, bounded commands, actor capabilities, the service supervisor, platform ACL proofs, macOS Drive credentials, and checkpoint publication are implemented. The default inbound Drive transport and staged-intent recovery have offline coverage. Installed bidirectional acceptance, Linux and Windows Drive secret custody, Windows service transport, and capture workers remain open.
 
 > **Architecture:** The headless Primary and Freed Desktop consume the
 > same extracted native Rust Library Core and the same stock SQLite contract.
@@ -84,8 +84,8 @@ The current product already provides the protocol foundation:
   enrollment, intent, and result coordinators. They verify exact immutable
   descriptors, canonical segment chains, actor and epoch identity, native
   counter advancement, result-head compare and swap, and publication readback.
-  The installed Google Drive discovery and publication adapter remains open and
-  requires its exact provider behavior approval before it can add live traffic.
+  The default Google Drive adapter is implemented; installed acceptance remains
+  open before this path can be described as production verified.
 - `@freed/library-service` binds those coordinators to the generated native
   command channel without keeping authority or transport cursors in Node. A
   sequence-bound result export command resolves the prior result digest inside
@@ -95,8 +95,11 @@ The current product already provides the protocol foundation:
   identity from native SQLite, processes one bounded enrollment page, then one
   bounded intent and result page per discovered actor. Actor discovery carries
   a bounded in-memory continuation between passes and restarts safely from the
-  beginning. The default Google Drive host does not inject this transport yet,
-  so this composition adds no live provider requests or cadence change.
+  beginning. The default Google Drive host now supplies this transport after
+  checking the remote writer and epoch. It reuses that pass's credential and
+  cancellation signal, then rereads the native revision after inbound work.
+  The existing schedule is unchanged. Nonempty installed round-trip acceptance
+  remains open.
 - Freed Desktop is the production consumer of that shared coordinator.
 - Freed Desktop performs one immediate publication attempt, checks local
   revisions every 15 seconds, and refreshes inbound actor work every 60
@@ -136,8 +139,8 @@ existing immutable checkpoint protocol, and persists only the committed
 control receipt through an already-bound private state-file descriptor. The
 coordinator stops before service settlement. A missing token, changed Library
 identity, cloud writer conflict, malformed response, or unavailable secret
-backend fails closed. Linux sealed credential custody and complete inbound
-enrollment, intent, and result processing remain open.
+backend fails closed. Linux sealed credential custody and installed inbound
+enrollment, intent, and result acceptance remain open.
 
 The native sidecar acquires the
 data-root lease before opening only the final normalized SQLite catalog in the
@@ -547,7 +550,7 @@ review before implementation.
 | 11.3  | Complete    | Extract the reusable native SQLite authority package without changing Tauri behavior                                                                                                                                                                                                                                                                                                                                               |
 | 11.4  | Complete    | Add the headless service supervisor, explicit role config, and fail-closed startup                                                                                                                                                                                                                                                                                                                                                 |
 | 11.5  | In Progress | macOS `drive-auth` now uses PKCE through the existing OAuth proxy, requests only Library Core Drive scopes, stores only the refresh token in Keychain, and keeps access tokens memory-only. Complete the versioned Linux sealed credential store and Windows vault adapter next.                                                                                                                                                   |
-| 11.6  | In Progress | Open final normalized SQLite behind the descriptor-bound sidecar and provide generated bounded checkpoint, atomic pinned export begin, registered query, Primary signing, canonical commit, authority-signed follower enrollment, follower-intent admission, actor state, and result export commands. The installed service now composes one bounded provider-neutral enrollment, intent, and result pass on the existing inbound hook when a transport is injected. Complete the Google Drive transport adapter after its exact behavior approval.              |
+| 11.6  | In Progress | Provide normalized SQLite through the descriptor-bound sidecar and bounded generated commands. The default Drive host now composes enrollment, intent and result processing after checking remote writer authority. Complete nonempty installed bidirectional acceptance. |
 | 11.7  | In Progress | Apply exact writer promotion through the generated native sidecar command and bind the shared 15-second revision plus 60-second inbound schedule to native actor and checkpoint identity. The installed macOS service now starts and stops that scheduler with immutable Drive checkpoint publication and durable exact control receipts. Complete installed promotion and competing-Primary acceptance next.                      |
 | 11.8  | Complete    | Prove actor capability certificates and the frozen transition policy in native SQLite. Phase 6 carries the same proof into PWA SQLite before activation.                                                                                                                                                                                                                                                                           |
 | 11.9  | Complete    | Apply authority-signed actor retirement atomically, return exact replay receipts, and verify the normalized retirement record during native and PWA checkpoint activation                                                                                                                                                                                                                                                          |

--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -12,6 +12,14 @@ do not extend either budget. Unknown preflight retains its five-minute bound.
 Drive request concurrency, retries, and remote-byte verification are unchanged.
 Installed publication and bidirectional follower acceptance remain open.
 
+Headless inbound transport now runs after the remote writer and epoch check.
+Complete unresolved native intent staging remains retryable after a late
+authority failure. Incomplete transactions still advance their receive cursor.
+Recovery verifies and replays the complete immutable segment containing the
+pending counter, preserving native exact-retry and atomic admission semantics.
+Offline native and coordinator tests cover these boundaries; installed
+bidirectional acceptance is still required.
+
 > **Architecture:** This phase is governed by
 > [LIBRARY-CORE-ARCHITECTURE.md](LIBRARY-CORE-ARCHITECTURE.md) and
 > [LIBRARY-CORE-CONTRACT.md](LIBRARY-CORE-CONTRACT.md).

--- a/docs/library-core-contract/follower-intents.md
+++ b/docs/library-core-contract/follower-intents.md
@@ -244,9 +244,18 @@ protocol version 2 intent records. It countersigns each discovered enrollment
 request through the selected normalized authority, publishes the resulting
 immutable certificate, and derives the actor set from typed certificate
 identities for the active Library and storage epoch. For each actor, one native
-query returns the next unprocessed counter as the greater of the accepted
-authority tip plus one and the greatest durable staged member plus one. This
-frontier never reads a follower device's local intent outbox cursor.
+query returns the earliest member of a complete unresolved staged transaction
+when one exists. Otherwise it returns the greater of the accepted authority tip
+plus one and the greatest durable staged member plus one. This distinction keeps
+late authority failures retryable without starving incomplete transactions of
+their remaining pages. Resolved staging cleanup remnants do not rewind the
+cursor. This frontier never reads a follower device's local intent outbox cursor.
+
+A retry counter may fall inside a committed immutable segment. Transport returns
+that complete segment and its exact first counter and predecessor. The coordinator
+verifies its bytes, digest and chain, requires the segment to contain the pending
+counter, then replays its members through native exact-retry admission. A segment
+entirely behind the pending counter cannot authorize progress.
 
 Before staging any remote intent record, the coordinator locates the exact
 immutable segment committed by the normalized v2 intent head. It validates the

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -19,7 +19,7 @@
     {
       "id": 4,
       "status": "current",
-      "reviewedAt": "2026-09-05",
+      "reviewedAt": "2026-09-06",
       "source": "docs/PHASE-4-SYNC.md"
     },
     {
@@ -58,6 +58,7 @@
     {
       "id": 11,
       "status": "current",
+      "reviewedAt": "2026-09-06",
       "source": "docs/PHASE-11-OPENCLAW.md"
     },
     {

--- a/packages/library-core-native/src/normalized_mutation.rs
+++ b/packages/library-core-native/src/normalized_mutation.rs
@@ -422,11 +422,22 @@ pub fn normalized_primary_follower_actor_transport_state_v1(
     let state = connection
         .query_row(
             "SELECT actor.actor_id, meta.library_id, active.epoch_id,
-                    MAX(actor.accepted_counter + 1, COALESCE((
+                    COALESCE((
+                      SELECT MIN(member.actor_counter)
+                      FROM library_primary_intent_stage_members AS member
+                      JOIN library_primary_intent_stage_transactions AS staged
+                        ON staged.transaction_id = member.transaction_id
+                      WHERE member.actor_id = actor.actor_id
+                        AND staged.received_count = staged.member_count
+                        AND NOT EXISTS (
+                          SELECT 1 FROM library_follower_result_outbox AS result
+                          WHERE result.transaction_id = staged.transaction_id
+                        )
+                    ), MAX(actor.accepted_counter + 1, COALESCE((
                       SELECT MAX(member.actor_counter) + 1
                       FROM library_primary_intent_stage_members AS member
                       WHERE member.actor_id = actor.actor_id
-                    ), actor.accepted_counter + 1))
+                    ), actor.accepted_counter + 1)))
              FROM library_meta AS meta
              JOIN library_active_authority AS active
                ON active.library_id = meta.library_id
@@ -3328,6 +3339,18 @@ pub(crate) mod tests {
         assert!(error
             .to_string()
             .contains("injected staged authority fault"));
+        // Reopen the durable fixture before asking where transport should
+        // resume. The old connection cannot supply a hidden recovery cursor.
+        let directory = tempfile::tempdir().expect("recovery fixture directory");
+        let database_path = directory.path().join("recovery.sqlite");
+        connection
+            .backup(rusqlite::DatabaseName::Main, &database_path, None)
+            .expect("persist failed staging fixture");
+        drop(connection);
+        let mut connection = Connection::open(&database_path).expect("reopen recovery fixture");
+        connection
+            .execute_batch("PRAGMA foreign_keys = ON;")
+            .expect("restore connection constraints");
         assert_eq!(
             connection
                 .query_row(
@@ -3348,6 +3371,16 @@ pub(crate) mod tests {
                 .expect("rolled back authority transaction"),
             0
         );
+        assert_eq!(
+            normalized_primary_follower_actor_transport_state_v1(
+                &connection,
+                &enrollment.actor_id,
+            )
+            .expect("complete unresolved transaction remains retryable")
+            .next_actor_counter,
+            records[0].actor_counter,
+            "cloud resume must revisit staged work that has no canonical result",
+        );
         connection
             .execute_batch("DROP TRIGGER fail_staged_authority_operation;")
             .expect("remove fault trigger");
@@ -3360,6 +3393,15 @@ pub(crate) mod tests {
         .expect("resume complete transaction");
         assert_eq!(resumed.exact_retries, 2);
         assert_eq!(resumed.resolved_transactions, 1);
+        let resolved: (String, i64, i64) = connection
+            .query_row(
+                "SELECT status, result_sequence, authoritative_source_revision
+                 FROM library_follower_result_outbox;",
+                [],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .expect("durable accepted result after restart");
+        assert_eq!(resolved, ("accepted".to_owned(), 1, 1));
         assert_eq!(
             connection
                 .query_row(

--- a/packages/library-service/src/google-drive-primary-transport.test.ts
+++ b/packages/library-service/src/google-drive-primary-transport.test.ts
@@ -40,10 +40,15 @@ describe("headless normalized Drive transport", () => {
         const body = {
           actor_enrollment_body: identity,
           enrollment_body_digest: requestDigest,
+          actor_proof: "d".repeat(128),
+          actor_capability_body: {},
+          actor_capability_body_digest: "e".repeat(64),
         };
-        const bytes = encodeLibraryCoreCanonicalValue(
-          certificate ? { certificate_body: body } : body,
-        );
+        const bytes = encodeLibraryCoreCanonicalValue({
+          certificate_body: body,
+          certificate_digest: hash(`certificate-${index}`),
+          ...(certificate ? { authority_signature: "f".repeat(128) } : {}),
+        });
         const digest = hash(bytes);
         const name = createLibraryCoreImmutableObjectKey({
           kind: certificate ? "actor_enrollment" : "actor_enrollment_request",

--- a/packages/library-service/src/google-drive-primary-transport.test.ts
+++ b/packages/library-service/src/google-drive-primary-transport.test.ts
@@ -1,0 +1,231 @@
+import { describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  createLibraryCoreImmutableObjectKey,
+  encodeLibraryCoreCanonicalValue,
+  type LibraryCoreLowercaseHex64,
+} from "@freed/shared/library-core";
+import { createGoogleDrivePrimaryTransportV2 } from "./google-drive-primary-transport.js";
+
+const libraryId = "a".repeat(64) as LibraryCoreLowercaseHex64;
+const epochId = "b".repeat(64) as LibraryCoreLowercaseHex64;
+const actorId = "c".repeat(64) as LibraryCoreLowercaseHex64;
+
+describe("headless normalized Drive transport", () => {
+  it("pages real nonempty discovery beyond sixteen actors and excludes completed enrollments", async () => {
+    const hash = (value: string | Uint8Array) =>
+      createHash("sha256").update(value).digest("hex");
+    const files: {
+      id: string;
+      name: string;
+      size: string;
+      bytes: Uint8Array;
+      appProperties: Record<string, string>;
+    }[] = [];
+    const actors = Array.from(
+      { length: 18 },
+      (_, index) =>
+        (index + 1).toString(16).padStart(64, "0") as LibraryCoreLowercaseHex64,
+    );
+    for (const [index, actor] of actors.entries()) {
+      const requestDigest = hash(`request-body-${index}`);
+      for (const certificate of [false, true]) {
+        if (certificate && index === 17) continue;
+        // Discovery identities are deliberately not native signature fixtures.
+        const identity = {
+          actor_id: actor,
+          library_id: libraryId,
+          epoch_id: epochId,
+        };
+        const body = {
+          actor_enrollment_body: identity,
+          enrollment_body_digest: requestDigest,
+        };
+        const bytes = encodeLibraryCoreCanonicalValue(
+          certificate ? { certificate_body: body } : body,
+        );
+        const digest = hash(bytes);
+        const name = createLibraryCoreImmutableObjectKey({
+          kind: certificate ? "actor_enrollment" : "actor_enrollment_request",
+          actorId: actor,
+          libraryId,
+          epochId,
+          digest,
+        });
+        files.push({
+          id: `object-${index}-${certificate}`,
+          name,
+          size: String(bytes.byteLength),
+          bytes,
+          appProperties: {
+            freedProtocol: "library-core-v1",
+            freedLibraryDigest: hash(libraryId),
+            freedObjectKind: certificate ? "enrollment" : "enrollment_request",
+            freedObjectKeyDigest: hash(name),
+            freedContentDigest: digest,
+          },
+        });
+      }
+    }
+    const googleFetch = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.method ?? "GET").toBe("GET");
+        const url = new URL(String(input));
+        if (url.searchParams.get("alt") === "media") {
+          const file = files.find((value) =>
+            url.pathname.endsWith(`/${value.id}`),
+          );
+          if (!file) throw new Error("unknown immutable fixture");
+          return new Response(file.bytes.slice().buffer, { status: 200 });
+        }
+        const kind = url.searchParams.get("q")?.includes("enrollment_request")
+          ? "enrollment_request"
+          : "enrollment";
+        return new Response(
+          JSON.stringify({
+            files: files
+              .filter((file) => file.appProperties.freedObjectKind === kind)
+              .map(({ bytes: _bytes, ...file }) => file),
+          }),
+          { status: 200 },
+        );
+      },
+    );
+    const transport = createGoogleDrivePrimaryTransportV2({
+      accessToken: "synthetic-token",
+      controlFileId: "control-1",
+      libraryId,
+      epochId,
+      signal: new AbortController().signal,
+      googleFetch,
+    });
+    const pending = await transport.pageEnrollmentRequests({
+      libraryId,
+      storageEpochId: epochId,
+      limit: 16,
+    });
+    expect(pending.done).toBe(true);
+    expect(
+      pending.requests.map((value) => value.reference.transportObjectId),
+    ).toEqual(["object-17-false"]);
+    const first = await transport.pageActors({
+      libraryId,
+      storageEpochId: epochId,
+      afterActorId: null,
+      limit: 16,
+    });
+    expect(first).toEqual({
+      actorIds: actors.slice(0, 16),
+      done: false,
+      nextActorId: actors[15],
+    });
+    const next = await transport.pageActors({
+      libraryId,
+      storageEpochId: epochId,
+      afterActorId: first.nextActorId,
+      limit: 16,
+    });
+    expect(next).toEqual({
+      actorIds: [actors[16]],
+      done: true,
+      nextActorId: actors[16],
+    });
+  });
+  it("uses real bounded discovery with the refresh signal and no empty-library writes", async () => {
+    const signal = new AbortController().signal;
+    const googleFetch = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.signal).toBe(signal);
+        expect(init?.method ?? "GET").toBe("GET");
+        return new Response(JSON.stringify({ files: [] }), { status: 200 });
+      },
+    );
+    const transport = createGoogleDrivePrimaryTransportV2({
+      accessToken: "synthetic-token",
+      controlFileId: "control-1",
+      libraryId,
+      epochId,
+      signal,
+      googleFetch,
+    });
+    await expect(
+      transport.pageEnrollmentRequests({
+        libraryId,
+        storageEpochId: epochId,
+        limit: 16,
+      }),
+    ).resolves.toEqual({ done: true, requests: [] });
+    await expect(
+      transport.pageActors({
+        libraryId,
+        storageEpochId: epochId,
+        afterActorId: null,
+        limit: 16,
+      }),
+    ).resolves.toEqual({ done: true, actorIds: [], nextActorId: null });
+    await expect(
+      transport.pageIntentReferences({
+        libraryId,
+        storageEpochId: epochId,
+        actorId,
+        firstActorCounter: 1,
+        limit: 16,
+      }),
+    ).resolves.toEqual({
+      done: true,
+      firstActorCounter: 1,
+      references: [],
+      previousSegmentDigest: null,
+    });
+    expect(googleFetch).toHaveBeenCalledTimes(4);
+  });
+
+  it("cancels an active discovery and refuses subsequent network work", async () => {
+    const controller = new AbortController();
+    let started!: () => void;
+    const reading = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const googleFetch = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.signal).toBe(controller.signal);
+        return new Promise<Response>((_, reject) => {
+          controller.signal.addEventListener(
+            "abort",
+            () => reject(controller.signal.reason),
+            { once: true },
+          );
+          started();
+        });
+      },
+    );
+    const transport = createGoogleDrivePrimaryTransportV2({
+      accessToken: "synthetic-token",
+      controlFileId: "control-1",
+      libraryId,
+      epochId,
+      signal: controller.signal,
+      googleFetch,
+    });
+    const result = transport.pageActors({
+      libraryId,
+      storageEpochId: epochId,
+      afterActorId: null,
+      limit: 16,
+    });
+    const refused = expect(result).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await reading;
+    controller.abort();
+    await refused;
+    await expect(
+      transport.pageEnrollmentRequests({
+        libraryId,
+        storageEpochId: epochId,
+        limit: 16,
+      }),
+    ).rejects.toMatchObject({ name: "AbortError" });
+    expect(googleFetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/library-service/src/google-drive-primary-transport.ts
+++ b/packages/library-service/src/google-drive-primary-transport.ts
@@ -1,0 +1,223 @@
+import {
+  decodeLibraryCoreCanonicalValue,
+  isLibraryCoreLowercaseHex64,
+  parseLibraryCoreNormalizedIntentHeadV2,
+  parseLibraryCoreNormalizedResultHeadV2,
+  type LibraryCoreLowercaseHex64,
+} from "@freed/shared/library-core";
+import {
+  createGoogleDriveLibraryCoreAdapterV1,
+  createGoogleDriveLibraryCoreNormalizedIntentAdapterV2,
+  createGoogleDriveLibraryCoreNormalizedResultAdapterV2,
+  discoverGoogleDriveLibraryCoreActorEnrollmentRequestsV1,
+  discoverGoogleDriveLibraryCoreActorEnrollmentsV1,
+  discoverGoogleDriveLibraryCoreIntentHeadV1,
+  discoverGoogleDriveLibraryCoreIntentSegmentsV1,
+  discoverGoogleDriveLibraryCoreResultHeadV1,
+  provisionGoogleDriveLibraryCoreNormalizedResultHeadV2,
+  type GoogleDriveFetch,
+} from "@freed/sync/cloud/library-core";
+import type { LibraryServiceNormalizedPrimaryTransportV2 } from "./normalized-primary-orchestration.js";
+
+function record(value: unknown): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("invalid normalized enrollment identity");
+  }
+  return value as Record<string, unknown>;
+}
+
+/** Bind one authority-checked refresh to existing bounded Drive adapters. */
+export function createGoogleDrivePrimaryTransportV2(
+  options: Readonly<{
+    accessToken: string;
+    controlFileId: string;
+    libraryId: string;
+    epochId: string;
+    signal: AbortSignal;
+    googleFetch?: GoogleDriveFetch;
+  }>,
+): LibraryServiceNormalizedPrimaryTransportV2 {
+  const guard = () => options.signal.throwIfAborted();
+  const immutable = createGoogleDriveLibraryCoreAdapterV1(options);
+  const scope = (libraryId: string, epochId: string) => {
+    guard();
+    if (libraryId !== options.libraryId || epochId !== options.epochId) {
+      throw new Error("normalized Primary transport authority changed");
+    }
+  };
+  const certificates = async () => {
+    guard();
+    const values =
+      await discoverGoogleDriveLibraryCoreActorEnrollmentsV1(options);
+    return values.map(({ bytes }) => {
+      const body = record(
+        record(decodeLibraryCoreCanonicalValue(bytes)).certificate_body,
+      );
+      const actor = record(body.actor_enrollment_body);
+      scope(String(actor.library_id), String(actor.epoch_id));
+      if (
+        !isLibraryCoreLowercaseHex64(actor.actor_id) ||
+        !isLibraryCoreLowercaseHex64(body.enrollment_body_digest)
+      ) {
+        throw new Error("invalid normalized enrollment identity");
+      }
+      return {
+        actorId: actor.actor_id,
+        requestDigest: body.enrollment_body_digest,
+      };
+    });
+  };
+  return {
+    intentReader: immutable,
+    async pageEnrollmentRequests(input) {
+      scope(input.libraryId, input.storageEpochId);
+      const enrolled = new Set(
+        (await certificates()).map((value) => value.requestDigest),
+      );
+      guard();
+      const requests =
+        await discoverGoogleDriveLibraryCoreActorEnrollmentRequestsV1(options);
+      const pending = requests.filter(({ bytes }) => {
+        const value = record(decodeLibraryCoreCanonicalValue(bytes));
+        return !enrolled.has(
+          value.enrollment_body_digest as LibraryCoreLowercaseHex64,
+        );
+      });
+      return {
+        done: pending.length <= input.limit,
+        requests: pending.slice(0, input.limit),
+      };
+    },
+    async publishEnrollmentCertificate({ certificate }) {
+      guard();
+      const uploaded = await immutable.putImmutable(certificate);
+      guard();
+      const descriptor = await immutable.verifyImmutable({
+        descriptor: certificate.descriptor,
+        transportObjectId: uploaded.transportObjectId,
+      });
+      return { descriptor, transportObjectId: uploaded.transportObjectId };
+    },
+    async pageActors(input) {
+      scope(input.libraryId, input.storageEpochId);
+      const actors = [
+        ...new Set((await certificates()).map((value) => value.actorId)),
+      ]
+        .sort()
+        .filter(
+          (actor) => input.afterActorId === null || actor > input.afterActorId,
+        );
+      const actorIds = actors.slice(0, input.limit);
+      return {
+        actorIds,
+        done: actors.length <= input.limit,
+        nextActorId: actorIds.at(-1) ?? null,
+      };
+    },
+    async pageIntentReferences(input) {
+      scope(input.libraryId, input.storageEpochId);
+      const context = { ...options, actorId: input.actorId };
+      const locator = await discoverGoogleDriveLibraryCoreIntentHeadV1(context);
+      if (locator === null) {
+        if (input.firstActorCounter !== 1)
+          throw new Error("missing committed intent head");
+        return {
+          done: true,
+          firstActorCounter: 1,
+          references: [],
+          previousSegmentDigest: null,
+        };
+      }
+      guard();
+      const adapter = createGoogleDriveLibraryCoreNormalizedIntentAdapterV2({
+        ...context,
+        ...locator,
+      });
+      const head = parseLibraryCoreNormalizedIntentHeadV2(
+        (await adapter.readHead()).head,
+      );
+      if (head.latest_segment === null) {
+        if (input.firstActorCounter !== 1)
+          throw new Error("intent head behind native cursor");
+        return {
+          done: true,
+          firstActorCounter: 1,
+          references: [],
+          previousSegmentDigest: null,
+        };
+      }
+      guard();
+      const segments =
+        await discoverGoogleDriveLibraryCoreIntentSegmentsV1(context);
+      const latest = segments.findIndex(
+        ({ reference }) =>
+          reference.transportObjectId ===
+            head.latest_segment!.transportObjectId &&
+          reference.descriptor.objectKey ===
+            head.latest_segment!.descriptor.objectKey &&
+          reference.descriptor.contentDigest ===
+            head.latest_segment!.descriptor.contentDigest &&
+          reference.descriptor.byteLength ===
+            head.latest_segment!.descriptor.byteLength,
+      );
+      if (latest < 0) throw new Error("committed intent segment missing");
+      let next = 1;
+      for (let index = 0; index <= latest; index += 1) {
+        const segment = segments[index]!;
+        if (segment.firstIntentSequence !== next)
+          throw new Error("intent chain gap or overlap");
+        next = segment.lastIntentSequence + 1;
+      }
+      if (next !== head.next_actor_counter || input.firstActorCounter > next) {
+        throw new Error("intent head and native cursor disagree");
+      }
+      const start = segments.findIndex(
+        (segment, index) =>
+          index <= latest &&
+          segment.lastIntentSequence >= input.firstActorCounter,
+      );
+      const first = start < 0 ? latest + 1 : start;
+      const end = Math.min(latest + 1, first + input.limit);
+      return {
+        done: end === latest + 1,
+        firstActorCounter:
+          start < 0
+            ? input.firstActorCounter
+            : segments[first]!.firstIntentSequence,
+        references: segments
+          .slice(first, end)
+          .map((segment) => segment.reference),
+        previousSegmentDigest:
+          first === 0
+            ? null
+            : segments[first - 1]!.reference.descriptor.contentDigest,
+      };
+    },
+    async openResultAdapter(input) {
+      scope(input.libraryId, input.storageEpochId);
+      const context = { ...options, actorId: input.actorId };
+      let locator = await discoverGoogleDriveLibraryCoreResultHeadV1(context);
+      if (locator === null) {
+        guard();
+        locator = await provisionGoogleDriveLibraryCoreNormalizedResultHeadV2({
+          ...options,
+          head: parseLibraryCoreNormalizedResultHeadV2({
+            actor_id: input.actorId,
+            library_id: input.libraryId,
+            storage_epoch_id: input.storageEpochId,
+            protocol: "normalized_result_head_v2",
+            protocol_version: 2,
+            next_result_sequence: 1,
+            latest_segment: null,
+            latest_segment_digest: null,
+          }),
+        });
+      }
+      guard();
+      return createGoogleDriveLibraryCoreNormalizedResultAdapterV2({
+        ...context,
+        ...locator,
+      });
+    },
+  };
+}

--- a/packages/library-service/src/google-drive-primary-transport.ts
+++ b/packages/library-service/src/google-drive-primary-transport.ts
@@ -78,7 +78,9 @@ export function createGoogleDrivePrimaryTransportV2(
       const requests =
         await discoverGoogleDriveLibraryCoreActorEnrollmentRequestsV1(options);
       const pending = requests.filter(({ bytes }) => {
-        const value = record(decodeLibraryCoreCanonicalValue(bytes));
+        const value = record(
+          record(decodeLibraryCoreCanonicalValue(bytes)).certificate_body,
+        );
         return !enrolled.has(
           value.enrollment_body_digest as LibraryCoreLowercaseHex64,
         );

--- a/packages/library-service/src/google-drive-publication.test.ts
+++ b/packages/library-service/src/google-drive-publication.test.ts
@@ -59,7 +59,9 @@ function descriptor(writer = writerId) {
   });
 }
 
-class MemoryAdapter implements LibraryCoreImmutablePublicationAdapterV1<Uint8Array> {
+class MemoryAdapter
+  implements LibraryCoreImmutablePublicationAdapterV1<Uint8Array>
+{
   readonly objects = new Map<
     string,
     {
@@ -183,6 +185,7 @@ describe("headless Google Drive checkpoint publication", () => {
   });
 
   it("returns ownership_required without exporting when Drive names another writer", async () => {
+    const refreshInbound = vi.fn();
     const adapter = new MemoryAdapter();
     const remotePublication = createLibraryServiceGoogleDrivePublicationV1({
       state: { read: async () => null, write: async () => undefined },
@@ -199,6 +202,7 @@ describe("headless Google Drive checkpoint publication", () => {
     });
     const objectCountAfterRemotePublication = adapter.objects.size;
     const publication = createLibraryServiceGoogleDrivePublicationV1({
+      refreshInbound,
       state: { read: async () => null, write: async () => undefined },
       token: { accessToken: async () => "access-token" },
       transport: {
@@ -221,5 +225,62 @@ describe("headless Google Drive checkpoint publication", () => {
     });
     expect(client.execute).toHaveBeenCalledTimes(1);
     expect(adapter.objects.size).toBe(objectCountAfterRemotePublication);
+    expect(refreshInbound).not.toHaveBeenCalled();
+  });
+
+  it("checks cloud authority before inbound work and observes its new revision", async () => {
+    const adapter = new MemoryAdapter();
+    let state: LibraryServiceGoogleDrivePublicationStateV1 | null = null;
+    let revision = 7;
+    const refreshInbound = vi.fn(async () => {
+      revision = 8;
+    });
+    const publication = createLibraryServiceGoogleDrivePublicationV1({
+      refreshInbound,
+      state: {
+        read: async () => state,
+        write: async (next) => {
+          state = next;
+        },
+      },
+      token: { accessToken: async () => "access-token" },
+      transport: {
+        provision: async () => ({ controlFileId: "control-file" }),
+        adapter: () => adapter,
+      },
+    });
+    const client = native();
+    const originalExecute = client.execute;
+    client.execute = vi.fn(async (command: string, payload: unknown) => {
+      if (command === "describe_checkpoint_export_v2") {
+        return { ...descriptor(), sourceRevision: revision };
+      }
+      if (command === "begin_checkpoint_export_v2" && revision === 8) {
+        // Stop at the export boundary: the distinct contract here is that a
+        // successful inbound edit cannot take the stale 'current' shortcut.
+        throw new Error("fresh export reached");
+      }
+      return originalExecute(command as never, payload as never);
+    }) as typeof client.execute;
+    await publication.publish({
+      native: client,
+      reason: "initial",
+      signal: new AbortController().signal,
+    });
+    expect(refreshInbound).not.toHaveBeenCalled();
+    const signal = new AbortController().signal;
+    await expect(
+      publication.publish({
+        native: client,
+        reason: "inbound_refresh",
+        signal,
+      }),
+    ).rejects.toThrow("fresh export reached");
+    expect(refreshInbound).toHaveBeenCalledExactlyOnceWith({
+      accessToken: "access-token",
+      controlFileId: "control-file",
+      descriptor: descriptor(),
+      signal,
+    });
   });
 });

--- a/packages/library-service/src/google-drive-publication.ts
+++ b/packages/library-service/src/google-drive-publication.ts
@@ -81,6 +81,14 @@ export interface LibraryServiceGoogleDrivePublicationOptionsV1 {
   readonly state: LibraryServiceGoogleDrivePublicationStatePortV1;
   readonly token: LibraryServiceGoogleDriveTokenPortV1;
   readonly transport?: GoogleDrivePublicationTransportV1;
+  readonly refreshInbound?: (
+    input: Readonly<{
+      accessToken: string;
+      controlFileId: string;
+      descriptor: LibraryCoreNormalizedCheckpointExportDescriptorV2;
+      signal: AbortSignal;
+    }>,
+  ) => Promise<void>;
 }
 
 export function createBoundGoogleDrivePublicationStatePortV1(
@@ -286,6 +294,7 @@ export function createLibraryServiceGoogleDrivePublicationV1(
     },
     async publish({
       native,
+      reason,
       signal,
     }: {
       readonly native: LibraryCoreNativeCommandClientV1;
@@ -332,16 +341,47 @@ export function createLibraryServiceGoogleDrivePublicationV1(
           localWriterId: descriptor.writerId,
         });
       }
+      // Never admit inbound work against an absent or foreign cloud writer.
+      // Reuse this pass's credential and control discovery, without a second
+      // scheduler or a mutable process-global transport context.
+      if (
+        reason === "inbound_refresh" &&
+        pointer !== null &&
+        options.refreshInbound
+      ) {
+        signal.throwIfAborted();
+        await options.refreshInbound({
+          accessToken,
+          controlFileId: provisioned.controlFileId,
+          descriptor,
+          signal,
+        });
+        signal.throwIfAborted();
+      }
+      const currentDescriptor =
+        reason === "inbound_refresh" && options.refreshInbound
+          ? exactDescriptor(
+              await native.execute("describe_checkpoint_export_v2", {}),
+            )
+          : descriptor;
+      if (
+        currentDescriptor.libraryId !== descriptor.libraryId ||
+        currentDescriptor.authorityEpoch !== descriptor.authorityEpoch ||
+        currentDescriptor.writerId !== descriptor.writerId
+      ) {
+        throw new LibraryServiceFailure("authority_not_primary");
+      }
       if (
         pointer !== null &&
-        pointer.causalFrontierDigest === descriptor.causalFrontierDigest &&
-        persisted?.lastPublishedRevision === descriptor.sourceRevision &&
+        pointer.causalFrontierDigest ===
+          currentDescriptor.causalFrontierDigest &&
+        persisted?.lastPublishedRevision === currentDescriptor.sourceRevision &&
         persisted.controlFileId === provisioned.controlFileId &&
         persisted.controlRevision === controlRead.revision
       ) {
         return Object.freeze({
           status: "current" as const,
-          revision: descriptor.sourceRevision,
+          revision: currentDescriptor.sourceRevision,
         });
       }
       const exportDescriptor = exactDescriptor(

--- a/packages/library-service/src/index.ts
+++ b/packages/library-service/src/index.ts
@@ -52,7 +52,6 @@ export {
 } from "./normalized-primary-native-runtime.js";
 export {
   createLibraryServiceNormalizedPrimaryOrchestrationV2,
-  createLibraryServiceNormalizedPrimaryPublicationV2,
   type LibraryServiceNormalizedPrimaryActorPageV2,
   type LibraryServiceNormalizedPrimaryOrchestrationOptionsV2,
   type LibraryServiceNormalizedPrimaryOrchestrationV2,

--- a/packages/library-service/src/normalized-primary-orchestration.test.ts
+++ b/packages/library-service/src/normalized-primary-orchestration.test.ts
@@ -9,7 +9,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { LibraryCoreNativeCommandClientV1 } from "./native-command.js";
 import {
   createLibraryServiceNormalizedPrimaryOrchestrationV2,
-  createLibraryServiceNormalizedPrimaryPublicationV2,
   type LibraryServiceNormalizedPrimaryTransportV2,
 } from "./normalized-primary-orchestration.js";
 
@@ -107,10 +106,17 @@ function transport(
       expect(input.libraryId).toBe(LIBRARY_ID);
       expect(input.limit).toBe(16);
       expect(input.storageEpochId).toBe(EPOCH_ID);
-      return { done: true, previousSegmentDigest: null, references: [] };
+      return {
+        done: true,
+        firstActorCounter: 1,
+        previousSegmentDigest: null,
+        references: [],
+      };
     },
     async publishEnrollmentCertificate() {
-      throw new Error("an empty enrollment page must not publish a certificate");
+      throw new Error(
+        "an empty enrollment page must not publish a certificate",
+      );
     },
   };
 }
@@ -145,59 +151,6 @@ function native() {
 }
 
 describe("normalized Primary service orchestration", () => {
-  it("uses only the existing inbound refresh hook and runs before publication", async () => {
-    const events: string[] = [];
-    const publication = createLibraryServiceNormalizedPrimaryPublicationV2(
-      {
-        async publish(input) {
-          events.push(`publish:${input.reason}`);
-          return { status: "current" };
-        },
-      },
-      {
-        async refresh() {
-          events.push("normalized:refresh");
-          return {
-            actorPageDone: true,
-            enrollment: {
-              done: true,
-              processedRequestCount: 0,
-              publishedCertificates: [],
-            },
-            importedIntentCount: 0,
-            nextActorId: null,
-            processedActorCount: 0,
-            publishedResultCount: 0,
-          };
-        },
-      },
-    );
-    const controller = new AbortController();
-
-    await publication.publish({
-      native: native().client,
-      reason: "initial",
-      signal: controller.signal,
-    });
-    await publication.publish({
-      native: native().client,
-      reason: "local_revision",
-      signal: controller.signal,
-    });
-    await publication.publish({
-      native: native().client,
-      reason: "inbound_refresh",
-      signal: controller.signal,
-    });
-
-    expect(events).toEqual([
-      "publish:initial",
-      "publish:local_revision",
-      "normalized:refresh",
-      "publish:inbound_refresh",
-    ]);
-  });
-
   it("runs one bounded enrollment, intent, and result pass in authority order", async () => {
     const active = native();
     const runtime = createLibraryServiceNormalizedPrimaryOrchestrationV2({
@@ -207,20 +160,20 @@ describe("normalized Primary service orchestration", () => {
       transport: transport(),
     });
 
-    await expect(runtime.refresh(new AbortController().signal)).resolves.toEqual(
-      {
-        actorPageDone: true,
-        enrollment: {
-          done: true,
-          processedRequestCount: 0,
-          publishedCertificates: [],
-        },
-        importedIntentCount: 0,
-        nextActorId: null,
-        processedActorCount: 1,
-        publishedResultCount: 0,
+    await expect(
+      runtime.refresh(new AbortController().signal),
+    ).resolves.toEqual({
+      actorPageDone: true,
+      enrollment: {
+        done: true,
+        processedRequestCount: 0,
+        publishedCertificates: [],
       },
-    );
+      importedIntentCount: 0,
+      nextActorId: null,
+      processedActorCount: 1,
+      publishedResultCount: 0,
+    });
     expect(active.execute.mock.calls.map(([commandId]) => commandId)).toEqual([
       "describe_checkpoint_export_v2",
       "primary_follower_actor_transport_state_v1",
@@ -265,12 +218,12 @@ describe("normalized Primary service orchestration", () => {
       ]),
     });
 
-    await expect(runtime.refresh(new AbortController().signal)).resolves.toMatchObject(
-      { actorPageDone: false, nextActorId: ACTOR_ID },
-    );
-    await expect(runtime.refresh(new AbortController().signal)).resolves.toMatchObject(
-      { actorPageDone: true, nextActorId: null },
-    );
+    await expect(
+      runtime.refresh(new AbortController().signal),
+    ).resolves.toMatchObject({ actorPageDone: false, nextActorId: ACTOR_ID });
+    await expect(
+      runtime.refresh(new AbortController().signal),
+    ).resolves.toMatchObject({ actorPageDone: true, nextActorId: null });
   });
 
   it("does no work after cancellation", async () => {
@@ -288,5 +241,74 @@ describe("normalized Primary service orchestration", () => {
       name: "AbortError",
     });
     expect(active.execute).not.toHaveBeenCalled();
+  });
+
+  it("binds cancellation per pass without resetting fairness after an interrupted read", async () => {
+    const active = native();
+    const actors = Array.from(
+      { length: 17 },
+      (_, index) =>
+        (index + 1).toString(16).padStart(64, "0") as LibraryCoreLowercaseHex64,
+    );
+    const controllers = Array.from({ length: 3 }, () => new AbortController());
+    const signals: AbortSignal[] = [];
+    const blocked = vi.fn();
+    let started!: () => void;
+    const reading = new Promise<void>((resolve) => {
+      started = resolve;
+    });
+    const runtime = createLibraryServiceNormalizedPrimaryOrchestrationV2({
+      native: active.client,
+      now: () => 10,
+      subtle: crypto.subtle,
+      async transport(signal) {
+        signals.push(signal);
+        if (signals.length === 2) {
+          return {
+            ...transport(),
+            pageActors: blocked,
+            pageEnrollmentRequests() {
+              return new Promise((_, reject) => {
+                signal.addEventListener("abort", () => reject(signal.reason), {
+                  once: true,
+                });
+                started();
+              });
+            },
+          };
+        }
+        return transport([
+          signals.length === 1
+            ? { afterActorId: null, actorIds: actors.slice(0, 16), done: false }
+            : {
+                afterActorId: actors[15]!,
+                actorIds: actors.slice(16),
+                done: true,
+              },
+        ]);
+      },
+    });
+
+    await expect(
+      runtime.refresh(controllers[0]!.signal),
+    ).resolves.toMatchObject({
+      processedActorCount: 16,
+      nextActorId: actors[15],
+    });
+    const interrupted = runtime.refresh(controllers[1]!.signal);
+    const rejected = expect(interrupted).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await reading;
+    controllers[1]!.abort();
+    await rejected;
+    expect(blocked).not.toHaveBeenCalled();
+    await expect(
+      runtime.refresh(controllers[2]!.signal),
+    ).resolves.toMatchObject({
+      processedActorCount: 1,
+      nextActorId: null,
+    });
+    expect(signals).toEqual(controllers.map((controller) => controller.signal));
   });
 });

--- a/packages/library-service/src/normalized-primary-orchestration.ts
+++ b/packages/library-service/src/normalized-primary-orchestration.ts
@@ -12,12 +12,10 @@ import {
   parseLibraryCoreNormalizedCheckpointExportDescriptorV2,
   type LibraryCoreLowercaseHex64,
 } from "@freed/shared/library-core";
-import type { LibraryCorePrimaryPublicationResultV1 } from "@freed/sync/cloud/library-core-primary-coordinator";
 
 import { LibraryServiceFailure } from "./contracts.js";
 import type { LibraryCoreNativeCommandClientV1 } from "./native-command.js";
 import { createLibraryServiceNormalizedPrimaryNativeRuntimeV2 } from "./normalized-primary-native-runtime.js";
-import type { LibraryServicePrimaryPublicationPortV1 } from "./primary-runtime.js";
 
 const ACTOR_PAGE_LIMIT = 16;
 
@@ -31,12 +29,14 @@ export interface LibraryServiceNormalizedPrimaryTransportV2
   extends LibraryCoreNormalizedPrimaryEnrollmentTransportV2,
     LibraryCoreNormalizedPrimaryIntentTransportV2,
     LibraryCoreNormalizedPrimaryResultTransportV2 {
-  pageActors(input: Readonly<{
-    afterActorId: LibraryCoreLowercaseHex64 | null;
-    libraryId: LibraryCoreLowercaseHex64;
-    limit: number;
-    storageEpochId: LibraryCoreLowercaseHex64;
-  }>): Promise<LibraryServiceNormalizedPrimaryActorPageV2>;
+  pageActors(
+    input: Readonly<{
+      afterActorId: LibraryCoreLowercaseHex64 | null;
+      libraryId: LibraryCoreLowercaseHex64;
+      limit: number;
+      storageEpochId: LibraryCoreLowercaseHex64;
+    }>,
+  ): Promise<LibraryServiceNormalizedPrimaryActorPageV2>;
 }
 
 export interface LibraryServiceNormalizedPrimaryRefreshReceiptV2 {
@@ -51,6 +51,7 @@ export interface LibraryServiceNormalizedPrimaryRefreshReceiptV2 {
 export interface LibraryServiceNormalizedPrimaryOrchestrationV2 {
   refresh(
     signal: AbortSignal,
+    transport?: LibraryServiceNormalizedPrimaryTransportV2,
   ): Promise<LibraryServiceNormalizedPrimaryRefreshReceiptV2>;
 }
 
@@ -58,28 +59,11 @@ export interface LibraryServiceNormalizedPrimaryOrchestrationOptionsV2 {
   readonly native: LibraryCoreNativeCommandClientV1;
   readonly now: () => number;
   readonly subtle: SubtleCrypto;
-  readonly transport: LibraryServiceNormalizedPrimaryTransportV2;
-}
-
-/** Run normalized inbound work only on the scheduler's existing inbound pass. */
-export function createLibraryServiceNormalizedPrimaryPublicationV2<
-  Result extends LibraryCorePrimaryPublicationResultV1,
->(
-  publication: LibraryServicePrimaryPublicationPortV1<Result>,
-  normalizedPrimary: LibraryServiceNormalizedPrimaryOrchestrationV2,
-): LibraryServicePrimaryPublicationPortV1<Result> {
-  return Object.freeze({
-    async publish(
-      input: Parameters<
-        LibraryServicePrimaryPublicationPortV1<Result>["publish"]
-      >[0],
-    ) {
-      if (input.reason === "inbound_refresh") {
-        await normalizedPrimary.refresh(input.signal);
-      }
-      return publication.publish(input);
-    },
-  });
+  readonly transport?:
+    | LibraryServiceNormalizedPrimaryTransportV2
+    | ((
+        signal: AbortSignal,
+      ) => Promise<LibraryServiceNormalizedPrimaryTransportV2>);
 }
 
 function checkpointContext(value: unknown): Readonly<{
@@ -87,9 +71,8 @@ function checkpointContext(value: unknown): Readonly<{
   storageEpochId: LibraryCoreLowercaseHex64;
 }> {
   try {
-    const descriptor = parseLibraryCoreNormalizedCheckpointExportDescriptorV2(
-      value,
-    );
+    const descriptor =
+      parseLibraryCoreNormalizedCheckpointExportDescriptorV2(value);
     return Object.freeze({
       libraryId: descriptor.libraryId,
       storageEpochId: descriptor.authorityEpoch,
@@ -114,7 +97,9 @@ function actorPage(
     !Array.isArray(value.actorIds) ||
     value.actorIds.length > ACTOR_PAGE_LIMIT ||
     (value.actorIds.length === 0 && !value.done) ||
-    value.actorIds.some((candidate) => !isLibraryCoreLowercaseHex64(candidate)) ||
+    value.actorIds.some(
+      (candidate) => !isLibraryCoreLowercaseHex64(candidate),
+    ) ||
     value.actorIds.some(
       (candidate, index) =>
         (index === 0 && afterActorId !== null && candidate <= afterActorId) ||
@@ -152,22 +137,32 @@ export function createLibraryServiceNormalizedPrimaryOrchestrationV2(
   return Object.freeze({
     async refresh(
       signal: AbortSignal,
+      boundTransport?: LibraryServiceNormalizedPrimaryTransportV2,
     ): Promise<LibraryServiceNormalizedPrimaryRefreshReceiptV2> {
       signal.throwIfAborted();
       const context = checkpointContext(
         await options.native.execute("describe_checkpoint_export_v2", {}),
       );
       signal.throwIfAborted();
-      const enrollment =
-        await syncLibraryCoreNormalizedPrimaryEnrollmentsV2(
-          options.transport,
-          runtime,
-          context,
-          { signal },
-        );
+      // Keep the fairness cursor on this runtime, but bind network clients to
+      // this pass. A cancelled pass must not poison the next refresh's signal.
+      const transport =
+        boundTransport ??
+        (typeof options.transport === "function"
+          ? await options.transport(signal)
+          : options.transport);
+      if (transport === undefined)
+        throw new Error("normalized Primary transport unavailable");
+      signal.throwIfAborted();
+      const enrollment = await syncLibraryCoreNormalizedPrimaryEnrollmentsV2(
+        transport,
+        runtime,
+        context,
+        { signal },
+      );
       signal.throwIfAborted();
       const actors = actorPage(
-        await options.transport.pageActors({
+        await transport.pageActors({
           afterActorId,
           ...context,
           limit: ACTOR_PAGE_LIMIT,
@@ -180,7 +175,7 @@ export function createLibraryServiceNormalizedPrimaryOrchestrationV2(
         signal.throwIfAborted();
         const actorContext = Object.freeze({ ...context, actorId });
         const intents = await syncLibraryCoreNormalizedPrimaryIntentsV2(
-          options.transport,
+          transport,
           runtime,
           actorContext,
           { signal },
@@ -188,7 +183,7 @@ export function createLibraryServiceNormalizedPrimaryOrchestrationV2(
         importedIntentCount += intents.importedIntentCount;
         signal.throwIfAborted();
         const results = await syncLibraryCoreNormalizedPrimaryResultsV2(
-          options.transport,
+          transport,
           runtime,
           actorContext,
           { signal },

--- a/packages/library-service/src/primary-cloud-runtime.test.ts
+++ b/packages/library-service/src/primary-cloud-runtime.test.ts
@@ -1,4 +1,11 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createHash } from "node:crypto";
+import {
+  createLibraryCoreImmutableObjectKey,
+  createLibraryCoreResultHeadObjectKey,
+  encodeLibraryCoreCanonicalValue,
+} from "@freed/shared/library-core";
+import capabilityVectors from "../../shared/src/library-core/actor-capability-certificate-v2-vectors.json" with { type: "json" };
 import type { LibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runtime.js";
 
 const hooks = vi.hoisted(() => ({
@@ -29,7 +36,222 @@ import { createNodeLibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runt
 
 afterEach(() => vi.unstubAllGlobals());
 
-describe("installed Primary cloud composition", () => {
+describe("default Primary cloud composition", () => {
+  it("countersigns and publishes a real enrollment envelope through the default transport", async () => {
+    const vector = capabilityVectors.vectors[0]!;
+    const certificate = vector.certificate;
+    const actorId = certificate.certificate_body.actor_enrollment_body.actor_id;
+    const libraryId = vector.authority_state.library_id;
+    const epochId = vector.authority_state.epoch_id;
+    const hash = (value: string | Uint8Array) =>
+      createHash("sha256").update(value).digest("hex");
+    type File = {
+      id: string;
+      name: string;
+      bytes: Uint8Array;
+      appProperties: Record<string, string>;
+    };
+    const files: File[] = [];
+    const immutable = (
+      id: string,
+      bytes: Uint8Array,
+      kind: "actor_enrollment" | "actor_enrollment_request",
+    ): File => {
+      const digest = hash(bytes);
+      const name = createLibraryCoreImmutableObjectKey({
+        actorId,
+        libraryId,
+        epochId,
+        digest,
+        kind,
+      });
+      return {
+        id,
+        name,
+        bytes,
+        appProperties: {
+          freedProtocol: "library-core-v1",
+          freedLibraryDigest: hash(libraryId),
+          freedObjectKind:
+            kind === "actor_enrollment" ? "enrollment" : "enrollment_request",
+          freedObjectKeyDigest: hash(name),
+          freedContentDigest: digest,
+        },
+      };
+    };
+    const requestBytes = encodeLibraryCoreCanonicalValue({
+      certificate_body: certificate.certificate_body,
+      certificate_digest: certificate.certificate_digest,
+    });
+    const certificateBytes = encodeLibraryCoreCanonicalValue(certificate);
+    files.push(
+      immutable("request-1", requestBytes, "actor_enrollment_request"),
+    );
+    files.push({
+      id: "result-head",
+      name: createLibraryCoreResultHeadObjectKey(libraryId, epochId, actorId),
+      bytes: encodeLibraryCoreCanonicalValue({
+        actor_id: actorId,
+        library_id: libraryId,
+        storage_epoch_id: epochId,
+        protocol: "normalized_result_head_v2",
+        protocol_version: 2,
+        next_result_sequence: 1,
+        latest_segment: null,
+        latest_segment_digest: null,
+      }),
+      appProperties: {
+        freedProtocol: "library-core-v1",
+        freedLibraryDigest: hash(libraryId),
+        freedObjectKind: "result_head",
+        freedEpochDigest: hash(epochId),
+        freedActorDigest: hash(actorId),
+      },
+    });
+    const metadata = (file: File) => ({
+      id: file.id,
+      name: file.name,
+      size: String(file.bytes.byteLength),
+      appProperties: file.appProperties,
+      etag: '"revision-1"',
+    });
+    const signal = new AbortController().signal;
+    const fetcher = vi.fn(
+      async (input: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.signal).toBe(signal);
+        const url = new URL(String(input));
+        if (init?.method === "POST") {
+          expect(url.pathname).toBe("/upload/drive/v3/files");
+          expect(init.body).toBeInstanceOf(Blob);
+          expect(await (init.body as Blob).text()).toContain(
+            new TextDecoder().decode(certificateBytes),
+          );
+          const file = immutable(
+            "certificate-1",
+            certificateBytes,
+            "actor_enrollment",
+          );
+          files.push(file);
+          return Response.json(metadata(file));
+        }
+        expect(init?.method ?? "GET").toBe("GET");
+        if (url.pathname === "/drive/v3/files") {
+          const properties = [
+            ...(url.searchParams.get("q") ?? "").matchAll(
+              /appProperties has \{ key='([^']+)' and value='([^']*)' \}/gu,
+            ),
+          ];
+          return Response.json({
+            files: files
+              .filter((file) =>
+                properties.every(
+                  (match) => file.appProperties[match[1]!] === match[2],
+                ),
+              )
+              .map(metadata),
+          });
+        }
+        const file = files.find((candidate) =>
+          url.pathname.endsWith(`/${candidate.id}`),
+        );
+        if (!file)
+          throw new Error(
+            `unexpected synthetic Drive request: ${url.pathname}`,
+          );
+        return url.searchParams.get("alt") === "media"
+          ? new Response(file.bytes.slice().buffer, {
+              headers: { ETag: '"revision-1"' },
+            })
+          : Response.json(metadata(file), {
+              headers: { ETag: '"revision-1"' },
+            });
+      },
+    );
+    vi.stubGlobal("fetch", fetcher);
+    const descriptor = {
+      authorityEpoch: epochId,
+      causalFrontierDigest: "d".repeat(64),
+      format: "freed_normalized_checkpoint_export_v2",
+      itemCount: 0,
+      libraryId,
+      protocolVersion: 2,
+      recordCount: 0,
+      sourceRevision: 7,
+      writerId: "c".repeat(64),
+    };
+    const execute = vi.fn(async (command: string, payload: unknown) => {
+      if (command === "describe_checkpoint_export_v2") return descriptor;
+      if (command === "countersign_follower_actor_request_v2") {
+        expect(payload).toMatchObject({
+          canonicalEnrollmentRequestJson: new TextDecoder().decode(
+            requestBytes,
+          ),
+        });
+        return {
+          actorChainGenesis: vector.actor_chain_genesis,
+          actorId,
+          actorPublicKey: vector.actor_public_key_hex,
+          authorityEpochId: epochId,
+          canonicalEnrollmentCertificateJson: new TextDecoder().decode(
+            certificateBytes,
+          ),
+          enrolledAt: 1_000,
+          enrollmentCertificateDigest: certificate.certificate_digest,
+          libraryId,
+        };
+      }
+      if (command === "primary_follower_actor_transport_state_v1")
+        return {
+          actorId,
+          libraryId,
+          nextActorCounter: 1,
+          storageEpochId: epochId,
+        };
+      if (command === "export_follower_result_page_v2")
+        return {
+          canonicalRecordBytes: 0,
+          done: true,
+          nextCursor: null,
+          records: [],
+        };
+      throw new Error(`unexpected native command: ${command}`);
+    });
+    await createNodeLibraryServicePrimaryCloudPortV1().start({
+      config: {
+        credentialRecordId: "synthetic-record",
+        installationWitness: "e".repeat(64),
+      },
+      clock: { nowMs: () => 1_000 },
+      native: { execute },
+      stateFile: {},
+      fileSystem: {},
+    } as unknown as Parameters<LibraryServicePrimaryCloudPortV1["start"]>[0]);
+    await hooks.publication!.refreshInbound({
+      accessToken: "synthetic-token",
+      controlFileId: "control-1",
+      descriptor,
+      signal,
+    });
+    expect(
+      files.filter(
+        (file) => file.appProperties.freedObjectKind === "enrollment",
+      ),
+    ).toHaveLength(1);
+    expect(execute.mock.calls.map(([command]) => command)).toContain(
+      "export_follower_result_page_v2",
+    );
+    await hooks.publication!.refreshInbound({
+      accessToken: "synthetic-token",
+      controlFileId: "control-1",
+      descriptor,
+      signal,
+    });
+    expect(
+      execute.mock.calls.filter(
+        ([command]) => command === "countersign_follower_actor_request_v2",
+      ),
+    ).toHaveLength(1);
+  });
   it("constructs the default Drive transport without a supplied transport object", async () => {
     const descriptor = {
       authorityEpoch: "b".repeat(64),

--- a/packages/library-service/src/primary-cloud-runtime.test.ts
+++ b/packages/library-service/src/primary-cloud-runtime.test.ts
@@ -2,9 +2,12 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { createHash } from "node:crypto";
 import {
   createLibraryCoreImmutableObjectKey,
+  createLibraryCoreIntentHeadObjectKey,
   createLibraryCoreResultHeadObjectKey,
+  decodeLibraryCoreCanonicalValue,
   encodeLibraryCoreCanonicalValue,
 } from "@freed/shared/library-core";
+import { prepareLibraryCoreNormalizedIntentSegmentV2 } from "@freed/sync/cloud/library-core";
 import capabilityVectors from "../../shared/src/library-core/actor-capability-certificate-v2-vectors.json" with { type: "json" };
 import type { LibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runtime.js";
 
@@ -37,7 +40,7 @@ import { createNodeLibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runt
 afterEach(() => vi.unstubAllGlobals());
 
 describe("default Primary cloud composition", () => {
-  it("countersigns and publishes a real enrollment envelope through the default transport", async () => {
+  it("enrolls, imports an intent and publishes its result through the default transport", async () => {
     const vector = capabilityVectors.vectors[0]!;
     const certificate = vector.certificate;
     const actorId = certificate.certificate_body.actor_enrollment_body.actor_id;
@@ -87,6 +90,108 @@ describe("default Primary cloud composition", () => {
     files.push(
       immutable("request-1", requestBytes, "actor_enrollment_request"),
     );
+    // These envelopes test transport composition, not cryptographic admission.
+    // Native signature and atomic mutation proofs live in the Rust suite.
+    const intentBytes = encodeLibraryCoreCanonicalValue({
+      actor_chain_digest: "a".repeat(64),
+      actor_id: actorId,
+      actor_sequence: 1,
+      blob_references: [],
+      causal_frontier: [],
+      created_at_ms: 1,
+      entity_id: "item-1",
+      entity_type: "FeedItem",
+      epoch: 1,
+      epoch_id: epochId,
+      hlc_counter: 0,
+      hlc_wall_ms: 1,
+      library_id: libraryId,
+      operation_id: "operation-1",
+      operation_type: "feed_item_read_assignment",
+      payload: { read_at_ms: 1 },
+      payload_digest: "b".repeat(64),
+      previous_actor_chain_digest: vector.actor_chain_genesis,
+      previous_actor_operation_id: null,
+      schema_version: 1,
+      signature: "d".repeat(128),
+      signature_algorithm: "ed25519",
+      transaction_digest: "e".repeat(64),
+      transaction_id: "transaction-1",
+      transaction_member_count: 1,
+      transaction_member_index: 0,
+    });
+    const intent = await prepareLibraryCoreNormalizedIntentSegmentV2({
+      actorId,
+      libraryId,
+      storageEpochId: epochId,
+      previousSegmentDigest: null,
+      canonicalEnvelopes: [intentBytes],
+      subtle: crypto.subtle,
+    });
+    const segmentBytes = intent.object.source;
+    const intentReference = {
+      descriptor: { ...intent.object.descriptor },
+      transportObjectId: "intent-segment",
+    };
+    files.push({
+      id: "intent-segment",
+      name: intent.object.descriptor.objectKey,
+      bytes: segmentBytes,
+      appProperties: {
+        freedProtocol: "library-core-v1",
+        freedLibraryDigest: hash(libraryId),
+        freedObjectKind: "intents",
+        freedObjectKeyDigest: hash(intent.object.descriptor.objectKey),
+        freedContentDigest: intent.object.descriptor.contentDigest,
+      },
+    });
+    files.push({
+      id: "intent-head",
+      name: createLibraryCoreIntentHeadObjectKey(libraryId, epochId, actorId),
+      bytes: encodeLibraryCoreCanonicalValue({
+        actor_id: actorId,
+        library_id: libraryId,
+        storage_epoch_id: epochId,
+        protocol: "normalized_intent_head_v2",
+        protocol_version: 2,
+        next_actor_counter: 2,
+        latest_segment: intentReference,
+        latest_segment_digest: intent.object.descriptor.contentDigest,
+      }),
+      appProperties: {
+        freedProtocol: "library-core-v1",
+        freedLibraryDigest: hash(libraryId),
+        freedObjectKind: "intent_head",
+        freedEpochDigest: hash(epochId),
+        freedActorDigest: hash(actorId),
+      },
+    });
+    const resultBytes = encodeLibraryCoreCanonicalValue({
+      actor_id: actorId,
+      authoritative_source_revision: 8,
+      authority_key_id: "6".repeat(64),
+      canonical_operation_ids: ["operation-1"],
+      epoch: 1,
+      epoch_id: epochId,
+      format: "freed_follower_result_v1",
+      intent_epoch: 1,
+      intent_epoch_id: epochId,
+      library_id: libraryId,
+      original_result_digest: null,
+      previous_result_digest: null,
+      receipt_ids: ["receipt-1"],
+      rejection_reason: null,
+      replacement_fields: [],
+      resolved_at_ms: 1,
+      result_body_digest: "7".repeat(64),
+      result_sequence: 1,
+      schema_version: 1,
+      signature: "8".repeat(128),
+      signature_algorithm: "ed25519",
+      status: "accepted",
+      transaction_digest: "e".repeat(64),
+      transaction_id: "transaction-1",
+    });
     files.push({
       id: "result-head",
       name: createLibraryCoreResultHeadObjectKey(libraryId, epochId, actorId),
@@ -123,16 +228,36 @@ describe("default Primary cloud composition", () => {
         if (init?.method === "POST") {
           expect(url.pathname).toBe("/upload/drive/v3/files");
           expect(init.body).toBeInstanceOf(Blob);
-          expect(await (init.body as Blob).text()).toContain(
-            new TextDecoder().decode(certificateBytes),
+          const multipart = Buffer.from(
+            await (init.body as Blob).arrayBuffer(),
           );
-          const file = immutable(
-            "certificate-1",
-            certificateBytes,
-            "actor_enrollment",
+          const boundary = multipart
+            .subarray(0, multipart.indexOf("\r\n"))
+            .toString();
+          const metadataStart = multipart.indexOf("\r\n\r\n") + 4;
+          const separator = multipart.indexOf(`\r\n${boundary}`, metadataStart);
+          const uploaded = JSON.parse(
+            multipart.subarray(metadataStart, separator).toString(),
           );
+          const bytesStart = multipart.indexOf("\r\n\r\n", separator) + 4;
+          const bytesEnd = multipart.lastIndexOf(`\r\n${boundary}--`);
+          const file: File = {
+            id: `uploaded-${files.length}`,
+            name: uploaded.name,
+            appProperties: uploaded.appProperties,
+            bytes: new Uint8Array(multipart.subarray(bytesStart, bytesEnd)),
+          };
           files.push(file);
           return Response.json(metadata(file));
+        }
+        if (init?.method === "PUT") {
+          expect(url.pathname).toBe("/upload/drive/v2/files/result-head");
+          expect(new Headers(init.headers).get("If-Match")).toBe(
+            '"revision-1"',
+          );
+          files.find((file) => file.id === "result-head")!.bytes =
+            new Uint8Array(init.body as ArrayBuffer);
+          return Response.json({ id: "result-head", etag: '"revision-1"' });
         }
         expect(init?.method ?? "GET").toBe("GET");
         if (url.pathname === "/drive/v3/files") {
@@ -179,6 +304,7 @@ describe("default Primary cloud composition", () => {
       sourceRevision: 7,
       writerId: "c".repeat(64),
     };
+    let nextActorCounter = 1;
     const execute = vi.fn(async (command: string, payload: unknown) => {
       if (command === "describe_checkpoint_export_v2") return descriptor;
       if (command === "countersign_follower_actor_request_v2") {
@@ -204,16 +330,64 @@ describe("default Primary cloud composition", () => {
         return {
           actorId,
           libraryId,
-          nextActorCounter: 1,
+          nextActorCounter,
           storageEpochId: epochId,
         };
-      if (command === "export_follower_result_page_v2")
+      if (command === "ingest_follower_intent_page_v1") {
+        expect(payload).toMatchObject({
+          page: {
+            records: [
+              {
+                actorCounter: 1,
+                canonicalEnvelopeJson: new TextDecoder().decode(intentBytes),
+              },
+            ],
+          },
+        });
+        nextActorCounter = 2;
         return {
-          canonicalRecordBytes: 0,
-          done: true,
-          nextCursor: null,
-          records: [],
+          exactRetries: 0,
+          pendingTransactions: 0,
+          resolvedRecords: 1,
+          resolvedTransactions: 1,
+          stagedRecords: 1,
         };
+      }
+      if (command === "export_follower_result_page_v2") {
+        expect(nextActorCounter).toBe(2);
+        const first = (payload as { firstResultSequence: number })
+          .firstResultSequence;
+        return {
+          canonicalRecordBytes: first === 1 ? resultBytes.byteLength : 0,
+          done: true,
+          nextCursor: {
+            actorId,
+            resultSequence: 1,
+            resultDigest: "7".repeat(64),
+          },
+          records:
+            first === 1
+              ? [
+                  {
+                    actorId,
+                    authoritativeSourceRevision: 8,
+                    authorityEpochId: epochId,
+                    canonicalResultJson: new TextDecoder().decode(resultBytes),
+                    enqueuedAt: 1,
+                    intentEpochId: epochId,
+                    originalResultDigest: null,
+                    previousResultDigest: null,
+                    rejectionReason: null,
+                    resultDigest: "7".repeat(64),
+                    resultSequence: 1,
+                    status: "accepted",
+                    transactionDigest: "e".repeat(64),
+                    transactionId: "transaction-1",
+                  },
+                ]
+              : [],
+        };
+      }
       throw new Error(`unexpected native command: ${command}`);
     });
     await createNodeLibraryServicePrimaryCloudPortV1().start({
@@ -251,6 +425,29 @@ describe("default Primary cloud composition", () => {
         ([command]) => command === "countersign_follower_actor_request_v2",
       ),
     ).toHaveLength(1);
+    expect(
+      execute.mock.calls.filter(
+        ([command]) => command === "ingest_follower_intent_page_v1",
+      ),
+    ).toHaveLength(1);
+    expect(
+      files.filter((file) => file.appProperties.freedObjectKind === "results"),
+    ).toHaveLength(1);
+    expect(
+      files.find((file) => file.appProperties.freedObjectKind === "enrollment")!
+        .bytes,
+    ).toEqual(certificateBytes);
+    expect(
+      fetcher.mock.calls.filter(([, init]) => init?.method === "PUT"),
+    ).toHaveLength(1);
+    expect(
+      decodeLibraryCoreCanonicalValue(
+        files.find((file) => file.id === "result-head")!.bytes,
+      ),
+    ).toMatchObject({
+      next_result_sequence: 2,
+      latest_segment: { transportObjectId: expect.any(String) },
+    });
   });
   it("constructs the default Drive transport without a supplied transport object", async () => {
     const descriptor = {

--- a/packages/library-service/src/primary-cloud-runtime.test.ts
+++ b/packages/library-service/src/primary-cloud-runtime.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { LibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runtime.js";
+
+const hooks = vi.hoisted(() => ({
+  publication: null as null | {
+    refreshInbound(input: unknown): Promise<void>;
+  },
+}));
+
+vi.mock("./google-drive-publication.js", () => ({
+  createBoundGoogleDrivePublicationStatePortV1: vi.fn(),
+  createLibraryServiceGoogleDrivePublicationV1(
+    options: typeof hooks.publication,
+  ) {
+    hooks.publication = options;
+    return {};
+  },
+}));
+vi.mock("./node-google-drive-token.js", () => ({
+  createNodeGoogleDriveTokenPortV1: vi.fn(),
+}));
+vi.mock("./primary-runtime.js", () => ({
+  createLibraryServicePrimaryRuntimeV1: () => ({
+    start: async () => undefined,
+  }),
+}));
+
+import { createNodeLibraryServicePrimaryCloudPortV1 } from "./primary-cloud-runtime.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("installed Primary cloud composition", () => {
+  it("constructs the default Drive transport without a supplied transport object", async () => {
+    const descriptor = {
+      authorityEpoch: "b".repeat(64),
+      causalFrontierDigest: "d".repeat(64),
+      format: "freed_normalized_checkpoint_export_v2",
+      itemCount: 0,
+      libraryId: "a".repeat(64),
+      protocolVersion: 2,
+      recordCount: 0,
+      sourceRevision: 7,
+      writerId: "c".repeat(64),
+    };
+    const signal = new AbortController().signal;
+    const fetcher = vi.fn(
+      async (_url: RequestInfo | URL, init?: RequestInit) => {
+        expect(init?.signal).toBe(signal);
+        return new Response(JSON.stringify({ files: [] }), { status: 200 });
+      },
+    );
+    vi.stubGlobal("fetch", fetcher);
+    const execute = vi.fn(async () => descriptor);
+    await createNodeLibraryServicePrimaryCloudPortV1().start({
+      config: {
+        credentialRecordId: "synthetic-record",
+        installationWitness: "e".repeat(64),
+      },
+      clock: { nowMs: () => 1_000 },
+      native: { execute },
+      stateFile: {},
+      fileSystem: {},
+    } as unknown as Parameters<LibraryServicePrimaryCloudPortV1["start"]>[0]);
+
+    // Publication authority is covered by its own suite. Exercise the real
+    // composition's admitted callback without vault access or live HTTP.
+    expect(hooks.publication?.refreshInbound).toBeTypeOf("function");
+    await hooks.publication!.refreshInbound({
+      accessToken: "synthetic-token",
+      controlFileId: "control-1",
+      descriptor,
+      signal,
+    });
+    expect(execute).toHaveBeenCalledWith("describe_checkpoint_export_v2", {});
+    expect(fetcher).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/library-service/src/primary-cloud-runtime.ts
+++ b/packages/library-service/src/primary-cloud-runtime.ts
@@ -9,6 +9,7 @@ import {
   createLibraryServiceGoogleDrivePublicationV1,
 } from "./google-drive-publication.js";
 import type { LibraryCoreNativeCommandClientV1 } from "./native-command.js";
+import { createGoogleDrivePrimaryTransportV2 } from "./google-drive-primary-transport.js";
 import { createNodeGoogleDriveTokenPortV1 } from "./node-google-drive-token.js";
 import {
   createLibraryServicePrimaryRuntimeV1,
@@ -16,7 +17,6 @@ import {
 } from "./primary-runtime.js";
 import {
   createLibraryServiceNormalizedPrimaryOrchestrationV2,
-  createLibraryServiceNormalizedPrimaryPublicationV2,
   type LibraryServiceNormalizedPrimaryTransportV2,
 } from "./normalized-primary-orchestration.js";
 
@@ -44,7 +44,32 @@ export function createNodeLibraryServicePrimaryCloudPortV1(
 ): LibraryServicePrimaryCloudPortV1 {
   return Object.freeze({
     async start(input: PrimaryCloudStartInputV1) {
+      const normalizedPrimary =
+        createLibraryServiceNormalizedPrimaryOrchestrationV2({
+          native: input.native,
+          now: () => input.clock.nowMs(),
+          subtle: crypto.subtle,
+          transport: options.normalizedPrimaryTransport,
+        });
       const publication = createLibraryServiceGoogleDrivePublicationV1({
+        refreshInbound: async ({
+          accessToken,
+          controlFileId,
+          descriptor,
+          signal,
+        }) => {
+          await normalizedPrimary.refresh(
+            signal,
+            options.normalizedPrimaryTransport ??
+              createGoogleDrivePrimaryTransportV2({
+                accessToken,
+                controlFileId,
+                signal,
+                libraryId: descriptor.libraryId,
+                epochId: descriptor.authorityEpoch,
+              }),
+          );
+        },
         state: createBoundGoogleDrivePublicationStatePortV1(
           input.stateFile,
           input.fileSystem,
@@ -53,28 +78,12 @@ export function createNodeLibraryServicePrimaryCloudPortV1(
           input.config.credentialRecordId,
         ),
       });
-      const normalizedPrimary =
-        options.normalizedPrimaryTransport === undefined
-          ? null
-          : createLibraryServiceNormalizedPrimaryOrchestrationV2({
-              native: input.native,
-              now: () => input.clock.nowMs(),
-              subtle: crypto.subtle,
-              transport: options.normalizedPrimaryTransport,
-            });
-      const coordinatedPublication =
-        normalizedPrimary === null
-          ? publication
-          : createLibraryServiceNormalizedPrimaryPublicationV2(
-              publication,
-              normalizedPrimary,
-            );
       const runtime = createLibraryServicePrimaryRuntimeV1({
         clock: { nowMs: () => input.clock.nowMs() },
         diagnostics: { record() {} },
         installationWitness: input.config.installationWitness,
         native: input.native,
-        publication: coordinatedPublication,
+        publication,
         publicationState: publication,
         scheduler: {
           schedule(callback, delayMs) {

--- a/packages/sync/src/cloud/library-core-normalized-primary-sync.test.ts
+++ b/packages/sync/src/cloud/library-core-normalized-primary-sync.test.ts
@@ -11,6 +11,7 @@ import {
   type LibraryCoreNormalizedResultHeadV2,
 } from "@freed/shared/library-core";
 import { describe, expect, it, vi } from "vitest";
+import capabilityVectors from "../../../shared/src/library-core/actor-capability-certificate-v2-vectors.json" with { type: "json" };
 import {
   syncLibraryCoreNormalizedPrimaryEnrollmentsV2,
   syncLibraryCoreNormalizedPrimaryIntentsV2,
@@ -28,22 +29,15 @@ import type { LibraryCoreNormalizedHeadPublicationAdapterV2 } from "./library-co
 
 const LIBRARY_ID = "1".repeat(64);
 const EPOCH_ID = "2".repeat(64);
-const ACTOR_ID = "3".repeat(64);
-const ACTOR_KEY = "4".repeat(64);
-const REQUEST_DIGEST = "5".repeat(64);
+const capabilityVector = capabilityVectors.vectors[0]!;
+const ACTOR_ID =
+  capabilityVector.certificate.certificate_body.actor_enrollment_body.actor_id;
+const ACTOR_KEY = capabilityVector.actor_public_key_hex;
+const REQUEST_DIGEST = capabilityVector.certificate.certificate_digest;
 
 function request(): LibraryCoreNormalizedPrimaryEnrollmentRequestV2 {
   const bytes = encodeLibraryCoreCanonicalValue({
-    certificate_body: {
-      actor_enrollment_body: {
-        actor_id: ACTOR_ID,
-        actor_public_key: ACTOR_KEY,
-        authority_epoch_id: EPOCH_ID,
-        library_id: LIBRARY_ID,
-      },
-      actor_proof: "6".repeat(128),
-      enrollment_body_digest: "7".repeat(64),
-    },
+    certificate_body: capabilityVector.certificate.certificate_body,
     certificate_digest: REQUEST_DIGEST,
   } as LibraryCoreCanonicalValue);
   const contentDigest = sha256LowerHex(bytes);
@@ -67,22 +61,11 @@ function request(): LibraryCoreNormalizedPrimaryEnrollmentRequestV2 {
 }
 
 function nativeReceipt() {
-  const certificate = encodeLibraryCoreCanonicalValue({
-    authority_signature: "8".repeat(128),
-    certificate_body: {
-      actor_enrollment_body: {
-        actor_id: ACTOR_ID,
-        actor_public_key: ACTOR_KEY,
-        authority_epoch_id: EPOCH_ID,
-        library_id: LIBRARY_ID,
-      },
-      actor_proof: "6".repeat(128),
-      enrollment_body_digest: "7".repeat(64),
-    },
-    certificate_digest: REQUEST_DIGEST,
-  } as LibraryCoreCanonicalValue);
+  const certificate = encodeLibraryCoreCanonicalValue(
+    capabilityVector.certificate as LibraryCoreCanonicalValue,
+  );
   return Object.freeze({
-    actorChainGenesis: "9".repeat(64),
+    actorChainGenesis: capabilityVector.actor_chain_genesis,
     actorId: ACTOR_ID,
     actorPublicKey: ACTOR_KEY,
     authorityEpochId: EPOCH_ID,
@@ -128,6 +111,48 @@ function fixture(input: {
 }
 
 describe("normalized Primary enrollment sync", () => {
+  it("rejects the obsolete enrollment body before native countersigning", async () => {
+    const body = capabilityVector.certificate.certificate_body;
+    const bytes = encodeLibraryCoreCanonicalValue({
+      certificate_body: {
+        actor_enrollment_body: body.actor_enrollment_body,
+        actor_proof: body.actor_proof,
+        enrollment_body_digest: body.enrollment_body_digest,
+      },
+      certificate_digest: REQUEST_DIGEST,
+    } as LibraryCoreCanonicalValue);
+    const contentDigest = sha256LowerHex(bytes);
+    const active = fixture({
+      requests: [
+        {
+          bytes,
+          reference: {
+            transportObjectId: "obsolete-request",
+            descriptor: parseLibraryCoreImmutableObjectDescriptorV1({
+              byteLength: bytes.byteLength,
+              contentDigest,
+              objectKey: createLibraryCoreImmutableObjectKey({
+                actorId: ACTOR_ID,
+                digest: contentDigest,
+                epochId: EPOCH_ID,
+                kind: "actor_enrollment_request",
+                libraryId: LIBRARY_ID,
+              }),
+            }),
+          },
+        },
+      ],
+    });
+    await expect(
+      syncLibraryCoreNormalizedPrimaryEnrollmentsV2(
+        active.transport,
+        active.runtime,
+        { libraryId: LIBRARY_ID, storageEpochId: EPOCH_ID },
+      ),
+    ).rejects.toThrow();
+    expect(active.countersignEnrollment).not.toHaveBeenCalled();
+    expect(active.published).toHaveLength(0);
+  });
   it("countersigns one exact request and publishes one immutable certificate", async () => {
     const active = fixture({});
     const receipt = await syncLibraryCoreNormalizedPrimaryEnrollmentsV2(

--- a/packages/sync/src/cloud/library-core-normalized-primary-sync.test.ts
+++ b/packages/sync/src/cloud/library-core-normalized-primary-sync.test.ts
@@ -195,25 +195,32 @@ function canonicalIntent(actorSequence = 1) {
     operation_type: "feed_item_read_assignment",
     payload: { read_at_ms: 1 },
     payload_digest: "b".repeat(64),
-    previous_actor_chain_digest: "c".repeat(64),
-    previous_actor_operation_id: null,
+    previous_actor_chain_digest: (actorSequence === 1 ? "c" : "a").repeat(64),
+    previous_actor_operation_id:
+      actorSequence === 1 ? null : `operation-${actorSequence - 1}`,
     schema_version: 1,
     signature: "d".repeat(128),
     signature_algorithm: "ed25519",
     transaction_digest: "e".repeat(64),
-    transaction_id: "transaction-1",
+    transaction_id: `transaction-${actorSequence}`,
     transaction_member_count: 1,
     transaction_member_index: 0,
   } as LibraryCoreCanonicalValue);
 }
 
 async function intentFixture(
-  input: { previousSegmentDigest?: LibraryCoreLowercaseHex64 | null } = {},
+  input: {
+    previousSegmentDigest?: LibraryCoreLowercaseHex64 | null;
+    resumeCounter?: number;
+  } = {},
 ) {
   const canonicalEnvelope = canonicalIntent();
   const prepared = await prepareLibraryCoreNormalizedIntentSegmentV2({
     actorId: ACTOR_ID,
-    canonicalEnvelopes: [canonicalEnvelope],
+    canonicalEnvelopes:
+      input.resumeCounter === 2
+        ? [canonicalEnvelope, canonicalIntent(2)]
+        : [canonicalEnvelope],
     libraryId: LIBRARY_ID,
     previousSegmentDigest: null,
     storageEpochId: EPOCH_ID,
@@ -223,7 +230,7 @@ async function intentFixture(
     descriptor: prepared.object.descriptor,
     transportObjectId: "intent-segment-1",
   });
-  let nextActorCounter = 1;
+  let nextActorCounter = input.resumeCounter ?? 1;
   const ingestIntentPage = vi.fn(async ({ page }) => {
     nextActorCounter = page.records.at(-1)!.actorCounter + 1;
     return {
@@ -257,13 +264,14 @@ async function intentFixture(
     async pageIntentReferences(page) {
       expect(page).toEqual({
         actorId: ACTOR_ID,
-        firstActorCounter: 1,
+        firstActorCounter: input.resumeCounter ?? 1,
         libraryId: LIBRARY_ID,
         limit: 16,
         storageEpochId: EPOCH_ID,
       });
       return {
         done: true,
+        firstActorCounter: 1,
         previousSegmentDigest: input.previousSegmentDigest ?? null,
         references: [reference],
       };
@@ -273,6 +281,27 @@ async function intentFixture(
 }
 
 describe("normalized Primary intent sync", () => {
+  it("replays a complete verified segment containing an unresolved native counter", async () => {
+    const active = await intentFixture({ resumeCounter: 2 });
+    const receipt = await syncLibraryCoreNormalizedPrimaryIntentsV2(
+      active.transport,
+      active.runtime,
+      {
+        actorId: ACTOR_ID,
+        libraryId: LIBRARY_ID,
+        storageEpochId: EPOCH_ID,
+      },
+    );
+    expect(receipt).toMatchObject({
+      nextActorCounter: 3,
+      importedIntentCount: 2,
+    });
+    expect(
+      active.ingestIntentPage.mock.calls[0]![0].page.records.map(
+        (record: { actorCounter: number }) => record.actorCounter,
+      ),
+    ).toEqual([1, 2]);
+  });
   it("imports one exact immutable segment and proves native counter advance", async () => {
     const active = await intentFixture();
     const receipt = await syncLibraryCoreNormalizedPrimaryIntentsV2(

--- a/packages/sync/src/cloud/library-core-normalized-primary-sync.ts
+++ b/packages/sync/src/cloud/library-core-normalized-primary-sync.ts
@@ -254,7 +254,13 @@ function parseEnrollmentRequestIdentity(
   );
   const certificateBody = closedRecord(
     request.certificate_body,
-    ["actor_enrollment_body", "actor_proof", "enrollment_body_digest"],
+    [
+      "actor_enrollment_body",
+      "actor_proof",
+      "enrollment_body_digest",
+      "actor_capability_body",
+      "actor_capability_body_digest",
+    ],
     "normalized enrollment request certificate body",
   );
   const enrollmentBody = closedRecord(
@@ -265,7 +271,7 @@ function parseEnrollmentRequestIdentity(
   const actorId = enrollmentBody.actor_id;
   const actorPublicKey = enrollmentBody.actor_public_key;
   const libraryId = enrollmentBody.library_id;
-  const storageEpochId = enrollmentBody.authority_epoch_id;
+  const storageEpochId = enrollmentBody.epoch_id;
   const certificateDigest = request.certificate_digest;
   if (
     !isLibraryCoreLowercaseHex64(actorId) ||

--- a/packages/sync/src/cloud/library-core-normalized-primary-sync.ts
+++ b/packages/sync/src/cloud/library-core-normalized-primary-sync.ts
@@ -75,6 +75,8 @@ export interface LibraryCoreNormalizedPrimaryEnrollmentReceiptV2 {
 
 export interface LibraryCoreNormalizedPrimaryIntentReferencePageV2 {
   readonly done: boolean;
+  /** First counter of the first complete immutable segment, including replay. */
+  readonly firstActorCounter: number;
   readonly previousSegmentDigest: LibraryCoreLowercaseHex64 | null;
   readonly references: readonly LibraryCoreImmutableObjectReferenceV1[];
 }
@@ -592,10 +594,14 @@ export async function syncLibraryCoreNormalizedPrimaryIntentsV2(
     !Array.isArray(page.references) ||
     page.references.length > INTENT_REFERENCE_PAGE_LIMIT ||
     (page.references.length === 0 && !page.done) ||
+    !isLibraryCoreNonnegativeSafeInteger(page.firstActorCounter) ||
+    page.firstActorCounter < 1 ||
+    page.firstActorCounter > actorState.nextActorCounter ||
+    (page.references.length === 0 &&
+      page.firstActorCounter !== actorState.nextActorCounter) ||
     (page.previousSegmentDigest !== null &&
       !isLibraryCoreLowercaseHex64(page.previousSegmentDigest)) ||
-    (actorState.nextActorCounter === 1) !==
-      (page.previousSegmentDigest === null)
+    (page.firstActorCounter === 1) !== (page.previousSegmentDigest === null)
   ) {
     throw new TypeError("normalized intent reference page is invalid");
   }
@@ -605,7 +611,10 @@ export async function syncLibraryCoreNormalizedPrimaryIntentsV2(
   for (const rawReference of page.references) {
     options.signal?.throwIfAborted();
     const reference = parseLibraryCoreImmutableObjectReferenceV1(rawReference);
-    const expectedFirstActorCounter = actorState.nextActorCounter;
+    const expectedFirstActorCounter =
+      importedSegmentCount === 0
+        ? page.firstActorCounter
+        : actorState.nextActorCounter;
     let segmentLastActorCounter: number | null = null;
     await importLibraryCoreNormalizedIntentSegmentV2({
       actorId,
@@ -618,6 +627,11 @@ export async function syncLibraryCoreNormalizedPrimaryIntentsV2(
       subtle: runtime.subtle,
       writer: {
         async stageNormalizedIntentSegment(input): Promise<void> {
+          if (input.header.last_actor_counter < actorState.nextActorCounter) {
+            throw new Error(
+              "normalized intent replay does not contain the pending counter",
+            );
+          }
           const records = input.envelopes.map((envelope, index) =>
             stageIntentRecord(envelope, input.canonicalEnvelopes[index]!),
           );


### PR DESCRIPTION
(AI Generated).

## Change

Wire the headless Primary's default cloud composition to normalized enrollment,
intent import and result publication. The installed entry point previously
omitted the transport and silently skipped inbound follower work.

The existing inbound refresh now checks remote writer/epoch authority before
constructing a request-scoped Drive transport. Cancellation reaches active reads,
and the actor cursor survives passes without retaining a stale AbortSignal.
Discovery keeps its existing bounds and each pass processes at most 16 actors.

Correct enrollment parsing to match the five-field capability certificate body
and epoch_id emitted by the native/PWA protocol. Completed requests are excluded
using the nested enrollment-body digest.

Recover a complete staged transaction left unresolved by a late native failure.
The native transport cursor points back to its first unresolved member, and the
transport replays the containing verified segment. Incomplete transactions still
advance toward their missing members; resolved outbox records are not retried.
No schema or storage-epoch transition is introduced.

## Proof

- Native restart regression preserves staged rows in a file-backed SQLite fixture,
  reopens it, retries the signed transaction and verifies one accepted result.
- Default-runtime composition uses real Drive adapters with synthetic HTTP/native
  boundaries. It enrolls, imports an intent, publishes its result and suppresses
  duplicate work on the next refresh. Native admission is mocked in this test;
  signature and atomicity proof remains in the native suite.
- Authority-ordering tests refuse a foreign writer/epoch before inbound admission.
- Actor fairness and cancellation tests cover more than 16 actors and a fresh
  signal after interruption.
- Package checks pass: 118 sync tests, 144 service tests with one platform skip,
  and TypeScript checks. Full feature validation passed at commit
  134704833c9ce711132a7d5b543a9f5628d22bea, including PWA and Desktop builds,
  371 PWA tests, 826 Desktop tests, nine smoke tests, native Rust validation,
  activation/release checks, instruction validation and roadmap checks.

## Release status

Related to #1813. Keep that issue open until installed headless acceptance proves
follower import, edit, Primary acceptance and result reconciliation.

Hold merge until the active v26.9.501-dev installed acceptance outcome is recorded.
This PR does not install a build, contact a live provider or prove PWA convergence.
Linux/Windows credential custody and Windows secure actor ingress remain separate
production gaps.

Google Drive will observe the newly enabled inbound requests and result writes
on the existing schedule. No timer, concurrency, retry or cadence is added.
The attached behavior review records the owner-authorized scope and rollback:
stop the candidate process on authority/admission or reconciliation failure,
preserve evidence and newer SQLite data, and revert executable code only.

## Provider Review
- Status: Draft publication was requested. Provider authority is validated, but no ready transition was requested.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `788d8fc90b94e627b8806360930cd1c0df3b82de`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `headless-inbound-1813-20260906`
- Provider review decision: `behavior_approved`
- Provider review artifact: `27683bc38fe3e4ddf2897a7a6209b9de453518edfe5fd7f4c109c792fc9f45a3`
- Providers: other
- Observable behavior: Google Drive: the headless Primary will use the existing inbound_refresh schedule to discover follower enrollment requests and actors, read committed intent segments, publish verified enrollment certificates, and publish signed result segments and their head. The installed default composition previously skipped this transport. A fresh authority check precedes inbound work.
- Fingerprinting risk: Enabling the previously missing inbound path increases Drive reads and immutable writes when follower work exists. Google can observe the additional request sequence and volume, and quota or throttling exposure can increase. No social provider behavior changes.
- Lowest profile alternative: Keep all development on synthetic HTTP/native fixtures and leave the installed release unchanged until its current acceptance window completes. No live Drive traffic is needed for local validation.

Files bound into this provider review:
- `packages/library-service/src/google-drive-publication.ts`
- `packages/library-service/src/primary-cloud-runtime.ts`
- `packages/sync/src/cloud/library-core-normalized-primary-sync.test.ts`
- `packages/sync/src/cloud/library-core-normalized-primary-sync.ts`