### PR TITLE
fix: preserve interrupted PWA result replay identity

### DIFF
--- a/docs/library-core-contract/follower-intents.md
+++ b/docs/library-core-contract/follower-intents.md
@@ -161,6 +161,9 @@ settlement commits but operation application fails, the optimistic overlay
 remains visible and an exact result-segment retry resumes the staged operation.
 The overlay is removed only inside the successful operation transaction, or
 when an exact already-applied operation proof is present.
+Resuming a locally settled result uses its stored first receive time, not the
+retry's wall clock. Direct and transport-based retries therefore retain the
+same staging identity after an interrupted materialization.
 
 The PWA cloud coordinator never resumes publication by scanning that history
 from counter one. One closed SQLite transport context returns the enrolled

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -758,6 +758,12 @@ test("startup emits renderer health before background work can run", async ({ ap
 });
 
 test("no console errors on startup", async ({ page }) => {
+  // This checks application startup, not the availability of an external font
+  // service. A stalled stylesheet otherwise holds page.load after the legal
+  // gate has rendered and prevents the runtime assertion from executing.
+  await page.route("https://fonts.googleapis.com/**", (route) =>
+    route.fulfill({ contentType: "text/css", body: "" }),
+  );
   await page.addInitScript(tauriInitScript());
 
   const errors: string[] = [];

--- a/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
@@ -2131,6 +2131,12 @@ describe("PWA Library Core SQLite engine", () => {
       }),
     ).toEqual([[7, 1, 1, 1, 0, 0, 0]]);
     database.exec("DROP TRIGGER fail_operation_replication_result;");
+    // The failed materialization leaves durable staging behind. A later direct
+    // replay must retain the original receive time for the same signed result.
+    await expect(engine.applyFollowerResult({ canonicalResultBytes })).resolves.toMatchObject({
+      sourceRevision: 8,
+      transactionId: "intent-transaction-1",
+    });
     const transportReceipt =
       await engine.importNormalizedFollowerResultTransport(resultPublication);
     expect(transportReceipt).toEqual({

--- a/packages/pwa/src/lib/library-core-sqlite-engine.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.ts
@@ -6696,15 +6696,18 @@ export class PwaLibraryCoreSqliteEngine {
 
   async #applyAcceptedFollowerResultThroughOperationImport(
     verified: LibraryCoreVerifiedFollowerResultV1,
-    receivedAt: number,
   ): Promise<void> {
     const envelope = verified.envelope;
     if (envelope.status !== "accepted") return;
     const transactionRows = this.#database.exec({
-      sql: `SELECT transaction_digest, member_count
-            FROM library_intent_transactions
-            WHERE transaction_id = ?1 AND actor_id = ?2;`,
-      bind: [envelope.transaction_id, envelope.actor_id],
+      sql: `SELECT intent.transaction_digest, intent.member_count,
+                   result.received_at
+            FROM library_intent_transactions AS intent
+            JOIN library_intent_results AS result
+              ON result.transaction_id = intent.transaction_id
+            WHERE intent.transaction_id = ?1 AND intent.actor_id = ?2
+              AND result.result_digest = ?3;`,
+      bind: [envelope.transaction_id, envelope.actor_id, verified.resultDigest],
       rowMode: "array",
       returnValue: "resultRows",
     });
@@ -6717,6 +6720,13 @@ export class PwaLibraryCoreSqliteEngine {
     ) {
       throw new Error("accepted result operation transaction is unavailable");
     }
+    // Settlement may have committed before a worker stopped mid-import. The
+    // original result receipt owns staging's receive time across every replay,
+    // including a replay arriving through a different transport entry point.
+    const receivedAt = safeInteger(
+      transactionRows[0]![2],
+      "accepted result original receive time",
+    );
     const memberRows = this.#database.exec({
       sql: `SELECT member_index, operation_id, canonical_member
             FROM library_intent_members
@@ -7096,7 +7106,6 @@ export class PwaLibraryCoreSqliteEngine {
     for (const verified of verifiedResults) {
       await this.#applyAcceptedFollowerResultThroughOperationImport(
         verified,
-        publication.receivedAt,
       );
     }
     return receipt;
@@ -7152,7 +7161,6 @@ export class PwaLibraryCoreSqliteEngine {
     this.#applyVerifiedFollowerResult(verified, authority, receivedAt, true);
     await this.#applyAcceptedFollowerResultThroughOperationImport(
       verified,
-      receivedAt,
     );
     const receipt = this.#followerResultRetry(
       candidate.transaction_id,

--- a/packages/pwa/tests/sqlite-opfs-durability.spec.ts
+++ b/packages/pwa/tests/sqlite-opfs-durability.spec.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { createServer, type ViteDevServer } from "vite";
 import {
   devices,
   expect,
@@ -16,6 +17,41 @@ import {
   SAMPLE_SHOWCASE_SOCIAL_IDENTITY_COUNT,
 } from "@freed/shared";
 import { pwaOpfsE2eBaseUrl } from "./opfs-e2e-settings";
+
+const profileOrigins = new Map<string, { origin: string; server: ViteDevServer }>();
+
+async function isolatedProfileOrigin(profileRoot: string): Promise<string> {
+  const existing = profileOrigins.get(profileRoot);
+  if (existing) return existing.origin;
+  // macOS WebKit can share OPFS across persistent profiles at one origin,
+  // while keeping their IndexedDB keys separate. Give each synthetic Library
+  // its own origin, retained across reopen and worker-loss checks. Keep ports
+  // reserved until the suite ends so a later profile cannot inherit one.
+  const server = await createServer({
+    configFile: false,
+    appType: "custom",
+    root: profileRoot,
+    server: {
+      host: "127.0.0.1",
+      port: 0,
+      proxy: { "/": { target: pwaOpfsE2eBaseUrl, ws: true } },
+    },
+  });
+  await server.listen();
+  const address = server.httpServer?.address();
+  if (!address || typeof address === "string") {
+    await server.close();
+    throw new Error("WebKit test origin did not acquire a TCP port");
+  }
+  const origin = `http://127.0.0.1:${address.port}`;
+  profileOrigins.set(profileRoot, { origin, server });
+  return origin;
+}
+
+test.afterAll(async () => {
+  await Promise.all([...profileOrigins.values()].map(({ server }) => server.close()));
+  profileOrigins.clear();
+});
 
 interface BrowserLibraryCore {
   facetSummary(): Promise<{
@@ -110,10 +146,11 @@ async function openLibrary(page: Page): Promise<void> {
 
 async function launchPersistentLibraryContext(
   profileRoot: string,
-  baseURL = pwaOpfsE2eBaseUrl,
 ): Promise<BrowserContext> {
+  const firstOpen = !profileOrigins.has(profileRoot);
+  const baseURL = await isolatedProfileOrigin(profileRoot);
   const iphone = devices["iPhone 14"];
-  return webkit.launchPersistentContext(profileRoot, {
+  const context = await webkit.launchPersistentContext(profileRoot, {
     userAgent: iphone.userAgent,
     viewport: iphone.viewport,
     screen: iphone.screen,
@@ -123,6 +160,23 @@ async function launchPersistentLibraryContext(
     baseURL,
     headless: true,
   });
+  if (firstOpen) {
+    try {
+      const page = context.pages()[0] ?? (await context.newPage());
+      await page.goto("/favicon.svg");
+      const entries = await page.evaluate(async () => {
+        const root = await navigator.storage.getDirectory();
+        const names: string[] = [];
+        for await (const name of root.keys()) names.push(name);
+        return names;
+      });
+      expect(entries, "a fresh test Library must not inherit another profile's OPFS").toEqual([]);
+    } catch (error) {
+      await context.close();
+      throw error;
+    }
+  }
+  return context;
 }
 
 async function openPersistentLibrary(profileRoot: string): Promise<{
@@ -645,11 +699,7 @@ test("iPhone WebKit treats a second Library tab as busy, not corrupted", async (
   let context: BrowserContext | null = null;
 
   try {
-    // This case interrupts sample writes when the owning tab closes. Give it
-    // its own origin as well as its own profile to isolate WebKit OPFS state.
-    const busyOrigin = new URL(pwaOpfsE2eBaseUrl);
-    busyOrigin.hostname = "localhost";
-    context = await launchPersistentLibraryContext(profileRoot, busyOrigin.origin);
+    context = await launchPersistentLibraryContext(profileRoot);
     const firstPage = context.pages()[0] ?? (await context.newPage());
     await openLibrary(firstPage);
     const secondPage = await context.newPage();


### PR DESCRIPTION
(AI Generated).

## Summary

Fix interrupted PWA result recovery discovered while diagnosing the WebKit failure that blocked the superseded development release #1823.

- Preserve the per-test loopback origin isolation already merged in #1827. Add an explicit assertion that a fresh test Library starts with empty OPFS. Retain the origin across restarts and preserve the existing worker-loss, interruption, corruption and cross-tab checks. The original overlapping implementation was removed during integration.
- Resume accepted-result materialization with the original receive time from its matching immutable SQLite result receipt. A retry after the final materialization fault previously assigned a new time and rejected unchanged signed bytes as a changed staging replay.
- Keep signatures, digests, actor and epoch checks, transaction completeness, source revisions and checkpoint conflict guards unchanged. No schema, protocol, storage epoch, activation, provider request or cadence change.
- Make the existing startup-console smoke test independent of the external Google Fonts stylesheet. A controlled stalled-stylesheet probe reproduced the legal screen rendering while the page-load event remained pending. Runtime error assertions and load completion remain required.

## Validation

- Existing engine fault test reproduced the exact replay error before the fix: 30 passed, one failed. After the fix: 31 passed.
- Full changed-path validation passed: production build, root and PWA types, 421 PWA unit tests, all six actual WebKit durability tests, 80 release-activation tests, 16 instruction tests and instruction validation.
- Actual WebKit suite passed in 2.8 minutes with both fixes and the fresh-OPFS assertion. No retry or timeout increase.
- Full local dev integration passed at d4e5d02eb2a1c78c5a59637bde5718bc64d72e68, including all 164 Desktop regressions, visual tests, native Rust lint/tests and the retired-runtime artifact guards. GitHub Validation34048099189 and CodeQL34048097379 passed at the same head, including actual macOS WebKit.
- Those receipts precede integration of #1827. The combined candidate is 4994bb6576a7becbb1c78b8af8d9ca4706f50d7d. Its engine tests pass 31/31 and six actual WebKit durability cases pass in 3.2 minutes. Full changed-path validation also passed on this head: production build and types, 421 PWA tests, another six WebKit cases, 841 Desktop tests, nine smoke tests, 80 release-activation tests, and instruction checks.
- Initial full integration passed builds, types, lint, 424 shared, 138 service, 421 PWA, six WebKit and 841 Desktop tests before a startup page-load timeout. A traced unchanged rerun passed; a controlled offline font-stall probe demonstrated the blocking mechanism. With the stylesheet fixture, all nine smoke tests and the complete subsequent integration run passed.

This repair does not reset a user's Library or change the Desktop provider fixes already merged in #1822.