### PR TITLE
fix: add sealed Linux Drive credential custody

### DIFF
--- a/docs/PHASE-11-OPENCLAW.md
+++ b/docs/PHASE-11-OPENCLAW.md
@@ -1,6 +1,6 @@
 # Phase 11: Headless Library Authority and Agent Integrations
 
-> **Status:** 🚧 In Progress (the shared transport-neutral Primary scheduler, normalized native SQLite authority, local process lease, native and PWA actor capability enforcement with separate signed mutation and query grants, authority-signed actor enrollment and retirement, fail-closed service supervisor, descriptor-bound normalized sidecar startup, bounded checkpoint and query ingress, native mutation and signed agent query admission, exact local writer reassignment, production macOS and Linux ACL proofs, deterministic service definitions, macOS Drive PKCE and Keychain custody, installed immutable checkpoint publication, and provider-neutral bounded enrollment, intent, and result orchestration have landed; installed inbound transport binding, Linux and Windows Drive secret custody, Windows service transport, and capture workers remain open)
+> **Status:** 🚧 In Progress. Native SQLite authority, bounded commands, actor capabilities, the service supervisor, platform ACL proofs, macOS Keychain custody, Linux sealed OAuth records, and checkpoint publication are implemented. Installed bidirectional acceptance, Linux service lifecycle acceptance, Windows vault and service transport, and capture workers remain open. The inbound transport follow-up is tracked separately.
 
 > **Architecture:** The headless Primary and Freed Desktop consume the
 > same extracted native Rust Library Core and the same stock SQLite contract.
@@ -136,8 +136,10 @@ existing immutable checkpoint protocol, and persists only the committed
 control receipt through an already-bound private state-file descriptor. The
 coordinator stops before service settlement. A missing token, changed Library
 identity, cloud writer conflict, malformed response, or unavailable secret
-backend fails closed. Linux sealed credential custody and complete inbound
-enrollment, intent, and result processing remain open.
+backend fails closed. Linux sealed credential custody has an explicit bound
+configuration and shared authorization/refresh store; installed Linux lifecycle
+acceptance remains open. Complete inbound enrollment, intent, and result
+processing is tracked separately.
 
 The native sidecar acquires the
 data-root lease before opening only the final normalized SQLite catalog in the
@@ -315,10 +317,20 @@ credentials remain separate secret records. They never appear in SQLite,
 backups, cloud objects, command arguments, environment values, logs, or bug
 reports.
 
-macOS and Windows use their platform credential vaults. Linux uses an injected
-secret store. The first Linux implementation should use a versioned sealed
-file whose wrapping key is supplied as a mounted credential file. An
-environment variable is not an acceptable wrapping-key source.
+macOS uses Keychain. Windows vault support remains open. Linux uses the explicit
+`linux-sealed-file-v1` store shared by CLI authorization and runtime refresh.
+Its configuration binds a private record directory, a separate mounted 32-byte
+wrapping-key file and its SHA-256 digest into the admitted configuration hash.
+The key cannot live inside the writable record directory or reuse the native
+signing bundle. Environment values are not acceptable wrapping-key sources.
+
+Bounded AES-256-GCM records authenticate their format and record identity. The
+store checks owner, mode, link count, ACLs, descriptor identity and key digest;
+it atomically replaces sealed files and verifies stored bytes before returning.
+Corrupt existing records are preserved. Linux consent uses the existing PKCE
+flow with an interactive-terminal URL and loopback forwarding instructions for
+remote hosts. It does not log tokens or open a browser automatically. Installed
+Linux acceptance and Windows custody remain required before this phase closes.
 
 Headless Drive authorization uses PKCE through the existing Freed OAuth proxy.
 It requests only the Drive scopes needed by Library Core. Google Contacts
@@ -546,7 +558,7 @@ review before implementation.
 | 11.2  | Complete    | Enforce one operating system backed Library data-root lease before SQLite opens                                                                                                                                                                                                                                                                                                                                                    |
 | 11.3  | Complete    | Extract the reusable native SQLite authority package without changing Tauri behavior                                                                                                                                                                                                                                                                                                                                               |
 | 11.4  | Complete    | Add the headless service supervisor, explicit role config, and fail-closed startup                                                                                                                                                                                                                                                                                                                                                 |
-| 11.5  | In Progress | macOS `drive-auth` now uses PKCE through the existing OAuth proxy, requests only Library Core Drive scopes, stores only the refresh token in Keychain, and keeps access tokens memory-only. Complete the versioned Linux sealed credential store and Windows vault adapter next.                                                                                                                                                   |
+| 11.5 | In Progress | macOS Keychain and Linux versioned sealed-file custody share the existing Drive-only PKCE flow. Linux binds its separate mounted wrapping key and record directory through admitted configuration. Complete installed Linux lifecycle acceptance and the Windows vault adapter. |
 | 11.6  | In Progress | Open final normalized SQLite behind the descriptor-bound sidecar and provide generated bounded checkpoint, atomic pinned export begin, registered query, Primary signing, canonical commit, authority-signed follower enrollment, follower-intent admission, actor state, and result export commands. The installed service now composes one bounded provider-neutral enrollment, intent, and result pass on the existing inbound hook when a transport is injected. Complete the Google Drive transport adapter after its exact behavior approval.              |
 | 11.7  | In Progress | Apply exact writer promotion through the generated native sidecar command and bind the shared 15-second revision plus 60-second inbound schedule to native actor and checkpoint identity. The installed macOS service now starts and stops that scheduler with immutable Drive checkpoint publication and durable exact control receipts. Complete installed promotion and competing-Primary acceptance next.                      |
 | 11.8  | Complete    | Prove actor capability certificates and the frozen transition policy in native SQLite. Phase 6 carries the same proof into PWA SQLite before activation.                                                                                                                                                                                                                                                                           |

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -58,6 +58,7 @@
     {
       "id": 11,
       "status": "current",
+      "reviewedAt": "2026-09-06",
       "source": "docs/PHASE-11-OPENCLAW.md"
     },
     {

--- a/packages/library-service/README.md
+++ b/packages/library-service/README.md
@@ -148,9 +148,44 @@ does not prove Drive authentication, OAuth validity, cloud reachability, or
 writer promotion. The sidecar never interprets a Drive token or makes a
 provider request. On macOS, `drive-auth` performs one interactive PKCE flow and
 writes only the refresh token to Keychain. The token is sent to `security`
-through standard input, never an argument or environment value. Linux and
-Windows Drive secret stores remain fail-closed until their platform custody
-contracts land.
+through standard input, never an argument or environment value. Windows Drive
+custody remains fail-closed. Linux requires an explicit sealed-file store in
+the `cloud` configuration:
+
+```json
+"credentialStore": {
+  "backend": "linux-sealed-file-v1",
+  "directory": "/physical/state/oauth-records",
+  "wrappingKeyFile": "/physical/state/oauth-wrapping-key",
+  "wrappingKeyDigest": "<SHA-256 of the mounted 32-byte wrapping key>"
+}
+```
+
+Provision the record directory with mode `0700` and the separate mounted key
+file with mode `0600`, both owned by the service user. Both must be physical
+paths inside `stateRoot`, outside the native `mounted-credentials` signing
+directory. The key cannot be inside the writable record directory. The expected
+digest and paths change the configuration hash and therefore require matching
+service admission. Never pass key bytes in command arguments or environment
+values. Keep the wrapping key out of Library backups and cloud storage.
+
+Linux `drive-auth` prints its consent URL only to an interactive terminal on
+stderr. On a remote host, forward the displayed loopback port through SSH before
+opening the URL in a local browser. The attempt expires after five minutes.
+Redirected output is refused; stdout retains the final JSON result. The existing
+PKCE flow and Drive-only scopes are unchanged.
+
+Authorization and refresh use the same descriptor-bound store. Each bounded
+record uses AES-256-GCM with a random nonce and authenticated record identity.
+Writes fsync a private temporary sealed file, rename it atomically, sync the
+directory, and verify the stored bytes before acknowledging success. Invalid,
+nonprivate or corrupt existing records are preserved rather than overwritten.
+Changing the mounted key without a matching configuration and admission fails
+closed. This does not rotate native signing keys or the Library storage epoch.
+The running service pins the authenticated credential record revision before
+token use. Replacing, removing, or invalidating that record prevents cached
+token reuse and requires a service restart, even if the original file is
+restored. A token returned during a detected credential change is discarded.
 
 The admission record on fd6 is exact-shape JSON. It binds the operator's local
 Primary admission to the start envelope, executable, both inherited root

--- a/packages/library-service/src/bound-drive-credential-store.ts
+++ b/packages/library-service/src/bound-drive-credential-store.ts
@@ -1,0 +1,20 @@
+import type { BoundLibraryServiceConfiguration } from "./config.js";
+import {
+  LibraryServiceFailure,
+  type LibraryServiceAclProofPort,
+} from "./contracts.js";
+import { createLinuxDriveCredentialStore } from "./linux-drive-credential-store.js";
+
+/** Select only explicitly configured, admission-bound OAuth custody. */
+export function createBoundDriveCredentialStore(
+  bound: BoundLibraryServiceConfiguration,
+  aclProof: LibraryServiceAclProofPort,
+) {
+  if (bound.config.cloud?.credentialStore === undefined) return undefined;
+  if (bound.driveCredentialStore === undefined)
+    throw new LibraryServiceFailure("drive_credential_unavailable");
+  return createLinuxDriveCredentialStore({
+    ...bound.driveCredentialStore,
+    aclProof,
+  });
+}

--- a/packages/library-service/src/cli-runtime.ts
+++ b/packages/library-service/src/cli-runtime.ts
@@ -17,6 +17,8 @@ import {
 import { createLibraryServiceDefinitionV1 } from "./service-definition.js";
 import { LibraryServiceSupervisor } from "./supervisor.js";
 import { authorizeNodeGoogleDriveV1 } from "./node-google-drive-auth.js";
+import { createBoundDriveCredentialStore } from "./bound-drive-credential-store.js";
+import { createLinuxDriveConsentPresenter } from "./linux-drive-consent.js";
 
 interface ParsedArguments {
   command: "serve" | "status" | "doctor" | "service-definition" | "drive-auth";
@@ -183,8 +185,24 @@ async function authorizeGoogleDrive(configPath: string): Promise<number> {
     if (bound.config.cloud === null) {
       throw new LibraryServiceFailure("config_invalid");
     }
+    const credentialStore = createBoundDriveCredentialStore(
+      bound,
+      ports.aclProof,
+    );
     const receipt = await authorizeNodeGoogleDriveV1(
       bound.config.cloud.credentialRecordId,
+      {
+        ...(credentialStore === undefined
+          ? {}
+          : { persistCredential: credentialStore.persistCredential }),
+        ...(process.platform === "linux"
+          ? {
+              openAuthorizationUrl: createLinuxDriveConsentPresenter(
+                process.stderr,
+              ),
+            }
+          : {}),
+      },
     );
     await assertLibraryServiceBindingsStable(bound, ports.fileSystem);
     writeStandardReport({

--- a/packages/library-service/src/config.test.ts
+++ b/packages/library-service/src/config.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { bindLibraryServiceConfig } from "./config.js";
+import {
+  assertLibraryServiceBindingsStable,
+  bindLibraryServiceConfig,
+} from "./config.js";
 import { LibraryServiceFailure } from "./contracts.js";
 import { inspectLibraryServiceReadiness } from "./diagnostics.js";
 import {
@@ -30,6 +33,90 @@ async function loadLibraryServiceConfig(
 }
 
 describe("loadLibraryServiceConfig", () => {
+  function linuxCloudFixture() {
+    const fileSystem = validConfigFileSystem();
+    const raw = JSON.parse(fileSystem.texts.get("/safe/config.json")!);
+    const keyFile = "/safe/state/oauth-wrapping-key";
+    fileSystem.addFile(keyFile, "k".repeat(32));
+    fileSystem.addDirectory("/safe/state/oauth-records");
+    fileSystem.addFile("/safe/state/drive-state.json", "");
+    raw.cloud = {
+      provider: "google-drive",
+      installationWitness: "e".repeat(64),
+      credentialRecordId: "drive-1",
+      publicationStateFile: "/safe/state/drive-state.json",
+      credentialStore: {
+        backend: "linux-sealed-file-v1",
+        directory: "/safe/state/oauth-records",
+        wrappingKeyFile: keyFile,
+        wrappingKeyDigest: fileSystem.digests.get(keyFile),
+      },
+    };
+    fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+    return { fileSystem, raw, keyFile };
+  }
+
+  it("binds and closes OAuth custody and detects same-size key changes", async () => {
+    const { fileSystem, raw, keyFile } = linuxCloudFixture();
+    const bound = await bindLibraryServiceConfig(
+      "/safe/config.json",
+      fileSystem,
+      new FakeIdentity(),
+      new FakeAclProof(),
+    );
+    expect(bound.config.cloud).toEqual(raw.cloud);
+    expect(bound.driveCredentialStore?.directory.path).toBe(
+      raw.cloud.credentialStore.directory,
+    );
+    expect(bound.driveCredentialStore?.wrappingKey.path).toBe(keyFile);
+    fileSystem.rewriteFileInPlace(keyFile, "z".repeat(32));
+    await expect(
+      assertLibraryServiceBindingsStable(bound, fileSystem),
+    ).rejects.toThrow("bound_input_changed");
+    await bound.close();
+    expect(fileSystem.opened.every((resource) => resource.closed)).toBe(true);
+  });
+
+  it.each([
+    { directory: "/outside/oauth" },
+    { directory: "/safe/state/mounted-credentials" },
+    { wrappingKeyFile: "/safe/state/oauth-records/key" },
+    { wrappingKeyFile: "/safe/state/mounted-credentials/key" },
+    { backend: "plaintext" },
+    { wrappingKeyDigest: "invalid" },
+    { extra: true },
+  ])(
+    "rejects unsafe or unrecognized OAuth store configuration %j",
+    async (patch) => {
+      const { fileSystem, raw } = linuxCloudFixture();
+      Object.assign(raw.cloud.credentialStore, patch);
+      fileSystem.addFile("/safe/config.json", JSON.stringify(raw));
+      await expect(
+        bindLibraryServiceConfig(
+          "/safe/config.json",
+          fileSystem,
+          new FakeIdentity(),
+          new FakeAclProof(),
+        ),
+      ).rejects.toThrow("config_invalid");
+      expect(fileSystem.opened.every((resource) => resource.closed)).toBe(true);
+    },
+  );
+
+  it("rejects a wrong mounted key before returning bound configuration", async () => {
+    const { fileSystem, keyFile } = linuxCloudFixture();
+    fileSystem.rewriteFileInPlace(keyFile, "x".repeat(32));
+    await expect(
+      bindLibraryServiceConfig(
+        "/safe/config.json",
+        fileSystem,
+        new FakeIdentity(),
+        new FakeAclProof(),
+      ),
+    ).rejects.toThrow("drive_credential_unavailable");
+    expect(fileSystem.opened.every((resource) => resource.closed)).toBe(true);
+  });
+
   it("accepts one explicit Primary with private roots and a pinned sidecar", async () => {
     const fileSystem = validConfigFileSystem();
 

--- a/packages/library-service/src/config.ts
+++ b/packages/library-service/src/config.ts
@@ -67,6 +67,11 @@ export interface BoundLibraryServiceConfiguration {
   credentialDescriptorDigest: string;
   configFile: LibraryServiceBoundPath;
   cloudState: LibraryServiceBoundPath | null;
+  driveCredentialStore?: {
+    directory: LibraryServiceBoundPath;
+    wrappingKey: LibraryServiceBoundPath;
+    wrappingKeyDigest: string;
+  };
   bindings: LibraryServiceBoundInputs;
   close(): Promise<void>;
 }
@@ -365,7 +370,13 @@ function parseConfig(text: string): LibraryServiceConfig {
   if ("cloud" in raw && raw.cloud !== null) {
     if (
       !isObject(raw.cloud) ||
-      !hasExactKeys(raw.cloud, CLOUD_CONFIG_KEYS) ||
+      !hasExactKeys(
+        raw.cloud,
+        new Set([
+          ...CLOUD_CONFIG_KEYS,
+          ...("credentialStore" in raw.cloud ? ["credentialStore"] : []),
+        ]),
+      ) ||
       raw.cloud.provider !== "google-drive" ||
       typeof raw.cloud.installationWitness !== "string" ||
       !LOWERCASE_SHA256.test(raw.cloud.installationWitness) ||
@@ -383,6 +394,38 @@ function parseConfig(text: string): LibraryServiceConfig {
         "cloud_state_missing",
       ),
     };
+    if ("credentialStore" in raw.cloud) {
+      const store = raw.cloud.credentialStore;
+      if (
+        !isObject(store) ||
+        !hasExactKeys(
+          store,
+          new Set([
+            "backend",
+            "directory",
+            "wrappingKeyFile",
+            "wrappingKeyDigest",
+          ]),
+        ) ||
+        store.backend !== "linux-sealed-file-v1" ||
+        typeof store.wrappingKeyDigest !== "string" ||
+        !LOWERCASE_SHA256.test(store.wrappingKeyDigest)
+      ) {
+        throw new LibraryServiceFailure("config_invalid");
+      }
+      cloud.credentialStore = {
+        backend: "linux-sealed-file-v1",
+        directory: requireAbsolutePhysicalPath(
+          store.directory,
+          "config_invalid",
+        ),
+        wrappingKeyFile: requireAbsolutePhysicalPath(
+          store.wrappingKeyFile,
+          "config_invalid",
+        ),
+        wrappingKeyDigest: store.wrappingKeyDigest,
+      };
+    }
   }
 
   if (
@@ -465,6 +508,31 @@ function validatePathSeparation(
 ): void {
   const statusPath = path.join(config.stateRoot, "library-service-status.json");
   const cloudStatePath = config.cloud?.publicationStateFile ?? null;
+  const store = config.cloud?.credentialStore;
+  if (store !== undefined) {
+    const signingMount = path.join(config.stateRoot, "mounted-credentials");
+    if (
+      !isStrictChild(store.directory, config.stateRoot) ||
+      !isStrictChild(store.wrappingKeyFile, config.stateRoot) ||
+      isWithinOrEqual(store.wrappingKeyFile, store.directory) ||
+      isWithinOrEqual(store.directory, signingMount) ||
+      isWithinOrEqual(signingMount, store.directory) ||
+      isWithinOrEqual(store.wrappingKeyFile, signingMount) ||
+      [
+        config.admissionFile,
+        config.credentialDescriptorFile,
+        statusPath,
+        cloudStatePath,
+      ].some(
+        (file) =>
+          file !== null &&
+          (isWithinOrEqual(file, store.directory) ||
+            file === store.wrappingKeyFile),
+      )
+    ) {
+      throw new LibraryServiceFailure("config_invalid");
+    }
+  }
   if (
     config.dataRoot === config.stateRoot ||
     isWithinOrEqual(config.dataRoot, config.stateRoot) ||
@@ -521,6 +589,12 @@ export async function assertLibraryServiceBindingsStable(
     bound.configFile,
     ...Object.values(bound.bindings),
     ...(bound.cloudState === null ? [] : [bound.cloudState]),
+    ...(bound.driveCredentialStore === undefined
+      ? []
+      : [
+          bound.driveCredentialStore.directory,
+          bound.driveCredentialStore.wrappingKey,
+        ]),
   ];
   for (const resource of paths) {
     throwIfAborted(signal);
@@ -550,6 +624,14 @@ export async function assertLibraryServiceBindingsStable(
     [bound.bindings.executable, bound.executableDigest],
     [bound.bindings.admission, bound.admissionDigest],
     [bound.bindings.credentialDescriptor, bound.credentialDescriptorDigest],
+    ...(bound.driveCredentialStore === undefined
+      ? []
+      : [
+          [
+            bound.driveCredentialStore.wrappingKey,
+            bound.driveCredentialStore.wrappingKeyDigest,
+          ] as const,
+        ]),
   ];
   for (const [resource, expectedDigest] of digests) {
     throwIfAborted(signal);
@@ -662,6 +744,35 @@ export async function bindLibraryServiceConfig(
         throw new LibraryServiceFailure("cloud_state_invalid");
       }
     }
+    let driveCredentialStore: BoundLibraryServiceConfiguration["driveCredentialStore"];
+    if (config.cloud?.credentialStore !== undefined) {
+      const store = config.cloud.credentialStore;
+      const directory = await bindPrivateDirectory(
+        store.directory,
+        context,
+        "config_invalid",
+        "drive_credential_unavailable",
+      );
+      opened.push(directory);
+      const wrappingKey = await bindPrivateFile(
+        store.wrappingKeyFile,
+        context,
+        "drive_credential_unavailable",
+        "drive_credential_unavailable",
+      );
+      opened.push(wrappingKey);
+      if (
+        wrappingKey.metadata.size !== 32 ||
+        (await wrappingKey.sha256()) !== store.wrappingKeyDigest
+      ) {
+        throw new LibraryServiceFailure("drive_credential_unavailable");
+      }
+      driveCredentialStore = {
+        directory,
+        wrappingKey,
+        wrappingKeyDigest: store.wrappingKeyDigest,
+      };
+    }
     const sidecar = await bindPinnedSidecar(config, context);
     opened.push(sidecar.bound);
 
@@ -682,6 +793,7 @@ export async function bindLibraryServiceConfig(
       credentialDescriptorDigest: sha256(credentialBytes),
       configFile,
       cloudState,
+      ...(driveCredentialStore === undefined ? {} : { driveCredentialStore }),
       bindings: {
         executable: sidecar.bound,
         dataRoot,
@@ -698,6 +810,12 @@ export async function bindLibraryServiceConfig(
           admission,
           credentialDescriptor,
           ...(cloudState === null ? [] : [cloudState]),
+          ...(driveCredentialStore === undefined
+            ? []
+            : [
+                driveCredentialStore.directory,
+                driveCredentialStore.wrappingKey,
+              ]),
         ]);
       },
     };

--- a/packages/library-service/src/contracts.ts
+++ b/packages/library-service/src/contracts.ts
@@ -105,6 +105,12 @@ export interface LibraryServiceGoogleDriveConfig {
   installationWitness: string;
   credentialRecordId: string;
   publicationStateFile: string;
+  credentialStore?: {
+    backend: "linux-sealed-file-v1";
+    directory: string;
+    wrappingKeyFile: string;
+    wrappingKeyDigest: string;
+  };
 }
 
 export interface LibraryServiceCredentialDescriptor {
@@ -262,7 +268,11 @@ export interface LibraryServiceProcessPort {
 }
 
 export type LibraryServicePhase =
-  "starting" | "running" | "stopping" | "stopped" | "failed";
+  | "starting"
+  | "running"
+  | "stopping"
+  | "stopped"
+  | "failed";
 
 export interface LibraryServiceStatusRecord {
   schemaVersion: typeof LIBRARY_SERVICE_STATUS_SCHEMA_VERSION;

--- a/packages/library-service/src/linux-drive-consent.test.ts
+++ b/packages/library-service/src/linux-drive-consent.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from "vitest";
+import { createLinuxDriveConsentPresenter } from "./linux-drive-consent.js";
+
+function consentUrl() {
+  return (
+    "https://accounts.google.com/o/oauth2/v2/auth?" +
+    new URLSearchParams({
+      client_id: "synthetic-client",
+      redirect_uri: "http://127.0.0.1:43127/callback",
+      response_type: "code",
+      scope: "synthetic-scope",
+      include_granted_scopes: "true",
+      code_challenge: "synthetic-challenge",
+      code_challenge_method: "S256",
+      access_type: "offline",
+      prompt: "consent",
+      state: "synthetic-state",
+    }).toString()
+  );
+}
+
+describe("Linux terminal PKCE consent", () => {
+  it("shows bounded consent and loopback forwarding instructions on a TTY", async () => {
+    const write = vi.fn();
+    await createLinuxDriveConsentPresenter({ isTTY: true, write })(
+      consentUrl(),
+    );
+    expect(write).toHaveBeenCalledOnce();
+    expect(write.mock.calls[0]![0]).toContain("127.0.0.1:43127");
+    expect(write.mock.calls[0]![0]).toContain(consentUrl());
+  });
+  it.each([false, undefined])(
+    "does not leak the consent URL into redirected output %s",
+    async (isTTY) => {
+      const write = vi.fn();
+      await expect(
+        createLinuxDriveConsentPresenter({ isTTY, write })(consentUrl()),
+      ).rejects.toThrow("drive_auth_failed");
+      expect(write).not.toHaveBeenCalled();
+    },
+  );
+  it("rejects other origins, non-loopback callbacks, duplicate fields and token parameters", async () => {
+    const write = vi.fn();
+    const present = createLinuxDriveConsentPresenter({ isTTY: true, write });
+    for (const url of [
+      consentUrl().replace("accounts.google.com", "example.invalid"),
+      consentUrl().replace("127.0.0.1", "example.invalid"),
+      `${consentUrl()}&state=duplicate`,
+      `${consentUrl()}&access_token=synthetic-secret`,
+      "x".repeat(8_193),
+      "invalid",
+    ]) {
+      await expect(present(url)).rejects.toThrow("drive_auth_failed");
+    }
+    expect(write).not.toHaveBeenCalled();
+  });
+});

--- a/packages/library-service/src/linux-drive-consent.ts
+++ b/packages/library-service/src/linux-drive-consent.ts
@@ -1,0 +1,72 @@
+import { LibraryServiceFailure } from "./contracts.js";
+
+/** Show PKCE consent only on the invoking operator's interactive terminal. */
+export function createLinuxDriveConsentPresenter(output: {
+  readonly isTTY?: boolean;
+  write(text: string): unknown;
+}): (authorizationUrl: string) => Promise<void> {
+  return async (authorizationUrl) => {
+    if (
+      output.isTTY !== true ||
+      Buffer.byteLength(authorizationUrl, "utf8") > 8_192
+    ) {
+      throw new LibraryServiceFailure("drive_auth_failed");
+    }
+    let url: URL;
+    let redirect: URL;
+    try {
+      url = new URL(authorizationUrl);
+      redirect = new URL(url.searchParams.get("redirect_uri") ?? "");
+    } catch {
+      throw new LibraryServiceFailure("drive_auth_failed");
+    }
+    if (
+      url.origin !== "https://accounts.google.com" ||
+      url.pathname !== "/o/oauth2/v2/auth" ||
+      url.username !== "" ||
+      url.password !== "" ||
+      url.hash !== "" ||
+      redirect.protocol !== "http:" ||
+      redirect.hostname !== "127.0.0.1" ||
+      redirect.port === "" ||
+      redirect.pathname !== "/callback" ||
+      redirect.username !== "" ||
+      redirect.password !== "" ||
+      redirect.search !== "" ||
+      redirect.hash !== "" ||
+      url.searchParams.get("response_type") !== "code" ||
+      url.searchParams.get("code_challenge_method") !== "S256" ||
+      !url.searchParams.get("code_challenge") ||
+      !url.searchParams.get("state")
+    ) {
+      throw new LibraryServiceFailure("drive_auth_failed");
+    }
+    const allowed = new Set([
+      "client_id",
+      "redirect_uri",
+      "response_type",
+      "scope",
+      "include_granted_scopes",
+      "code_challenge",
+      "code_challenge_method",
+      "access_type",
+      "prompt",
+      "state",
+    ]);
+    const keys = [...url.searchParams.keys()];
+    if (
+      keys.length !== allowed.size ||
+      new Set(keys).size !== keys.length ||
+      keys.some((key) => !allowed.has(key))
+    ) {
+      throw new LibraryServiceFailure("drive_auth_failed");
+    }
+    // stderr preserves the CLI's single final JSON report on stdout. A pipe or
+    // redirected log never receives the temporary consent URL.
+    output.write(
+      `Google Drive consent requires a browser. Open the URL below on this host.\n` +
+        `For a remote host, first forward local port ${redirect.port} to 127.0.0.1:${redirect.port} on this host, then open the URL locally.\n` +
+        `This consent attempt expires after five minutes.\n${url.href}\n`,
+    );
+  };
+}

--- a/packages/library-service/src/linux-drive-credential-store.test.ts
+++ b/packages/library-service/src/linux-drive-credential-store.test.ts
@@ -11,6 +11,7 @@ import {
   writeFile,
 } from "node:fs/promises";
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
@@ -61,6 +62,60 @@ async function fixture() {
 }
 
 describe("Linux descriptor-bound Drive credential files", () => {
+  linuxIt.each(["before-rename", "after-rename"] as const)(
+    "reopens a complete credential after writer termination %s",
+    async (boundary) => {
+      const { root, keyPath, store } = await fixture();
+      await store.persistCredential("drive-1", "synthetic-old");
+      // Execute the compiled implementation in another process so SIGKILL
+      // bypasses every catch/finally. ACL checkpoints bracket atomic rename:
+      // the second temporary inspection follows file fsync, and the second
+      // target inspection follows rename and directory fsync. This proves
+      // process-crash recovery, not power-loss durability of the host disk.
+      const child = spawnSync(
+        process.execPath,
+        [
+          "--input-type=module",
+          "-e",
+          `
+        import { createNodeLibraryServicePorts } from ${JSON.stringify(new URL("../dist/node-ports.js", import.meta.url).href)};
+        import { createLinuxDriveCredentialStore } from ${JSON.stringify(new URL("../dist/linux-drive-credential-store.js", import.meta.url).href)};
+        const fs = createNodeLibraryServicePorts().fileSystem;
+        const directory = await fs.openBoundPath(${JSON.stringify(root)});
+        const wrappingKey = await fs.openBoundPath(${JSON.stringify(keyPath)});
+        let temporaryChecks = 0;
+        let targetChecks = 0;
+        const store = createLinuxDriveCredentialStore({
+          directory, wrappingKey, wrappingKeyDigest: await wrappingKey.sha256(),
+          aclProof: { async assertNoExtendedAcl(targets) {
+            for (const target of targets) {
+              if (target.path.endsWith('.tmp')) temporaryChecks += 1;
+              if (target.path.endsWith('/drive-1.sealed.json')) targetChecks += 1;
+            }
+            if ((${JSON.stringify(boundary)} === 'before-rename' && temporaryChecks === 2) ||
+                (${JSON.stringify(boundary)} === 'after-rename' && targetChecks === 2)) {
+              process.kill(process.pid, 'SIGKILL');
+              await new Promise(() => {});
+            }
+          } }
+        });
+        await store.persistCredential('drive-1', 'synthetic-new');
+        process.exit(90);
+      `,
+        ],
+        { timeout: 5000, encoding: "utf8", maxBuffer: 4096 },
+      );
+      expect(child.error).toBeUndefined();
+      expect(child.stderr).toBe("");
+      expect(child.signal).toBe("SIGKILL");
+      expect(await store.readCredential("drive-1")).toBe(
+        boundary === "before-rename" ? "synthetic-old" : "synthetic-new",
+      );
+      await store.persistCredential("drive-1", "synthetic-recovered");
+      expect(await store.readCredential("drive-1")).toBe("synthetic-recovered");
+    },
+  );
+
   linuxIt.each(["replace", "remove"] as const)(
     "invalidates cached tokens after record %s and recovers only with a new token port",
     async (change) => {

--- a/packages/library-service/src/linux-drive-credential-store.test.ts
+++ b/packages/library-service/src/linux-drive-credential-store.test.ts
@@ -1,0 +1,191 @@
+import {
+  chmod,
+  lstat,
+  mkdtemp,
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { createNodeLibraryServicePorts } from "./node-ports.js";
+import { createLinuxDriveCredentialStore } from "./linux-drive-credential-store.js";
+import { createNodeGoogleDriveTokenPortV1 } from "./node-google-drive-token.js";
+import type { LibraryServiceBoundPath } from "./contracts.js";
+
+const linuxIt = process.platform === "linux" ? it : it.skip;
+const cleanup: (() => Promise<void>)[] = [];
+afterEach(async () => {
+  for (const close of cleanup.splice(0).reverse()) await close();
+});
+
+async function fixture() {
+  const parent = await mkdtemp(path.join(tmpdir(), "freed-linux-oauth-"));
+  cleanup.push(() => rm(parent, { recursive: true, force: true }));
+  await chmod(parent, 0o700);
+  const root = path.join(parent, "records");
+  await mkdir(root, { mode: 0o700 });
+  const keyPath = path.join(parent, "wrapping-key");
+  const key = new Uint8Array(32).fill(23);
+  await writeFile(keyPath, key, { mode: 0o600 });
+  const fileSystem = createNodeLibraryServicePorts().fileSystem;
+  const directory = await fileSystem.openBoundPath(root);
+  const wrappingKey = await fileSystem.openBoundPath(keyPath);
+  cleanup.push(
+    () => wrappingKey.close(),
+    () => directory.close(),
+  );
+  const store = createLinuxDriveCredentialStore({
+    directory,
+    wrappingKey,
+    wrappingKeyDigest: createHash("sha256").update(key).digest("hex"),
+    // Filesystem tests exercise real descriptors. Extended ACL admission is
+    // separately covered by the production ACL port's platform tests.
+    aclProof: {
+      async assertNoExtendedAcl(targets) {
+        for (const target of targets) {
+          const stat = await lstat(target.path, { bigint: true });
+          expect(String(stat.dev)).toBe(target.device);
+          expect(String(stat.ino)).toBe(target.inode);
+        }
+      },
+    },
+  });
+  return { root, keyPath, store, directory };
+}
+
+describe("Linux descriptor-bound Drive credential files", () => {
+  linuxIt.each(["replace", "remove"] as const)(
+    "invalidates cached tokens after record %s and recovers only with a new token port",
+    async (change) => {
+      const { root, store } = await fixture();
+      const credential = JSON.stringify({
+        schemaVersion: 1,
+        refreshToken: "synthetic-refresh",
+      });
+      await store.persistCredential("drive-1", credential);
+      let requests = 0;
+      const dependencies = {
+        platform: "linux" as const,
+        readCredential: store.readCredential,
+        credentialRevision: store.credentialRevision,
+        fetch: (async () => {
+          requests += 1;
+          return new Response(
+            JSON.stringify({
+              access_token: "synthetic-access",
+              expires_in: 3600,
+            }),
+          );
+        }) as typeof fetch,
+      };
+      const token = createNodeGoogleDriveTokenPortV1("drive-1", dependencies);
+      const signal = new AbortController().signal;
+      expect(await token.accessToken(signal)).toBe("synthetic-access");
+      expect(await token.accessToken(signal)).toBe("synthetic-access");
+      expect(requests).toBe(1);
+      if (change === "replace")
+        await store.persistCredential("drive-1", credential);
+      else await rm(path.join(root, "drive-1.sealed.json"));
+      await expect(token.accessToken(signal)).rejects.toThrow(
+        "drive_credential_unavailable",
+      );
+      expect(requests).toBe(1);
+      if (change === "remove")
+        await store.persistCredential("drive-1", credential);
+      await expect(token.accessToken(signal)).rejects.toThrow(
+        "drive_credential_unavailable",
+      );
+      const restarted = createNodeGoogleDriveTokenPortV1(
+        "drive-1",
+        dependencies,
+      );
+      expect(await restarted.accessToken(signal)).toBe("synthetic-access");
+      expect(requests).toBe(2);
+    },
+  );
+
+  linuxIt(
+    "atomically creates and replaces a private sealed record",
+    async () => {
+      const { root, store } = await fixture();
+      await store.persistCredential("drive-1", "synthetic-first");
+      const target = path.join(root, "drive-1.sealed.json");
+      const first = await lstat(target);
+      expect(first.mode & 0o7777).toBe(0o600);
+      expect(first.nlink).toBe(1);
+      expect(await readFile(target, "utf8")).not.toContain("synthetic-first");
+      expect(await store.readCredential("drive-1")).toBe("synthetic-first");
+      await store.persistCredential("drive-1", "synthetic-second");
+      expect((await lstat(target)).ino).not.toBe(first.ino);
+      expect(await store.readCredential("drive-1")).toBe("synthetic-second");
+      expect(
+        (await readdir(root)).filter((name) => name.endsWith(".tmp")),
+      ).toEqual([]);
+    },
+  );
+
+  linuxIt(
+    "preserves corrupt existing data and refuses links or nonprivate files",
+    async () => {
+      const { root, store } = await fixture();
+      const target = path.join(root, "drive-1.sealed.json");
+      await writeFile(target, "corrupt fixture", { mode: 0o600 });
+      await expect(
+        store.persistCredential("drive-1", "replacement"),
+      ).rejects.toThrow("drive_credential_unavailable");
+      expect(await readFile(target, "utf8")).toBe("corrupt fixture");
+      await rm(target);
+      const other = path.join(root, "other");
+      await writeFile(other, "untouched", { mode: 0o600 });
+      await symlink(other, target);
+      await expect(
+        store.persistCredential("drive-1", "replacement"),
+      ).rejects.toThrow("drive_credential_unavailable");
+      expect(await readFile(other, "utf8")).toBe("untouched");
+      await rm(target);
+      await store.persistCredential("drive-1", "synthetic");
+      await chmod(target, 0o644);
+      await expect(store.readCredential("drive-1")).rejects.toThrow(
+        "drive_credential_unavailable",
+      );
+    },
+  );
+
+  linuxIt(
+    "fences key content changes and a renamed bound directory",
+    async () => {
+      const { root, keyPath, store } = await fixture();
+      await store.persistCredential("drive-1", "synthetic");
+      await writeFile(keyPath, new Uint8Array(32).fill(24));
+      await expect(store.readCredential("drive-1")).rejects.toThrow(
+        "drive_credential_unavailable",
+      );
+      await writeFile(keyPath, new Uint8Array(32).fill(23));
+      const moved = `${root}-moved`;
+      await rename(root, moved);
+      cleanup.unshift(() => rm(moved, { recursive: true, force: true }));
+      await expect(
+        store.persistCredential("drive-1", "replacement"),
+      ).rejects.toThrow("drive_credential_unavailable");
+    },
+  );
+
+  if (process.platform !== "linux")
+    it("does not claim a Linux store on another platform", () => {
+      expect(() =>
+        createLinuxDriveCredentialStore({
+          directory: {} as LibraryServiceBoundPath,
+          wrappingKey: {} as LibraryServiceBoundPath,
+          wrappingKeyDigest: "0".repeat(64),
+          aclProof: { assertNoExtendedAcl: async () => undefined },
+        }),
+      ).toThrow("unsupported_secret_store_or_acl_backend");
+    });
+});

--- a/packages/library-service/src/linux-drive-credential-store.test.ts
+++ b/packages/library-service/src/linux-drive-credential-store.test.ts
@@ -3,6 +3,7 @@ import {
   lstat,
   mkdtemp,
   mkdir,
+  open,
   readFile,
   readdir,
   rename,
@@ -172,10 +173,15 @@ describe("Linux descriptor-bound Drive credential files", () => {
       const { root, store } = await fixture();
       await store.persistCredential("drive-1", "synthetic-first");
       const target = path.join(root, "drive-1.sealed.json");
-      const first = await lstat(target);
-      expect(first.mode & 0o7777).toBe(0o600);
-      expect(first.nlink).toBe(1);
-      expect(await readFile(target, "utf8")).not.toContain("synthetic-first");
+      const handle = await open(target, "r");
+      const first = await handle.stat();
+      try {
+        expect(first.mode & 0o7777).toBe(0o600);
+        expect(first.nlink).toBe(1);
+        expect(await handle.readFile("utf8")).not.toContain("synthetic-first");
+      } finally {
+        await handle.close();
+      }
       expect(await store.readCredential("drive-1")).toBe("synthetic-first");
       await store.persistCredential("drive-1", "synthetic-second");
       expect((await lstat(target)).ino).not.toBe(first.ino);

--- a/packages/library-service/src/linux-drive-credential-store.ts
+++ b/packages/library-service/src/linux-drive-credential-store.ts
@@ -1,0 +1,257 @@
+import { constants } from "node:fs";
+import { open, rename, unlink } from "node:fs/promises";
+import type { FileHandle } from "node:fs/promises";
+import type { BigIntStats } from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+import {
+  LibraryServiceFailure,
+  type LibraryServiceBoundPath,
+  type LibraryServiceAclProofPort,
+} from "./contracts.js";
+import {
+  openLinuxDriveCredential,
+  sealLinuxDriveCredential,
+} from "./linux-drive-sealed-record.js";
+
+const MAX_RECORD_BYTES = 24_576;
+const READ_FLAGS =
+  constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK;
+const RECORD_ABSENT = Symbol("record absent at open");
+
+export interface LinuxDriveCredentialStoreInput {
+  readonly directory: LibraryServiceBoundPath;
+  readonly wrappingKey: LibraryServiceBoundPath;
+  readonly wrappingKeyDigest: string;
+  readonly aclProof: LibraryServiceAclProofPort;
+}
+
+function unavailable(): never {
+  throw new LibraryServiceFailure("drive_credential_unavailable");
+}
+
+function privateFile(stats: BigIntStats, owner: number): void {
+  if (
+    !stats.isFile() ||
+    stats.uid !== BigInt(owner) ||
+    (stats.mode & 0o7777n) !== 0o600n ||
+    stats.nlink !== 1n
+  )
+    unavailable();
+}
+
+function unchanged(before: BigIntStats, after: BigIntStats): void {
+  for (const key of [
+    "dev",
+    "ino",
+    "uid",
+    "mode",
+    "nlink",
+    "size",
+    "mtimeNs",
+    "ctimeNs",
+  ] as const) {
+    if (before[key] !== after[key]) unavailable();
+  }
+}
+
+/** Bind Linux OAuth records to verified directory and mounted-key descriptors. */
+export function createLinuxDriveCredentialStore(
+  input: LinuxDriveCredentialStoreInput,
+) {
+  if (process.platform !== "linux")
+    throw new LibraryServiceFailure("unsupported_secret_store_or_acl_backend");
+  const owner = process.getuid?.();
+  if (owner === undefined || !/^[a-f0-9]{64}$/u.test(input.wrappingKeyDigest))
+    unavailable();
+  const root = input.directory;
+  const keyFile = input.wrappingKey;
+  const keyRelative = path.relative(root.path, keyFile.path);
+  if (
+    keyRelative === "" ||
+    (!path.isAbsolute(keyRelative) &&
+      keyRelative !== ".." &&
+      !keyRelative.startsWith(`..${path.sep}`))
+  )
+    unavailable();
+  if (
+    root.metadata.kind !== "directory" ||
+    root.metadata.uid !== owner ||
+    (root.metadata.mode & 0o7777) !== 0o700 ||
+    keyFile.metadata.kind !== "file" ||
+    keyFile.metadata.uid !== owner ||
+    (keyFile.metadata.mode & 0o7777) !== 0o600 ||
+    keyFile.metadata.links !== 1 ||
+    keyFile.metadata.size !== 32
+  )
+    unavailable();
+  const descriptorRoot = `/proc/self/fd/${root.descriptor}`;
+
+  const assertBound = async () => {
+    for (const bound of [root, keyFile]) {
+      await bound.assertStable();
+      await bound.assertPathStable();
+      await bound.assertCanonicalPath();
+    }
+    await input.aclProof.assertNoExtendedAcl(
+      [root, keyFile].map((bound) => ({
+        path: bound.path,
+        device: bound.metadata.device,
+        inode: bound.metadata.inode,
+      })),
+    );
+    if ((await keyFile.sha256()) !== input.wrappingKeyDigest) unavailable();
+  };
+  const recordName = (recordId: string) => {
+    if (!/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(recordId)) unavailable();
+    return `${recordId}.sealed.json`;
+  };
+  const readKey = async () => {
+    await assertBound();
+    const bytes = await keyFile.readBoundedBytes(32);
+    if (
+      bytes.byteLength !== 32 ||
+      createHash("sha256").update(bytes).digest("hex") !==
+        input.wrappingKeyDigest
+    ) {
+      bytes.fill(0);
+      unavailable();
+    }
+    return bytes;
+  };
+  const inspectHandle = async (handle: FileHandle, name: string) => {
+    const before = await handle.stat({ bigint: true });
+    privateFile(before, owner);
+    await input.aclProof.assertNoExtendedAcl([
+      {
+        path: path.join(root.path, name),
+        device: String(before.dev),
+        inode: String(before.ino),
+      },
+    ]);
+    unchanged(before, await handle.stat({ bigint: true }));
+    return before;
+  };
+  const readRecord = async (name: string): Promise<Uint8Array> => {
+    const handle = await open(`${descriptorRoot}/${name}`, READ_FLAGS).catch(
+      (error: unknown) => {
+        if (
+          error instanceof Error &&
+          "code" in error &&
+          error.code === "ENOENT"
+        )
+          throw RECORD_ABSENT;
+        throw error;
+      },
+    );
+    try {
+      const before = await inspectHandle(handle, name);
+      if (before.size < 1n || before.size > BigInt(MAX_RECORD_BYTES))
+        unavailable();
+      const buffer = Buffer.alloc(MAX_RECORD_BYTES + 1);
+      let count = 0;
+      while (count < buffer.byteLength) {
+        const { bytesRead } = await handle.read(
+          buffer,
+          count,
+          buffer.byteLength - count,
+          count,
+        );
+        if (bytesRead === 0) break;
+        count += bytesRead;
+      }
+      if (count !== Number(before.size)) unavailable();
+      unchanged(before, await handle.stat({ bigint: true }));
+      await assertBound();
+      return buffer.subarray(0, count);
+    } finally {
+      await handle.close();
+    }
+  };
+
+  const readState = async (recordId: string) => {
+    let key: Uint8Array | undefined;
+    try {
+      const name = recordName(recordId);
+      key = await readKey();
+      const sealed = await readRecord(name);
+      const credential = openLinuxDriveCredential(recordId, sealed, key);
+      await assertBound();
+      return {
+        credential,
+        revision: createHash("sha256").update(sealed).digest("hex"),
+      };
+    } catch {
+      return unavailable();
+    } finally {
+      key?.fill(0);
+    }
+  };
+  return Object.freeze({
+    async readCredential(recordId: string): Promise<string> {
+      return (await readState(recordId)).credential;
+    },
+    async credentialRevision(recordId: string): Promise<string> {
+      return (await readState(recordId)).revision;
+    },
+    async persistCredential(
+      recordId: string,
+      credential: string,
+    ): Promise<void> {
+      let key: Uint8Array | undefined;
+      let temporary: string | undefined;
+      try {
+        const name = recordName(recordId);
+        key = await readKey();
+        // Refuse to overwrite an ambiguous existing record. Only ENOENT permits
+        // first creation; corrupt, nonprivate or substituted files stay intact.
+        try {
+          openLinuxDriveCredential(recordId, await readRecord(name), key);
+        } catch (error) {
+          if (error !== RECORD_ABSENT) throw error;
+        }
+        const sealed = sealLinuxDriveCredential(recordId, credential, key);
+        temporary = `.drive-${randomUUID()}.tmp`;
+        const handle = await open(
+          `${descriptorRoot}/${temporary}`,
+          constants.O_WRONLY |
+            constants.O_CREAT |
+            constants.O_EXCL |
+            constants.O_NOFOLLOW,
+          0o600,
+        );
+        try {
+          await inspectHandle(handle, temporary);
+          await handle.writeFile(sealed);
+          await handle.sync();
+          await inspectHandle(handle, temporary);
+        } finally {
+          await handle.close();
+        }
+        await assertBound();
+        await rename(
+          `${descriptorRoot}/${temporary}`,
+          `${descriptorRoot}/${name}`,
+        );
+        temporary = undefined;
+        const directory = await open(
+          descriptorRoot,
+          constants.O_RDONLY | constants.O_DIRECTORY,
+        );
+        try {
+          await directory.sync();
+        } finally {
+          await directory.close();
+        }
+        const stored = await readRecord(name);
+        if (!Buffer.from(stored).equals(sealed)) unavailable();
+      } catch {
+        return unavailable();
+      } finally {
+        key?.fill(0);
+        if (temporary !== undefined)
+          await unlink(`${descriptorRoot}/${temporary}`).catch(() => undefined);
+      }
+    },
+  });
+}

--- a/packages/library-service/src/linux-drive-sealed-record.test.ts
+++ b/packages/library-service/src/linux-drive-sealed-record.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import {
+  openLinuxDriveCredential,
+  sealLinuxDriveCredential,
+} from "./linux-drive-sealed-record.js";
+
+const key = new Uint8Array(32).fill(17);
+const secret = JSON.stringify({
+  schemaVersion: 1,
+  refreshToken: "synthetic-only-token",
+});
+const encode = (value: unknown) =>
+  new TextEncoder().encode(JSON.stringify(value));
+
+describe("Linux Drive sealed record", () => {
+  it("round trips bounded Unicode credentials without plaintext in the record", () => {
+    const plaintext = `${secret} café`;
+    const first = sealLinuxDriveCredential("drive-1", plaintext, key);
+    const second = sealLinuxDriveCredential("drive-1", plaintext, key);
+    expect(first).not.toEqual(second);
+    expect(new TextDecoder().decode(first)).not.toContain(
+      "synthetic-only-token",
+    );
+    expect(openLinuxDriveCredential("drive-1", first, key)).toBe(plaintext);
+    expect(key).toEqual(new Uint8Array(32).fill(17));
+  });
+
+  it("authenticates record identity even when the clear identity is relabeled", () => {
+    const record = JSON.parse(
+      new TextDecoder().decode(
+        sealLinuxDriveCredential("drive-1", secret, key),
+      ),
+    );
+    record.recordId = "drive-2";
+    expect(() =>
+      openLinuxDriveCredential("drive-2", encode(record), key),
+    ).toThrow("drive_credential_unavailable");
+  });
+
+  it.each(["nonce", "tag", "ciphertext"])(
+    "rejects changed %s without releasing plaintext",
+    (field) => {
+      const record = JSON.parse(
+        new TextDecoder().decode(
+          sealLinuxDriveCredential("drive-1", secret, key),
+        ),
+      );
+      const bytes = Buffer.from(record[field], "base64");
+      bytes[0] = bytes[0]! ^ 1;
+      record[field] = bytes.toString("base64");
+      expect(() =>
+        openLinuxDriveCredential("drive-1", encode(record), key),
+      ).toThrow("drive_credential_unavailable");
+    },
+  );
+
+  it("rejects wrong keys, future formats and noncanonical encoded fields", () => {
+    const sealed = sealLinuxDriveCredential("drive-1", secret, key);
+    expect(() =>
+      openLinuxDriveCredential("drive-1", sealed, new Uint8Array(32)),
+    ).toThrow("drive_credential_unavailable");
+    const record = JSON.parse(new TextDecoder().decode(sealed));
+    for (const patch of [
+      { schemaVersion: 2 },
+      { format: "unknown" },
+      { extra: true },
+      { nonce: `${record.nonce}\n` },
+      { tag: "" },
+      { ciphertext: "" },
+    ]) {
+      expect(() =>
+        openLinuxDriveCredential(
+          "drive-1",
+          encode({ ...record, ...patch }),
+          key,
+        ),
+      ).toThrow("drive_credential_unavailable");
+    }
+  });
+
+  it("enforces byte bounds and refuses malformed UTF-8 and identifiers", () => {
+    const maximum = "x".repeat(16_384);
+    expect(
+      openLinuxDriveCredential(
+        "drive-1",
+        sealLinuxDriveCredential("drive-1", maximum, key),
+        key,
+      ),
+    ).toBe(maximum);
+    for (const plaintext of ["", `${maximum}x`, "é".repeat(8_193), "\ud800"]) {
+      expect(() => sealLinuxDriveCredential("drive-1", plaintext, key)).toThrow(
+        "drive_credential_unavailable",
+      );
+    }
+    expect(() => sealLinuxDriveCredential("../drive", secret, key)).toThrow(
+      "drive_credential_unavailable",
+    );
+    expect(() =>
+      sealLinuxDriveCredential("drive-1", secret, new Uint8Array(31)),
+    ).toThrow("drive_credential_unavailable");
+    for (const bytes of [
+      new Uint8Array(),
+      new Uint8Array(24_577),
+      new Uint8Array([255]),
+    ]) {
+      expect(() => openLinuxDriveCredential("drive-1", bytes, key)).toThrow(
+        "drive_credential_unavailable",
+      );
+    }
+  });
+});

--- a/packages/library-service/src/linux-drive-sealed-record.ts
+++ b/packages/library-service/src/linux-drive-sealed-record.ts
@@ -1,0 +1,130 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "node:crypto";
+import { LibraryServiceFailure } from "./contracts.js";
+
+const FORMAT = "freed_google_drive_sealed_credential_v1";
+const MAX_PLAINTEXT_BYTES = 16_384;
+const MAX_RECORD_BYTES = 24_576;
+const RECORD_KEYS = "ciphertext,format,nonce,recordId,schemaVersion,tag";
+
+function refuse(): never {
+  // Never forward crypto/parser errors, which can contain record material.
+  throw new LibraryServiceFailure("drive_credential_unavailable");
+}
+
+function identity(recordId: string, wrappingKey: Uint8Array): Buffer {
+  if (
+    !/^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/u.test(recordId) ||
+    !(wrappingKey instanceof Uint8Array) ||
+    wrappingKey.byteLength !== 32
+  )
+    refuse();
+  return Buffer.from(`${FORMAT}\0${recordId}`, "utf8");
+}
+
+function exactBase64(value: unknown, minimum: number, maximum: number): Buffer {
+  if (typeof value !== "string" || value.length > Math.ceil(maximum / 3) * 4)
+    refuse();
+  const bytes = Buffer.from(value, "base64");
+  if (
+    bytes.length < minimum ||
+    bytes.length > maximum ||
+    bytes.toString("base64") !== value
+  )
+    refuse();
+  return bytes;
+}
+
+/** Seal one bounded OAuth record, binding its identity to the authentication tag. */
+export function sealLinuxDriveCredential(
+  recordId: string,
+  credential: string,
+  wrappingKey: Uint8Array,
+): Uint8Array {
+  const aad = identity(recordId, wrappingKey);
+  if (
+    typeof credential !== "string" ||
+    credential.length === 0 ||
+    Buffer.byteLength(credential, "utf8") > MAX_PLAINTEXT_BYTES
+  )
+    refuse();
+  const plaintext = Buffer.from(credential, "utf8");
+  try {
+    if (plaintext.toString("utf8") !== credential) refuse();
+    const nonce = randomBytes(12);
+    const cipher = createCipheriv("aes-256-gcm", wrappingKey, nonce, {
+      authTagLength: 16,
+    });
+    cipher.setAAD(aad);
+    const ciphertext = Buffer.concat([
+      cipher.update(plaintext),
+      cipher.final(),
+    ]);
+    return Buffer.from(
+      JSON.stringify({
+        ciphertext: ciphertext.toString("base64"),
+        format: FORMAT,
+        nonce: nonce.toString("base64"),
+        recordId,
+        schemaVersion: 1,
+        tag: cipher.getAuthTag().toString("base64"),
+      }),
+      "utf8",
+    );
+  } catch {
+    return refuse();
+  } finally {
+    plaintext.fill(0);
+  }
+}
+
+/** Authenticate a sealed record before returning any plaintext to the caller. */
+export function openLinuxDriveCredential(
+  recordId: string,
+  sealed: Uint8Array,
+  wrappingKey: Uint8Array,
+): string {
+  const aad = identity(recordId, wrappingKey);
+  if (
+    !(sealed instanceof Uint8Array) ||
+    sealed.byteLength === 0 ||
+    sealed.byteLength > MAX_RECORD_BYTES
+  )
+    refuse();
+  let pending: Buffer | undefined;
+  let plaintext: Buffer | undefined;
+  try {
+    const record: unknown = JSON.parse(
+      new TextDecoder("utf-8", { fatal: true }).decode(sealed),
+    );
+    if (
+      record === null ||
+      typeof record !== "object" ||
+      Array.isArray(record) ||
+      Object.keys(record).sort().join(",") !== RECORD_KEYS
+    )
+      refuse();
+    const value = record as Record<string, unknown>;
+    if (
+      value.format !== FORMAT ||
+      value.schemaVersion !== 1 ||
+      value.recordId !== recordId
+    )
+      refuse();
+    const nonce = exactBase64(value.nonce, 12, 12);
+    const tag = exactBase64(value.tag, 16, 16);
+    const ciphertext = exactBase64(value.ciphertext, 1, MAX_PLAINTEXT_BYTES);
+    const decipher = createDecipheriv("aes-256-gcm", wrappingKey, nonce, {
+      authTagLength: 16,
+    });
+    decipher.setAAD(aad);
+    decipher.setAuthTag(tag);
+    pending = decipher.update(ciphertext);
+    plaintext = Buffer.concat([pending, decipher.final()]);
+    return new TextDecoder("utf-8", { fatal: true }).decode(plaintext);
+  } catch {
+    return refuse();
+  } finally {
+    pending?.fill(0);
+    plaintext?.fill(0);
+  }
+}

--- a/packages/library-service/src/node-google-drive-auth.test.ts
+++ b/packages/library-service/src/node-google-drive-auth.test.ts
@@ -1,71 +1,81 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { authorizeNodeGoogleDriveV1 } from "./node-google-drive-auth.js";
+import { createLinuxDriveConsentPresenter } from "./linux-drive-consent.js";
 
 describe("headless Google Drive PKCE authorization", () => {
-  it("requests only Library Core Drive scopes and stores only the refresh token", async () => {
-    let authorizationUrl: URL | null = null;
-    let persisted = "";
-    const proxyFetch = vi.fn(
-      async (_input: RequestInfo | URL, init?: RequestInit) => {
-        const body = JSON.parse(String(init?.body));
-        expect(body.code).toBe("authorization-code");
-        expect(body.verifier).toMatch(/^[A-Za-z0-9_-]+$/u);
-        expect(body.redirectUri).toMatch(
-          /^http:\/\/127\.0\.0\.1:\d+\/callback$/u,
-        );
-        return new Response(
-          JSON.stringify({
-            access_token: "short-lived-access-token",
-            refresh_token: "refresh-secret",
-            expires_in: 3_600,
-          }),
-          { status: 200, headers: { "Content-Type": "application/json" } },
-        );
-      },
-    );
+  it.each(["darwin", "linux"] as const)(
+    "requests only Drive scopes and stores only the refresh token on %s",
+    async (platform) => {
+      let authorizationUrl: URL | null = null;
+      let persisted = "";
+      const proxyFetch = vi.fn(
+        async (_input: RequestInfo | URL, init?: RequestInit) => {
+          const body = JSON.parse(String(init?.body));
+          expect(body.code).toBe("authorization-code");
+          expect(body.verifier).toMatch(/^[A-Za-z0-9_-]+$/u);
+          expect(body.redirectUri).toMatch(
+            /^http:\/\/127\.0\.0\.1:\d+\/callback$/u,
+          );
+          return new Response(
+            JSON.stringify({
+              access_token: "short-lived-access-token",
+              refresh_token: "refresh-secret",
+              expires_in: 3_600,
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        },
+      );
 
-    const receipt = await authorizeNodeGoogleDriveV1("library-drive", {
-      platform: "darwin",
-      fetch: proxyFetch,
-      async openAuthorizationUrl(url) {
-        authorizationUrl = new URL(url);
-        const callback = new URL(
-          authorizationUrl.searchParams.get("redirect_uri")!,
-        );
-        callback.searchParams.set("code", "authorization-code");
-        callback.searchParams.set(
-          "state",
-          authorizationUrl.searchParams.get("state")!,
-        );
-        setImmediate(() => void fetch(callback));
-      },
-      async persistCredential(_recordId, credential) {
-        persisted = credential;
-      },
-    });
+      const receipt = await authorizeNodeGoogleDriveV1("library-drive", {
+        platform,
+        fetch: proxyFetch,
+        async openAuthorizationUrl(url) {
+          if (platform === "linux") {
+            await createLinuxDriveConsentPresenter({
+              isTTY: true,
+              write: () => undefined,
+            })(url);
+          }
+          authorizationUrl = new URL(url);
+          const callback = new URL(
+            authorizationUrl.searchParams.get("redirect_uri")!,
+          );
+          callback.searchParams.set("code", "authorization-code");
+          callback.searchParams.set(
+            "state",
+            authorizationUrl.searchParams.get("state")!,
+          );
+          setImmediate(() => void fetch(callback));
+        },
+        async persistCredential(_recordId, credential) {
+          persisted = credential;
+        },
+      });
 
-    expect(authorizationUrl).not.toBeNull();
-    const scopes = authorizationUrl!.searchParams.get("scope")!.split(" ");
-    expect(scopes).toEqual([
-      "https://www.googleapis.com/auth/drive.appdata",
-      "https://www.googleapis.com/auth/drive.file",
-    ]);
-    expect(scopes).not.toContain(
-      "https://www.googleapis.com/auth/contacts.readonly",
-    );
-    expect(JSON.parse(persisted)).toEqual({
-      schemaVersion: 1,
-      refreshToken: "refresh-secret",
-    });
-    expect(persisted).not.toContain("short-lived-access-token");
-    expect(receipt).toEqual({
-      schemaVersion: 1,
-      provider: "google-drive",
-      credentialRecordId: "library-drive",
-      scopes,
-    });
-  });
+      expect(authorizationUrl).not.toBeNull();
+      const scopes = authorizationUrl!.searchParams.get("scope")!.split(" ");
+      expect(scopes).toEqual([
+        "https://www.googleapis.com/auth/drive.appdata",
+        "https://www.googleapis.com/auth/drive.file",
+      ]);
+      expect(scopes).not.toContain(
+        "https://www.googleapis.com/auth/contacts.readonly",
+      );
+      expect(JSON.parse(persisted)).toEqual({
+        schemaVersion: 1,
+        refreshToken: "refresh-secret",
+      });
+      expect(persisted).not.toContain("short-lived-access-token");
+      expect(receipt).toEqual({
+        schemaVersion: 1,
+        provider: "google-drive",
+        credentialRecordId: "library-drive",
+        scopes,
+      });
+    },
+  );
 
   it("rejects a callback with the wrong state before token exchange", async () => {
     const proxyFetch = vi.fn();

--- a/packages/library-service/src/node-google-drive-token.test.ts
+++ b/packages/library-service/src/node-google-drive-token.test.ts
@@ -3,6 +3,72 @@ import { describe, expect, it, vi } from "vitest";
 import { createNodeGoogleDriveTokenPortV1 } from "./node-google-drive-token.js";
 
 describe("headless Google Drive token custody", () => {
+  it("fences cached tokens permanently after the sealed record revision changes", async () => {
+    let revision = "a".repeat(64);
+    const fetcher = vi.fn(async () =>
+      Response.json({ access_token: "synthetic-access", expires_in: 3_600 }),
+    );
+    const token = createNodeGoogleDriveTokenPortV1("library-record", {
+      platform: "linux",
+      credentialRevision: async () => revision,
+      readCredential: async () =>
+        JSON.stringify({ schemaVersion: 1, refreshToken: "synthetic-refresh" }),
+      fetch: fetcher,
+    });
+    await expect(token.accessToken(new AbortController().signal)).resolves.toBe(
+      "synthetic-access",
+    );
+    revision = "b".repeat(64);
+    await expect(
+      token.accessToken(new AbortController().signal),
+    ).rejects.toThrow("drive_credential_unavailable");
+    revision = "a".repeat(64);
+    await expect(
+      token.accessToken(new AbortController().signal),
+    ).rejects.toThrow("drive_credential_unavailable");
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not make a refresh request after cancellation during credential reading", async () => {
+    const controller = new AbortController();
+    const fetcher = vi.fn();
+    const token = createNodeGoogleDriveTokenPortV1("library-record", {
+      platform: "linux",
+      fetch: fetcher,
+      readCredential: async () => {
+        controller.abort();
+        return JSON.stringify({
+          schemaVersion: 1,
+          refreshToken: "synthetic-refresh",
+        });
+      },
+    });
+    await expect(token.accessToken(controller.signal)).rejects.toThrow(
+      "startup_cancelled",
+    );
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it("refuses a refresh response when custody changes during the request", async () => {
+    let revision = "a".repeat(64);
+    const token = createNodeGoogleDriveTokenPortV1("library-record", {
+      platform: "linux",
+      credentialRevision: async () => revision,
+      readCredential: async () =>
+        JSON.stringify({ schemaVersion: 1, refreshToken: "synthetic-refresh" }),
+      fetch: async () => {
+        revision = "b".repeat(64);
+        return Response.json({
+          access_token: "must-not-be-returned",
+          expires_in: 3_600,
+        });
+      },
+    });
+    await expect(
+      token.accessToken(new AbortController().signal),
+    ).rejects.toThrow("drive_credential_unavailable");
+  });
+
   it("reads one refresh token from the platform boundary and caches only the access token", async () => {
     let nowMs = 1_000;
     const readCredential = vi.fn(async () =>

--- a/packages/library-service/src/node-google-drive-token.ts
+++ b/packages/library-service/src/node-google-drive-token.ts
@@ -28,6 +28,7 @@ export interface NodeGoogleDriveTokenDependenciesV1 {
   readonly platform?: NodeJS.Platform;
   readonly nowMs?: () => number;
   readonly readCredential?: (recordId: string) => Promise<string>;
+  readonly credentialRevision?: (recordId: string) => Promise<string>;
   readonly fetch?: typeof fetch;
 }
 
@@ -122,9 +123,34 @@ export function createNodeGoogleDriveTokenPortV1(
     readonly expiresAt: number;
   } | null = null;
   let pending: Promise<string> | null = null;
+  let pinnedRevision: string | null = null;
+  let credentialInvalidated = false;
+  const assertCredential = async (signal: AbortSignal) => {
+    if (signal.aborted) throw new LibraryServiceFailure("startup_cancelled");
+    if (credentialInvalidated)
+      throw new LibraryServiceFailure("drive_credential_unavailable");
+    if (dependencies.credentialRevision !== undefined) {
+      try {
+        const revision = await dependencies.credentialRevision(recordId);
+        if (
+          !/^[a-f0-9]{64}$/u.test(revision) ||
+          (pinnedRevision !== null && revision !== pinnedRevision)
+        ) {
+          throw new Error("credential revision changed");
+        }
+        pinnedRevision = revision;
+      } catch {
+        cached = null;
+        credentialInvalidated = true;
+        throw new LibraryServiceFailure("drive_credential_unavailable");
+      }
+    }
+    if (signal.aborted) throw new LibraryServiceFailure("startup_cancelled");
+  };
 
   return Object.freeze({
     async accessToken(signal: AbortSignal): Promise<string> {
+      await assertCredential(signal);
       const currentTime = now();
       if (
         cached !== null &&
@@ -140,6 +166,7 @@ export function createNodeGoogleDriveTokenPortV1(
         const credential = parseStoredCredential(
           await readCredential(recordId),
         );
+        await assertCredential(signal);
         let response: Response;
         try {
           response = await googleFetch(TOKEN_PROXY_URL, {
@@ -164,6 +191,7 @@ export function createNodeGoogleDriveTokenPortV1(
         } catch {
           throw new LibraryServiceFailure("drive_auth_failed");
         }
+        await assertCredential(signal);
         cached = parseAccessToken(payload, now());
         return cached.accessToken;
       })().finally(() => {

--- a/packages/library-service/src/primary-cloud-runtime.ts
+++ b/packages/library-service/src/primary-cloud-runtime.ts
@@ -27,6 +27,10 @@ export interface LibraryServicePrimaryCloudPortV1 {
     readonly fileSystem: LibraryServiceFileSystemPort;
     readonly clock: LibraryServiceClockPort;
     readonly native: LibraryCoreNativeCommandClientV1;
+    readonly credentialStore?: {
+      readCredential(recordId: string): Promise<string>;
+      credentialRevision?(recordId: string): Promise<string>;
+    };
   }): Promise<LibraryServicePrimaryRuntimeV1<{ readonly status: string }>>;
 }
 
@@ -51,6 +55,12 @@ export function createNodeLibraryServicePrimaryCloudPortV1(
         ),
         token: createNodeGoogleDriveTokenPortV1(
           input.config.credentialRecordId,
+          input.credentialStore === undefined
+            ? {}
+            : {
+                readCredential: input.credentialStore.readCredential,
+                credentialRevision: input.credentialStore.credentialRevision,
+              },
         ),
       });
       const normalizedPrimary =

--- a/packages/library-service/src/supervisor.ts
+++ b/packages/library-service/src/supervisor.ts
@@ -36,6 +36,7 @@ import {
   type LibraryCoreNativeCommandClientV1,
 } from "./native-command.js";
 import { createLibraryServiceNormalizedPrimaryNativeRuntimeV2 } from "./normalized-primary-native-runtime.js";
+import { createBoundDriveCredentialStore } from "./bound-drive-credential-store.js";
 import {
   createLibraryServiceLocalActorProcessorV1,
   type LibraryServiceLocalActorIngressPortV1,
@@ -281,6 +282,7 @@ export class LibraryServiceSupervisor {
   #statusTail: Promise<void> = Promise.resolve();
   #localActor: LibraryServiceLocalActorListenerV1 | null = null;
   #cloudState: LibraryServiceBoundPath | null = null;
+  #driveCredentialBindings: readonly LibraryServiceBoundPath[] = [];
   #primaryRuntime: LibraryServicePrimaryRuntimeV1<{
     readonly status: string;
   }> | null = null;
@@ -365,13 +367,18 @@ export class LibraryServiceSupervisor {
     const stateRoot = this.#stateRoot;
     const statusFile = this.#statusFile;
     const cloudState = this.#cloudState;
+    const driveCredentialBindings = this.#driveCredentialBindings;
     this.#stateRoot = null;
     this.#statusFile = null;
     this.#cloudState = null;
+    this.#driveCredentialBindings = [];
     await Promise.all([
       stateRoot?.close().catch(() => undefined),
       statusFile?.close().catch(() => undefined),
       cloudState?.close().catch(() => undefined),
+      ...driveCredentialBindings.map((bound) =>
+        bound.close().catch(() => undefined),
+      ),
     ]);
   }
 
@@ -573,6 +580,13 @@ export class LibraryServiceSupervisor {
       this.#config = bound.config;
       this.#stateRoot = bound.bindings.stateRoot;
       this.#cloudState = bound.cloudState;
+      this.#driveCredentialBindings =
+        bound.driveCredentialStore === undefined
+          ? []
+          : [
+              bound.driveCredentialStore.directory,
+              bound.driveCredentialStore.wrappingKey,
+            ];
       this.#startedAt = new Date(this.#clock.nowMs()).toISOString();
       throwIfAborted(signal);
       const statusBindingPromise = bindLibraryServiceStatusFile(
@@ -759,6 +773,10 @@ export class LibraryServiceSupervisor {
             fileSystem: this.#fileSystem,
             clock: this.#clock,
             native: commandClient,
+            credentialStore: createBoundDriveCredentialStore(
+              bound,
+              this.#aclProof,
+            ),
           });
         } catch (error) {
           throw toFailure(error, "cloud_runtime_failed");
@@ -847,6 +865,7 @@ export class LibraryServiceSupervisor {
           await bound.close().catch(() => undefined);
           this.#stateRoot = null;
           this.#cloudState = null;
+          this.#driveCredentialBindings = [];
           await this.#statusFile?.close().catch(() => undefined);
           this.#statusFile = null;
         }


### PR DESCRIPTION
(AI Generated).

## Summary

Implements explicit, admission-bound Linux Google Drive credential custody using AES-256-GCM sealed records, private descriptor-bound files and a mounted wrapping key. Authorization and refresh share the production store. Terminal consent preserves the existing Drive-only PKCE protocol.

Credential replacement, removal or invalidation fences cached token reuse until a new service instance starts. Corrupt records remain intact. No Library schema, epoch or native signing-key change.

## Validation

- Changed-path feature validation passed, including root typechecks, service tests and roadmap checks.
- Real Linux ARM64, Node 24.14.1, unprivileged Docker user: 162 passed, 8 platform skips; build and typechecks passed.
- SIGKILL at two deterministic boundaries, after temporary-file fsync before rename and after rename plus directory fsync, preserves a complete old or new credential. A subsequent write succeeds. This is process-crash evidence, not physical power-loss simulation.
- Initial head 0445e25a also passed Ubuntu x86_64 feature CI, including all five Linux filesystem tests before the two crash cases were added. Exact successor-head CI remains required.
- Real file replacement/removal tests prove cached-token refusal without another synthetic provider request and recovery with a new token port.
- macOS service suite: 163 passed, 6 platform skips.
- On source fe023767, an offline ARM64 container ran the compiled CLI as UID 1000 against a root-owned, single-link sidecar with production filesystem and ACL ports. Doctor, service-definition generation, startup, normalized SQLite creation and SIGTERM shutdown passed. A matching cloud-store configuration passed doctor and sealed-record persistence/readback through the production bound-store factory. Networking was disabled. No substituted ownership or ACL ports were used for this probe.

## Merge hold and remaining proof

Draft pending installed 26.9.501 acceptance. Keep issue #1816 open: installed Linux service lifecycle and exact successor-head x86_64 proof remain incomplete. Container tests do not establish real Google authentication or installed-service acceptance. PR #1815 carries the separate default inbound transport work; reconcile both before headless end-to-end acceptance.

The offline compiled-CLI probe does not prove systemd activation, real OAuth consent/refresh, cloud publication, or follower reconciliation. Those remain explicit acceptance gaps. Production source is unchanged by the temporary probe, which was removed from the worktree.

Local integration commit 039f66db combines PR 1815 head 13470483 and this PR head fe023767 without a remote merge. It passed 183 native tests, 168 service tests, 118 sync tests and the same unprivileged, network-disabled production-port CLI probe. Only Phase 11 prose conflicted; the runtime composition combined cleanly. This is combined-source evidence, not evidence that either PR has landed or completed live acceptance.

Strict doctor reports missing automation kernel guard provisioning. No automation activation occurred. This draft uses the supported ordinary authenticated publication path.
