### PR TITLE
fix: expose Linux actor socket outside private tmp

### DIFF
--- a/docs/PHASE-11-OPENCLAW.md
+++ b/docs/PHASE-11-OPENCLAW.md
@@ -450,6 +450,13 @@ supervisor proves the state root around socket creation, refuses foreign path
 replacement, removes only its exact owned socket, and fences the Primary if
 the listener fails.
 
+Linux long-path endpoints now use a verified private systemd runtime directory
+outside the unit's private `/tmp` namespace. Directory descriptors remain held
+through socket cleanup. Synthetic Linux tests prove external-process
+reachability, ownership and ACL refusal, and cleanup after directory replacement
+without deleting the replacement path. Actual systemd user-service activation
+remains an installed acceptance requirement; these tests do not establish it.
+
 Windows remains fail closed. Task 11.14 supplies the service-account named
 pipe and proves its ACL before the shared protocol processor can accept a
 request. Signature verification does not replace those transport controls.

--- a/docs/library-core-contract/runtime-ownership.md
+++ b/docs/library-core-contract/runtime-ownership.md
@@ -108,8 +108,13 @@ On macOS and Linux, the service binds an owner-only mode `0600` Unix socket.
 It proves the descriptor-bound state root before and after binding, validates
 socket ownership and identity, removes only an owned private stale socket, and
 never replaces a foreign path. A state root whose path exceeds the Unix socket
-limit uses a stable owner-specific endpoint under `/tmp`, derived from the
-canonical state-root identity and protected by the same ownership checks.
+limit uses a stable owner-specific endpoint derived from the canonical
+state-root identity. macOS uses `/tmp`. Linux uses the systemd-created mode
+`0700` directory `/run/user/<uid>/freed-library-<state-root-hash>`, so
+`PrivateTmp=true` does not hide the endpoint from external actors. Linux
+holds verified directory descriptors through listener shutdown and performs
+socket creation and cleanup through the runtime directory descriptor. Missing,
+foreign, writable-by-others, or extended-ACL runtime directories fail closed.
 Shutdown closes every connection and removes only the exact socket inode it
 created. Listener failure fences the Primary and kills the native sidecar.
 The private service status record reports the active endpoint while the

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -58,6 +58,7 @@
     {
       "id": 11,
       "status": "current",
+      "reviewedAt": "2026-09-06",
       "source": "docs/PHASE-11-OPENCLAW.md"
     },
     {

--- a/packages/library-service/README.md
+++ b/packages/library-service/README.md
@@ -30,6 +30,13 @@ bounded restart policy, and no shell. The command does not write, install,
 load, enable, or start the definition. Windows fails closed until its native
 service-account handle and named-pipe ACL contract is implemented.
 
+The Linux unit also creates a private mode `0700` runtime directory beneath
+`/run/user/<uid>`. Long state-root paths use its `actor.sock` endpoint, outside
+the service's private `/tmp` namespace. A manually launched Linux service with
+a long state-root path requires the same directory to exist with verified
+ownership and permissions. The service fails closed instead of falling back
+to a socket that external actors cannot reach.
+
 ## Configuration schema version 1
 
 The configuration is exact-shape JSON. Its physical file must be owned by the
@@ -226,6 +233,7 @@ child output, or credential values.
 On successful startup the native sidecar holds the data-root lease before it
 opens SQLite, constructs the reusable staged checkpoint, status, and closed
 backup authority, writes exactly one secret-free ready record, closes stdout,
-and waits on fd8. This slice adds no socket or public listener. SQLite, WAL,
+and waits on fd8. The supervisor exposes only the private local actor socket,
+not a public listener. SQLite, WAL,
 SHM, rollback journals, and backups stay beneath the descriptor-bound data
 root and never enter service state or transport.

--- a/packages/library-service/src/local-actor-node-server.ts
+++ b/packages/library-service/src/local-actor-node-server.ts
@@ -3,7 +3,12 @@ import { createHash } from "node:crypto";
 import net, { type Server, type Socket } from "node:net";
 import path from "node:path";
 
-import type { LibraryServiceBoundPath } from "./contracts.js";
+import type {
+  LibraryServiceBoundPath,
+  LibraryServiceFileSystemPort,
+  LibraryServiceAclProofPort,
+} from "./contracts.js";
+import { bindLocalActorRuntimeDirectory } from "./local-actor-runtime-directory.js";
 import {
   LIBRARY_CORE_LOCAL_ACTOR_MAXIMUM_ACTIVE_CONNECTIONS,
   LIBRARY_CORE_LOCAL_ACTOR_MAXIMUM_REQUEST_FRAME_BYTES,
@@ -148,7 +153,10 @@ async function listen(server: Server, endpoint: string): Promise<void> {
   });
 }
 
-export function createNodeLibraryServiceLocalActorIngressPortV1(): LibraryServiceLocalActorIngressPortV1 {
+export function createNodeLibraryServiceLocalActorIngressPortV1(dependencies?: {
+  fileSystem: LibraryServiceFileSystemPort;
+  aclProof: LibraryServiceAclProofPort;
+}): LibraryServiceLocalActorIngressPortV1 {
   return Object.freeze({
     async start(input: {
       readonly stateRoot: LibraryServiceBoundPath;
@@ -162,8 +170,28 @@ export function createNodeLibraryServiceLocalActorIngressPortV1(): LibraryServic
       await stateRoot.assertStable();
       await stateRoot.assertPathStable();
       await stateRoot.assertCanonicalPath();
-      const endpoint = socketEndpoint(stateRoot.path, expectedUserId);
-      await removeOwnedSocket(endpoint, expectedUserId);
+      const needsRuntimeDirectory =
+        process.platform === "linux" &&
+        Buffer.byteLength(path.join(stateRoot.path, SOCKET_FILE), "utf8") >
+          UNIX_SOCKET_PATH_MAXIMUM_BYTES;
+      if (needsRuntimeDirectory && dependencies === undefined)
+        throw new Error("local_actor_runtime_directory_unavailable");
+      const runtime = needsRuntimeDirectory
+        ? await bindLocalActorRuntimeDirectory({
+            stateRootPath: stateRoot.path,
+            userId: expectedUserId,
+            ...dependencies!,
+          })
+        : undefined;
+      const endpoint =
+        runtime?.endpoint ?? socketEndpoint(stateRoot.path, expectedUserId);
+      const boundEndpoint = runtime?.descriptorEndpoint ?? endpoint;
+      try {
+        await removeOwnedSocket(boundEndpoint, expectedUserId);
+      } catch (error) {
+        await runtime?.close();
+        throw error;
+      }
 
       let activeConnections = 0;
       const sockets = new Set<Socket>();
@@ -190,9 +218,9 @@ export function createNodeLibraryServiceLocalActorIngressPortV1(): LibraryServic
         | { readonly device: bigint; readonly inode: bigint }
         | undefined;
       try {
-        await listen(server, endpoint);
-        await chmod(endpoint, 0o600);
-        const metadata = await lstat(endpoint, { bigint: true });
+        await listen(server, boundEndpoint);
+        await chmod(boundEndpoint, 0o600);
+        const metadata = await lstat(boundEndpoint, { bigint: true });
         if (
           !metadata.isSocket() ||
           Number(metadata.uid) !== expectedUserId ||
@@ -201,10 +229,11 @@ export function createNodeLibraryServiceLocalActorIngressPortV1(): LibraryServic
         ) {
           throw new Error("local_actor_socket_not_private");
         }
+        createdIdentity = { device: metadata.dev, inode: metadata.ino };
+        await runtime?.assertStable();
         await stateRoot.assertStable();
         await stateRoot.assertPathStable();
         await stateRoot.assertCanonicalPath();
-        createdIdentity = { device: metadata.dev, inode: metadata.ino };
         const identity = createdIdentity;
         let stopping = false;
         let stopPromise: Promise<void> | null = null;
@@ -227,11 +256,15 @@ export function createNodeLibraryServiceLocalActorIngressPortV1(): LibraryServic
               await new Promise<void>((resolve) =>
                 server.close(() => resolve()),
               );
-              await removeOwnedSocket(
-                endpoint,
-                expectedUserId,
-                identity,
-              );
+              try {
+                await removeOwnedSocket(
+                  boundEndpoint,
+                  expectedUserId,
+                  identity,
+                );
+              } finally {
+                await runtime?.close();
+              }
             })();
             return stopPromise;
           },
@@ -243,11 +276,12 @@ export function createNodeLibraryServiceLocalActorIngressPortV1(): LibraryServic
         ).catch(() => undefined);
         if (createdIdentity !== undefined) {
           await removeOwnedSocket(
-            endpoint,
+            boundEndpoint,
             expectedUserId,
             createdIdentity,
           ).catch(() => undefined);
         }
+        await runtime?.close().catch(() => undefined);
         throw error;
       }
     },

--- a/packages/library-service/src/local-actor-runtime-directory.test.ts
+++ b/packages/library-service/src/local-actor-runtime-directory.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+import {
+  bindLocalActorRuntimeDirectory,
+  localActorRuntimeDirectoryName,
+} from "./local-actor-runtime-directory.js";
+import { createLibraryServiceDefinitionV1 } from "./service-definition.js";
+import { FakeAclProof, FakeFileSystem } from "./testing/fakes.js";
+
+const stateRootPath = `/home/freed/${"long-state-root-".repeat(10)}`;
+function fixture() {
+  const fileSystem = new FakeFileSystem();
+  const aclProof = new FakeAclProof();
+  const runtime = `/run/user/1000/${localActorRuntimeDirectoryName(stateRootPath)}`;
+  for (const root of ["/run", "/run/user"])
+    fileSystem.addDirectory(root, 0, 0o755);
+  for (const root of ["/run/user/1000", runtime])
+    fileSystem.addDirectory(root, 1000, 0o700);
+  return { runtime, fileSystem, aclProof, stateRootPath, userId: 1000 };
+}
+
+describe("private Linux actor runtime directory", () => {
+  it("shares the systemd directory identity and holds descriptors until close", async () => {
+    const input = fixture();
+    const bound = await bindLocalActorRuntimeDirectory(input);
+    expect(bound.endpoint).toBe(`${input.runtime}/actor.sock`);
+    expect(Buffer.byteLength(bound.endpoint)).toBeLessThanOrEqual(103);
+    expect(bound.descriptorEndpoint).toBe("/proc/self/fd/103/actor.sock");
+    expect(input.fileSystem.opened.every((value) => !value.closed)).toBe(true);
+    const definition = createLibraryServiceDefinitionV1({
+      platform: "linux",
+      nodeExecutable: "/opt/freed/node",
+      cliExecutable: "/opt/freed/service.js",
+      configPath: "/home/freed/config.json",
+      dataRoot: "/home/freed/data",
+      stateRoot: stateRootPath,
+    });
+    expect(definition.contents).toContain(
+      `RuntimeDirectory=${localActorRuntimeDirectoryName(stateRootPath)}\nRuntimeDirectoryMode=0700`,
+    );
+    expect(definition.contents).toContain("PrivateTmp=true");
+    expect(definition.contents).not.toContain("ReadWritePaths=/tmp");
+    await bound.close();
+    await bound.close();
+    await expect(bound.assertStable()).rejects.toThrow(
+      "local_actor_runtime_directory_closed",
+    );
+    expect(input.fileSystem.opened.every((value) => value.closed)).toBe(true);
+  });
+
+  it.each(["missing", "owner", "mode", "ancestor", "acl"])(
+    "refuses %s and closes every acquired descriptor",
+    async (fault) => {
+      const input = fixture();
+      if (fault === "missing") input.fileSystem.metadata.delete(input.runtime);
+      if (fault === "owner")
+        input.fileSystem.addDirectory(input.runtime, 1001, 0o700);
+      if (fault === "mode")
+        input.fileSystem.addDirectory(input.runtime, 1000, 0o755);
+      if (fault === "ancestor")
+        input.fileSystem.addDirectory("/run/user", 0, 0o777);
+      if (fault === "acl") input.aclProof.failure = new Error("acl_present");
+      await expect(bindLocalActorRuntimeDirectory(input)).rejects.toThrow();
+      expect(input.fileSystem.opened.every((value) => value.closed)).toBe(true);
+    },
+  );
+});

--- a/packages/library-service/src/local-actor-runtime-directory.ts
+++ b/packages/library-service/src/local-actor-runtime-directory.ts
@@ -1,0 +1,77 @@
+import { createHash } from "node:crypto";
+import type {
+  LibraryServiceAclProofPort,
+  LibraryServiceBoundPath,
+  LibraryServiceFileSystemPort,
+} from "./contracts.js";
+
+/** Match the systemd-created runtime directory to one canonical state root. */
+export function localActorRuntimeDirectoryName(stateRootPath: string): string {
+  return `freed-library-${createHash("sha256").update(stateRootPath, "utf8").digest("hex").slice(0, 24)}`;
+}
+
+/** Keep the externally visible Linux endpoint beneath verified open directories. */
+export async function bindLocalActorRuntimeDirectory(input: {
+  stateRootPath: string;
+  userId: number;
+  fileSystem: LibraryServiceFileSystemPort;
+  aclProof: LibraryServiceAclProofPort;
+}) {
+  if (
+    !Number.isSafeInteger(input.userId) ||
+    input.userId < 0 ||
+    input.userId > 0xffff_ffff
+  )
+    throw new Error("local_actor_runtime_directory_invalid");
+  const userRoot = `/run/user/${input.userId}`;
+  const runtimePath = `${userRoot}/${localActorRuntimeDirectoryName(input.stateRootPath)}`;
+  const bindings: LibraryServiceBoundPath[] = [];
+  const close = async () => {
+    await Promise.all(bindings.splice(0).map((bound) => bound.close()));
+  };
+  const assertStable = async () => {
+    if (bindings.length !== 4)
+      throw new Error("local_actor_runtime_directory_closed");
+    for (const bound of bindings) {
+      await bound.assertStable();
+      await bound.assertPathStable();
+      await bound.assertCanonicalPath();
+    }
+    await input.aclProof.assertNoExtendedAcl(
+      bindings.map((bound) => ({
+        path: bound.path,
+        device: bound.metadata.device,
+        inode: bound.metadata.inode,
+      })),
+    );
+  };
+  try {
+    for (const directory of ["/run", "/run/user", userRoot, runtimePath]) {
+      const bound = await input.fileSystem.openBoundPath(directory);
+      bindings.push(bound);
+      const privateDirectory =
+        directory === userRoot || directory === runtimePath;
+      const metadata = bound.metadata;
+      if (
+        metadata.kind !== "directory" ||
+        metadata.uid !== (privateDirectory ? input.userId : 0) ||
+        (privateDirectory
+          ? (metadata.mode & 0o7777) !== 0o700
+          : (metadata.mode & 0o7022) !== 0)
+      ) {
+        throw new Error("local_actor_runtime_directory_invalid");
+      }
+    }
+    await assertStable();
+    const directory = bindings[bindings.length - 1]!;
+    return Object.freeze({
+      endpoint: `${runtimePath}/actor.sock`,
+      descriptorEndpoint: `/proc/self/fd/${directory.descriptor}/actor.sock`,
+      assertStable,
+      close,
+    });
+  } catch (error) {
+    await close().catch(() => undefined);
+    throw error;
+  }
+}

--- a/packages/library-service/src/node-ports.ts
+++ b/packages/library-service/src/node-ports.ts
@@ -964,18 +964,23 @@ export function createNodeLibraryServicePorts(
 ): NodeLibraryServicePorts {
   const fileSystem = new NodeLibraryServiceFileSystem();
   const clock = new NodeLibraryServiceClock();
+  const aclProof = new NodeLibraryServiceAclProof(fileSystem);
   return {
     fileSystem,
     identity: new NodeLibraryServiceIdentity(),
-    aclProof: new NodeLibraryServiceAclProof(fileSystem),
+    aclProof,
     clock,
     entropy: new NodeLibraryServiceEntropy(),
     process: new NodeLibraryServiceProcess(clock, options.spawnChild ?? spawn),
-    localActorIngress: createNodeLibraryServiceLocalActorIngressPortV1(),
+    localActorIngress: createNodeLibraryServiceLocalActorIngressPortV1({
+      fileSystem,
+      aclProof,
+    }),
     primaryCloud: {
       async start(input) {
-        const { createNodeLibraryServicePrimaryCloudPortV1 } =
-          await import("./primary-cloud-runtime.js");
+        const { createNodeLibraryServicePrimaryCloudPortV1 } = await import(
+          "./primary-cloud-runtime.js"
+        );
         return createNodeLibraryServicePrimaryCloudPortV1().start(input);
       },
     },

--- a/packages/library-service/src/service-definition.ts
+++ b/packages/library-service/src/service-definition.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { localActorRuntimeDirectoryName } from "./local-actor-runtime-directory.js";
 
 export const LIBRARY_SERVICE_DEFINITION_SCHEMA_VERSION = 1 as const;
 export const LIBRARY_SERVICE_LAUNCHD_LABEL = "wtf.freed.library" as const;
@@ -144,6 +145,8 @@ function systemdDefinition(input: {
     "UMask=0077",
     "NoNewPrivileges=true",
     "PrivateTmp=true",
+    `RuntimeDirectory=${localActorRuntimeDirectoryName(input.stateRoot)}`,
+    "RuntimeDirectoryMode=0700",
     "PrivateDevices=true",
     "ProtectSystem=strict",
     "ProtectHome=read-only",
@@ -168,10 +171,7 @@ export function createLibraryServiceDefinitionV1(
     throw new TypeError("service definition platform is unsupported");
   }
   const exact = {
-    nodeExecutable: exactAbsolutePath(
-      input.nodeExecutable,
-      "Node executable",
-    ),
+    nodeExecutable: exactAbsolutePath(input.nodeExecutable, "Node executable"),
     cliExecutable: exactAbsolutePath(input.cliExecutable, "CLI executable"),
     configPath: exactAbsolutePath(input.configPath, "config path"),
     dataRoot: exactAbsolutePath(input.dataRoot, "data root"),
@@ -187,9 +187,7 @@ export function createLibraryServiceDefinitionV1(
     role: "primary",
     platform: input.platform,
     format:
-      input.platform === "darwin"
-        ? "launchd-plist-v1"
-        : "systemd-user-unit-v1",
+      input.platform === "darwin" ? "launchd-plist-v1" : "systemd-user-unit-v1",
     fileName:
       input.platform === "darwin"
         ? `${LIBRARY_SERVICE_LAUNCHD_LABEL}.plist`


### PR DESCRIPTION
(AI Generated).

## Summary

Fixes the source-level namespace conflict tracked by #1818. Long Linux state-root paths previously selected a socket under /tmp while the generated user unit isolated /tmp with PrivateTmp=true.

Keep PrivateTmp and existing hardening. Generate a state-root-specific RuntimeDirectory with mode 0700. Bind long-path sockets through verified, held runtime-directory descriptors and report the externally reachable canonical endpoint. Reject missing, foreign, unsafe-mode or extended-ACL directories. Cleanup removes only the owned socket and preserves replacement paths.

## Validation

- Full local feature gate passed on commit 7079002bafa5f3c09a84d9952c0de22b8c803e4c, including 144 service tests and one skip, repository typechecks, activation manifest, release activation and roadmap checks.
- Linux ARM64 focused suite: 137 passed, eight skipped; typechecks passed.
- Network-disabled Linux container, unprivileged UID 1000, production filesystem and ACL ports: a separate client process reached the long-path endpoint. Descriptor-pinned cleanup survived runtime-directory replacement and preserved the replacement file.
- Production callers verified for both new exports. No schema or storage-epoch transition, provider traffic, or cadence change.
- Debian systemd 252.39: system and user-mode unit verification passed without warnings. The actual user-manager test plan loaded the unit with PrivateTmp=yes, ProtectSystem=strict and the expected private RuntimeDirectory. A bounded startup attempt correctly refused this non-systemd-booted container, so actual activation remains unverified.

## Acceptance still required

Actual systemd user-service activation is not established by the container probe. Its request handler was synthetic, not native signed admission. Keep #1818 open until installed service proof exists. This draft does not merge or replace the current installed Desktop acceptance candidate.

The host automation guard cutover remains unprovisioned. No automation was activated; ordinary authenticated publication is used.
