### PR TITLE
fix: preserve valid provider capture media pairs

### DIFF
--- a/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
+++ b/docs/PHASE-12-ADDITIONAL-PLATFORMS.md
@@ -2,6 +2,11 @@
 
 > **Status:** 🚧 In Progress: LinkedIn and YouTube are integrated, and authenticated Substack and Medium capture is available in beta with local sessions, visible roster and activity extraction, provider health controls, and connection-only identity ingestion
 
+LinkedIn normalization keeps media types aligned with existing URLs, including
+video posts whose media URL was unavailable during extraction. Article link
+previews remain intact. Closed capture-payload regressions protect this local
+projection; they do not substitute for installed LinkedIn extraction proof.
+
 > **Library and media target:** Every captured record enters the exhaustive
 > Library Core mutation registry and normalized SQLite schema. Large media does
 > not enter checkpoint rows. Synced metadata carries typed content descriptors

--- a/docs/PHASE-2-CAPTURE-SKILLS.md
+++ b/docs/PHASE-2-CAPTURE-SKILLS.md
@@ -9,6 +9,10 @@
 
 First capture layers for X/Twitter and RSS feeds, with OpenClaw skill wrappers for CLI access.
 
+X normalization pairs each media URL with its type before Library capture.
+Link cards remain in `linkPreview`; unavailable video variants add neither a
+URL nor a type. Existing URL selection and provider requests are unchanged.
+
 ---
 
 ## Packages Delivered

--- a/docs/PHASE-5-DESKTOP.md
+++ b/docs/PHASE-5-DESKTOP.md
@@ -9,6 +9,12 @@ timeouts remain responsible for the final result. The native Drive observer
 allows the renderer's two-hour maximum publication budget plus one minute to
 report its terminal result. Social-provider observation stays at ten minutes.
 
+Capture normalization keeps media URLs and types positionally paired before
+the closed Library mutation validator runs. Synthetic Desktop regressions
+cover X link cards and unavailable video variants, LinkedIn and Facebook video
+markers without media, and Instagram's existing empty-media guard. This does
+not relax native persistence validation or change provider cadence.
+
 > **Architecture:** Freed Desktop is a bounded SQLite client and a host
 > for the shared native Library Core. Every view calls a named typed query.
 > Every durable product edit calls a registered mutation. React retains only

--- a/docs/PHASE-7-SOCIAL-CAPTURE.md
+++ b/docs/PHASE-7-SOCIAL-CAPTURE.md
@@ -7,6 +7,12 @@
 
 ## Overview
 
+Facebook normalization emits a video type only for an existing first media
+URL. An unavailable video URL therefore leaves both media arrays empty, and
+duplicate URLs retain their original positional types. Instagram already
+preserves the same empty-media invariant. Both paths are checked against the
+closed Library capture payload without changing extraction or provider timing.
+
 DOM scraping for Facebook and Instagram feeds uses Tauri's native WebView (WKWebView on macOS). Instead of Playwright, posts are captured by injecting extraction scripts into the same WebView that handles authentication. The scheduler does not claim this traffic is indistinguishable from a person.
 
 **Note:** DOM scraping is inherently fragile. These platforms actively fight scrapers and frequently change their DOM structure. This is lower priority than X + RSS.

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -9,6 +9,7 @@
     {
       "id": 2,
       "status": "complete",
+      "reviewedAt": "2026-09-06",
       "source": "docs/PHASE-2-CAPTURE-SKILLS.md"
     },
     {
@@ -63,6 +64,7 @@
     {
       "id": 12,
       "status": "current",
+      "reviewedAt": "2026-09-06",
       "source": "docs/PHASE-12-ADDITIONAL-PLATFORMS.md"
     },
     {

--- a/packages/capture-facebook/src/normalize.ts
+++ b/packages/capture-facebook/src/normalize.ts
@@ -49,17 +49,16 @@ function buildAuthor(post: RawFbPost): Author {
 // =============================================================================
 
 function buildContent(post: RawFbPost): Content {
-  const mediaTypes = post.mediaUrls.map((url): "image" | "video" => {
-    if (post.hasVideo && post.mediaUrls.indexOf(url) === 0) return "video";
+  // A video marker without an extracted URL must not create an orphan type.
+  const mediaTypes = post.mediaUrls.map((_, index): "image" | "video" => {
+    if (post.hasVideo && index === 0) return "video";
     return "image";
   });
 
   return {
     ...(post.text ? { text: post.text } : {}),
     mediaUrls: post.mediaUrls,
-    mediaTypes: post.hasVideo
-      ? ["video", ...mediaTypes.slice(1)]
-      : mediaTypes,
+    mediaTypes,
   };
 }
 

--- a/packages/capture-linkedin/src/normalize.ts
+++ b/packages/capture-linkedin/src/normalize.ts
@@ -28,16 +28,15 @@ function buildAuthor(post: RawLiPost): Author {
 // =============================================================================
 
 function buildContent(post: RawLiPost): Content {
-  const mediaTypes = post.mediaUrls.map((url): "image" | "video" => {
-    if (post.hasVideo && post.mediaUrls.indexOf(url) === 0) return "video";
+  // A video marker without an extracted URL must not create an orphan type.
+  const mediaTypes = post.mediaUrls.map((_, index): "image" | "video" => {
+    if (post.hasVideo && index === 0) return "video";
     return "image";
   });
 
   const content: Content = {
     mediaUrls: post.mediaUrls,
-    mediaTypes: post.hasVideo
-      ? ["video", ...mediaTypes.slice(1)]
-      : mediaTypes,
+    mediaTypes,
   };
 
   if (post.text) {

--- a/packages/capture-x/src/normalize.ts
+++ b/packages/capture-x/src/normalize.ts
@@ -18,11 +18,9 @@ import type {
 // Media Extraction
 // =============================================================================
 
-/**
- * Extract media URLs from a tweet
- */
-export function extractMediaUrls(tweet: XTweetResult): string[] {
-  const urls: string[] = [];
+/** Keep each media classification attached to the URL that actually exists. */
+function extractMedia(tweet: XTweetResult): { url: string; type: MediaType }[] {
+  const entries: { url: string; type: MediaType }[] = [];
 
   // Check extended_entities first (has full media info)
   const media =
@@ -32,7 +30,7 @@ export function extractMediaUrls(tweet: XTweetResult): string[] {
     for (const item of media) {
       if (item.type === "photo") {
         // Get highest quality image
-        urls.push(item.media_url_https + ":large");
+        entries.push({ url: item.media_url_https + ":large", type: "image" });
       } else if (item.type === "video" || item.type === "animated_gif") {
         // Get highest bitrate video variant
         if (item.video_info?.variants) {
@@ -41,46 +39,29 @@ export function extractMediaUrls(tweet: XTweetResult): string[] {
             .sort((a, b) => (b.bitrate || 0) - (a.bitrate || 0));
 
           if (mp4Variants.length > 0) {
-            urls.push(mp4Variants[0].url);
+            entries.push({ url: mp4Variants[0].url, type: "video" });
           }
         }
       }
     }
   }
 
-  return urls;
+  return entries;
 }
 
 /**
- * Extract media types from a tweet
+ * Extract media URLs from a tweet using the existing highest-quality selection.
+ */
+export function extractMediaUrls(tweet: XTweetResult): string[] {
+  return extractMedia(tweet).map((entry) => entry.url);
+}
+
+/**
+ * Match the media URL positions exactly. Cards belong in linkPreview, not in
+ * a type-only media entry that the normalized Library cannot persist.
  */
 export function extractMediaTypes(tweet: XTweetResult): MediaType[] {
-  const types: MediaType[] = [];
-
-  const media =
-    tweet.legacy.extended_entities?.media || tweet.legacy.entities.media;
-
-  if (media) {
-    for (const item of media) {
-      if (item.type === "photo") {
-        types.push("image");
-      } else if (item.type === "video" || item.type === "animated_gif") {
-        types.push("video");
-      }
-    }
-  }
-
-  // Check for link cards
-  if (
-    tweet.card ||
-    (tweet.legacy.entities.urls && tweet.legacy.entities.urls.length > 0)
-  ) {
-    if (!types.includes("link")) {
-      types.push("link");
-    }
-  }
-
-  return types;
+  return extractMedia(tweet).map((entry) => entry.type);
 }
 
 // =============================================================================

--- a/packages/desktop/src/lib/facebook-normalize.test.ts
+++ b/packages/desktop/src/lib/facebook-normalize.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
 import type { RawFbPost } from "@freed/capture-facebook/browser";
 import { fbPostToFeedItem } from "@freed/capture-facebook/browser";
+import { sanitizeFeedItemCaptureWrite } from "@freed/shared";
+import { FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA } from "@freed/shared/library-core";
 
 describe("fbPostToFeedItem", () => {
   function rawPost(overrides: Partial<RawFbPost> = {}): RawFbPost {
@@ -44,6 +46,19 @@ describe("fbPostToFeedItem", () => {
       name: "My Group",
       url: "https://www.facebook.com/groups/my-group",
     });
+  });
+
+  it.each([
+    { mediaUrls: [], expectedTypes: [] },
+    { mediaUrls: ["https://cdn.example/poster.jpg", "https://cdn.example/poster.jpg"], expectedTypes: ["video", "image"] },
+  ])("pairs video classification only with existing media: $mediaUrls", ({ mediaUrls, expectedTypes }) => {
+    const item = fbPostToFeedItem(rawPost({ hasVideo: true, mediaUrls }));
+    expect(item).not.toBeNull();
+    expect(item!.content.mediaUrls).toEqual(mediaUrls);
+    expect(item!.content.mediaTypes).toEqual(expectedTypes);
+    expect(FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA.validate({
+      item: sanitizeFeedItemCaptureWrite(item!),
+    })).toMatchObject({ ok: true });
   });
 
   it("rejects Facebook registration UI as an author", () => {

--- a/packages/desktop/src/lib/instagram-normalize.test.ts
+++ b/packages/desktop/src/lib/instagram-normalize.test.ts
@@ -1,7 +1,26 @@
 import { describe, expect, it } from "vitest";
 import { igPostToFeedItem } from "@freed/capture-instagram/browser";
+import { sanitizeFeedItemCaptureWrite } from "@freed/shared";
+import { FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA } from "@freed/shared/library-core";
 
 describe("igPostToFeedItem", () => {
+  it("already preserves a valid empty media pair when a video URL is unavailable", () => {
+    const item = igPostToFeedItem({
+      shortcode: "empty_video", url: "https://www.instagram.com/p/empty_video/",
+      authorHandle: "ada", authorDisplayName: "Ada", authorAvatarUrl: null,
+      authorProfileUrl: "https://www.instagram.com/ada/", caption: "Video post",
+      timestampIso: "2026-09-01T00:00:00.000Z", mediaUrls: [],
+      isVideo: true, isCarousel: false, likeCount: null, commentCount: null,
+      hashtags: [], location: null, locationUrl: null, postType: "video",
+    });
+    expect(item).not.toBeNull();
+    expect(item!.content.mediaUrls).toEqual([]);
+    expect(item!.content.mediaTypes).toEqual([]);
+    expect(FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA.validate({
+      item: sanitizeFeedItemCaptureWrite(item!),
+    })).toMatchObject({ ok: true });
+  });
+
   it("preserves story location metadata and marks it as a sticker", () => {
     const item = igPostToFeedItem({
       shortcode: "story_123",

--- a/packages/desktop/src/lib/li-normalize.test.ts
+++ b/packages/desktop/src/lib/li-normalize.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+import { liPostToFeedItem, type RawLiPost } from "@freed/capture-linkedin/browser";
+import { sanitizeFeedItemCaptureWrite } from "@freed/shared";
+import { FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA } from "@freed/shared/library-core";
+
+describe("LinkedIn capture media pairing", () => {
+  it.each([
+    { mediaUrls: [], expectedTypes: [] },
+    { mediaUrls: ["https://cdn.example/poster.jpg", "https://cdn.example/poster.jpg"], expectedTypes: ["video", "image"] },
+  ])("admits a video marker only alongside an existing URL: $mediaUrls", ({ mediaUrls, expectedTypes }) => {
+    const post: RawLiPost = {
+      urn: "urn:li:activity:123", url: "https://www.linkedin.com/feed/update/urn:li:activity:123/",
+      authorName: "Ada Example", authorHeadline: null,
+      authorProfileUrl: "https://www.linkedin.com/in/ada-example/", authorAvatarUrl: null,
+      text: "A video post", timestampIso: "2026-09-01T00:00:00.000Z", timestampRelative: null,
+      mediaUrls, hasVideo: true, articleUrl: "https://example.com/article", articleTitle: "Article",
+      reactionCount: 1, commentCount: null, repostCount: null, hashtags: [],
+      isRepost: false, repostedFrom: null, postType: "post",
+    };
+    const item = liPostToFeedItem(post);
+    expect(item).not.toBeNull();
+    expect(item!.content.mediaUrls).toEqual(mediaUrls);
+    expect(item!.content.mediaTypes).toEqual(expectedTypes);
+    expect(item!.content.linkPreview).toEqual({ url: post.articleUrl, title: post.articleTitle });
+    expect(FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA.validate({
+      item: sanitizeFeedItemCaptureWrite(item!),
+    })).toMatchObject({ ok: true });
+  });
+});

--- a/packages/desktop/src/lib/x-normalize.test.ts
+++ b/packages/desktop/src/lib/x-normalize.test.ts
@@ -7,7 +7,9 @@
 
 import { describe, it, expect } from "vitest";
 import { tweetToFeedItem, extractLinkPreview } from "@freed/capture-x/browser";
-import type { XTweetResult } from "@freed/capture-x/browser";
+import type { XMediaEntity, XTweetResult, XVideoVariant } from "@freed/capture-x/browser";
+import { sanitizeFeedItemCaptureWrite } from "@freed/shared";
+import { FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA } from "@freed/shared/library-core";
 
 // =============================================================================
 // Fixtures
@@ -135,6 +137,53 @@ function hasNoUndefined(obj: unknown): boolean {
 // =============================================================================
 
 describe("tweetToFeedItem", () => {
+  it.each([{ hasCard: true }, { hasUrlEntities: true }])(
+    "keeps link previews out of the paired media arrays: %j",
+    (options) => {
+      const item = tweetToFeedItem(makeTweet(options));
+      expect(item.content.linkPreview?.url).toBeTruthy();
+      expect(item.content.mediaUrls).toEqual([]);
+      expect(item.content.mediaTypes).toEqual([]);
+      expect(FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA.validate({
+        item: sanitizeFeedItemCaptureWrite(item),
+      })).toMatchObject({ ok: true });
+    },
+  );
+
+  it.each<{ variants: XVideoVariant[] }>([
+    { variants: [] },
+    { variants: [{ content_type: "application/x-mpegURL", url: "https://cdn.example/video.m3u8" }] },
+    { variants: [{ content_type: "video/mp4", url: "https://cdn.example/no-bitrate.mp4" }] },
+  ])("omits a video type when existing URL selection finds no playable variant: $variants", ({ variants }) => {
+    const tweet = makeTweet();
+    tweet.legacy.extended_entities = { media: [makeMedia("video", variants)] };
+    const item = tweetToFeedItem(tweet);
+    expect(item.content.mediaUrls).toEqual([]);
+    expect(item.content.mediaTypes).toEqual([]);
+    expect(FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA.validate({
+      item: sanitizeFeedItemCaptureWrite(item),
+    })).toMatchObject({ ok: true });
+  });
+
+  it("preserves URL order and highest-bitrate selection across missing media and links", () => {
+    const tweet = makeTweet({ hasCard: true });
+    tweet.legacy.extended_entities = { media: [
+      makeMedia("photo"),
+      makeMedia("animated_gif"),
+      makeMedia("video", [
+        { bitrate: 100, content_type: "video/mp4", url: "https://cdn.example/low.mp4" },
+        { bitrate: 200, content_type: "video/mp4", url: "https://cdn.example/high.mp4" },
+      ]),
+    ] };
+    const item = tweetToFeedItem(tweet);
+    expect(item.content.mediaUrls).toEqual(["https://cdn.example/photo.jpg:large", "https://cdn.example/high.mp4"]);
+    expect(item.content.mediaTypes).toEqual(["image", "video"]);
+    expect(item.content.linkPreview?.url).toBe("https://example.com");
+    expect(FEED_ITEM_CAPTURE_UPSERT_PAYLOAD_SCHEMA.validate({
+      item: sanitizeFeedItemCaptureWrite(item),
+    })).toMatchObject({ ok: true });
+  });
+
   it("produces no undefined values for a plain tweet without views or card", () => {
     const item = tweetToFeedItem(makeTweet());
     expect(hasNoUndefined(item)).toBe(true);
@@ -187,6 +236,16 @@ describe("tweetToFeedItem", () => {
     expect(item.author.avatarUrl).toContain("_bigger");
   });
 });
+
+function makeMedia(type: XMediaEntity["type"], variants: XVideoVariant[] = []): XMediaEntity {
+  const size = { w: 640, h: 480, resize: "fit" as const };
+  return {
+    id_str: "media-1", type, media_url_https: "https://cdn.example/photo.jpg",
+    url: "https://t.co/media", expanded_url: "https://x.com/testuser/status/9876543210/photo/1",
+    sizes: { thumb: size, small: size, medium: size, large: size },
+    video_info: { duration_millis: 1_000, variants },
+  };
+}
 
 describe("extractLinkPreview", () => {
   it("returns undefined when there are no URLs and no card", () => {


### PR DESCRIPTION
(AI Generated).

## Summary

Correct paired media URLs and types in the X, LinkedIn, and Facebook normalizers without loosening the closed FeedItem capture contract. X link previews remain separate from downloadable media; videos without a usable URL no longer create an orphan type. LinkedIn and Facebook use URL position when assigning the first video, including duplicate URLs. Instagram's existing empty-media guard gains regression coverage.

Installed 26.9.501 completed Google Drive publication, then X logged 87 extracted items before persistence rejected the closed capture shape. Synthetic input reproduced a reachable producer mismatch. The actual rejected live item was not inspected, so this does not establish a lost-item denominator.

## Validation

- Ten expected failures before the fix; all 29 focused regressions pass afterward in both Desktop jsdom and plain Node.
- Full feature validation passes, including 841 Desktop unit tests, 170 focused provider tests, 23 mocked provider workflows, nine smoke workflows, typechecks, and roadmap validation.
- Production frontend and native macOS application bundle build successfully at b28ad41460e5e60983678bed6010e1fa62063b75. Native executable SHA-256: e7a228ae43a67c83756b9f7dbdaddf74bf71699d5f9b19fb209d198360a72beb.
- Exact-head full local dev integration passes: all workspace builds, typechecks and lint; 424 shared tests, 138 Library service tests (one skipped), 421 PWA tests, six WebKit durability tests, 841 Desktop tests, nine smoke tests, 164 Desktop regressions, two visual tests, native lint, 176 Desktop native tests plus one launcher test, 183 Library Core native tests, and roadmap checks. Rust formatting also passes.
- GitHub Validation and CodeQL both completed successfully for the exact candidate head before merge.

## Behavior and acceptance

Provider review covers facebook, linkedin, and x. This patch changes no extractor, navigation, cookie, header, retry, cadence, URL selection, or hydration policy. Successfully persisted captures can permit existing media hydration that previous failures prevented, as disclosed under the owner's Level 7 authority.

The native bundle is a local candidate, not the signed successor. Installed signed 26.9.501 subsequently completed a scheduled LinkedIn attempt at 2026-09-06T15:59:11Z with two extracted and two persisted items. The same source window includes Instagram two/two and Facebook five/five. These successes are tied to installed source f3ca0f47c3c1a9ab53341e8d87169c9cfb0d74c2 and its original app session. No manual provider request was issued after unlock.

The remaining media-shape repair still requires signed successor verification. Existing Library data and credentials must be preserved. Canonical private evidence digest: 5b712fb41b0b5eef2db003f554d8af58175b261f6c0ac999604fc24854958a3a. Its continuous-soak and native-boot-UUID gaps do not negate the discrete matched success events.
