### PR TITLE
chore: prepare v26.9.600-dev

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.9.501",
+  "version": "26.9.600",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.9.501"
+version = "26.9.600"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.9.501"
+version = "26.9.600"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.9.501",
+  "version": "26.9.600",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.9.501",
+  "version": "26.9.600",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/dev/26.9.6.json
+++ b/release-notes/daily/dev/26.9.6.json
@@ -1,0 +1,14 @@
+{
+  "channel": "dev",
+  "dayKey": "26.9.6",
+  "date": "2026-09-06",
+  "preferredDeck": null,
+  "editorialGuidance": [
+    "Keep the tone concise, professional, and specific.",
+    "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
+    "Demote internal cleanup unless it clearly changes the shipped product."
+  ],
+  "pinnedHighlights": [],
+  "editorialNotes": [],
+  "updatedAt": "2026-09-06T16:07:48.833Z"
+}

--- a/release-notes/releases/v26.9.600-dev.json
+++ b/release-notes/releases/v26.9.600-dev.json
@@ -3,7 +3,7 @@
   "version": "26.9.600-dev",
   "channel": "dev",
   "dayKey": "26.9.6",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-09-06T16:07:48.833Z",
   "model": "heuristic",
@@ -52,10 +52,17 @@
     ]
   },
   "release": {
-    "deck": "Refine demo interactions and identity navigation",
-    "features": [],
-    "fixes": [],
+    "deck": "More reliable social captures, locally cached avatars, and smoother demo navigation.",
+    "features": [
+      "Freed Desktop caches discovered identity avatars locally, including identities not currently onscreen."
+    ],
+    "fixes": [
+      "X link previews and videos without a playable URL no longer create invalid media records that block capture.",
+      "LinkedIn and Facebook accept posts with a video marker but no extracted media URL, and classify duplicate URLs by position.",
+      "Anonymous demo tabs use separate temporary Libraries instead of competing for the persistent Library's lock.",
+      "Demo reader descriptions preserve paragraphs and credit lines."
+    ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.9.600-dev\n\nRefine demo interactions and identity navigation\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.600-dev\n\nMore reliable social captures, locally cached avatars, and smoother demo navigation\n\n### Features\n\n- Freed Desktop caches discovered identity avatars locally, including identities not currently onscreen\n\n### Fixes\n\n- X link previews and videos without a playable URL no longer create invalid media records that block capture\n- LinkedIn and Facebook accept posts with a video marker but no extracted media URL, and classify duplicate URLs by position\n- Anonymous demo tabs use separate temporary Libraries instead of competing for the persistent Library's lock\n- Demo reader descriptions preserve paragraphs and credit lines\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.9.600-dev.json
+++ b/release-notes/releases/v26.9.600-dev.json
@@ -1,0 +1,61 @@
+{
+  "tag": "v26.9.600-dev",
+  "version": "26.9.600-dev",
+  "channel": "dev",
+  "dayKey": "26.9.6",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-09-06T16:07:48.833Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "dev",
+    "previousPublishedTag": "v26.9.501-dev",
+    "previousPublishedDayTag": "v26.9.501-dev",
+    "compareRef": "HEAD",
+    "productCommitSha": "d60844ac79e299734c2aee38d2038c98825e1e6e",
+    "promotedDevCommitSha": null,
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "dev",
+        "previousPublishedTag": "v26.9.501-dev",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "12dde7b82c81e681ba7762b23a7573781b5f6055",
+        "toInclusiveProductCommitSha": "d60844ac79e299734c2aee38d2038c98825e1e6e"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:379d3ebca4e4e2b521cd4da4987224a5ae19a7d6e8259f9bb916c4dfb5e4099f",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.9.600-dev"
+    ],
+    "relatedBuildTags": [
+      "v26.9.600-dev"
+    ],
+    "prNumbers": [],
+    "commitSubjects": [
+      "fix: preserve valid provider capture media pairs",
+      "feat: refine demo interactions and identity navigation"
+    ]
+  },
+  "release": {
+    "deck": "Refine demo interactions and identity navigation",
+    "features": [],
+    "fixes": [],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.600-dev\n\nRefine demo interactions and identity navigation\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.9.600-dev.md
+++ b/release-notes/releases/v26.9.600-dev.md
@@ -2,11 +2,18 @@
 
 ## Freed v26.9.600-dev
 
-Refine demo interactions and identity navigation
+More reliable social captures, locally cached avatars, and smoother demo navigation
+
+### Features
+
+- Freed Desktop caches discovered identity avatars locally, including identities not currently onscreen
 
 ### Fixes
 
-- Bug fixes and improvements
+- X link previews and videos without a playable URL no longer create invalid media records that block capture
+- LinkedIn and Facebook accept posts with a video marker but no extracted media URL, and classify duplicate URLs by position
+- Anonymous demo tabs use separate temporary Libraries instead of competing for the persistent Library's lock
+- Demo reader descriptions preserve paragraphs and credit lines
 
 ### Downloads
 

--- a/release-notes/releases/v26.9.600-dev.md
+++ b/release-notes/releases/v26.9.600-dev.md
@@ -1,0 +1,17 @@
+(AI Generated).
+
+## Freed v26.9.600-dev
+
+Refine demo interactions and identity navigation
+
+### Fixes
+
+- Bug fixes and improvements
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

## Release

Prepare v26.9.600-dev from immutable product source d60844ac79e299734c2aee38d2038c98825e1e6e. This metadata-only release includes the provider media-pair repair from PR1822 and the already-merged demo and identity work from PR1802.

The official release script generated numeric bundle version 26.9.600, reviewed notes, and the immutable source boundary. The generated Library Core inspection has identical prior/current manifests, no transitions, and no_activation_declared. No activation fields or versions were hand-entered.

## Proof and authority

The product candidate passed full local dev integration, a native macOS bundle build, Rust formatting, and exact-head GitHub Validation and CodeQL before merge. Provider artifacts cover both the media-pair repair and PR1802's existing-identity public avatar cache/backfill.

The release commit receives its own feature/native validation and exact-head remote checks before merge. The tag will be created only through the repository release publisher after protected dev integration passes. Signed artifact publication, installation, and installed verification remain separate steps.

Installed signed 26.9.501 already completed a real scheduled LinkedIn attempt with two extracted and two persisted items, plus successful Facebook and Instagram attempts. That evidence does not substitute for verifying the new capture repair in the signed successor. Existing Library data, writer authority, and credentials will be preserved.