### PR TITLE
fix: make update and settings accents theme aware

### DIFF
--- a/packages/desktop/src/components/DesktopSnapshotsSection.tsx
+++ b/packages/desktop/src/components/DesktopSnapshotsSection.tsx
@@ -62,12 +62,12 @@ export function DesktopSnapshotsSection() {
   if (!tauriAvailable) {
     return (
       <div className="mt-8">
-        <h3 className="mb-4 text-xs font-semibold uppercase tracking-wider text-[#71717a]">
+        <h3 className="mb-4 text-xs font-semibold uppercase tracking-wider text-text-muted">
           Local Snapshots
         </h3>
-        <div className="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-white/5 p-4">
-          <p className="text-sm text-white">Snapshots are unavailable in browser preview</p>
-          <p className="mt-1 max-w-xl text-xs text-[#71717a]">
+        <div className="rounded-2xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-surface)] p-4">
+          <p className="text-sm text-text-primary">Snapshots are unavailable in browser preview</p>
+          <p className="mt-1 max-w-xl text-xs text-text-muted">
             Local snapshot creation and restore use native Freed Desktop storage APIs, so this section only works in the real app.
           </p>
         </div>
@@ -110,15 +110,15 @@ export function DesktopSnapshotsSection() {
 
   return (
     <div className="mt-8">
-      <h3 className="text-xs font-semibold text-[#71717a] uppercase tracking-wider mb-4">
+      <h3 className="text-xs font-semibold text-text-muted uppercase tracking-wider mb-4">
         Local Snapshots
       </h3>
 
-      <div className="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-white/5 p-4">
+      <div className="rounded-2xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-surface)] p-4">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-1">
-            <p className="text-sm text-white">Automatic rotating snapshots</p>
-            <p className="text-xs text-[#71717a] max-w-xl">
+            <p className="text-sm text-text-primary">Automatic rotating snapshots</p>
+            <p className="text-xs text-text-muted max-w-xl">
               Freed Desktop keeps up to {(24).toLocaleString()} verified snapshots of your
               normalized library records. Device caches and Google Contacts matching data stay
               local and are not included.
@@ -127,16 +127,16 @@ export function DesktopSnapshotsSection() {
           <button
             onClick={() => void handleCreateSnapshot()}
             disabled={creating || restoringId !== null}
-            className="shrink-0 rounded-xl bg-white/10 px-3 py-2 text-sm text-[#a1a1aa] transition-colors hover:bg-white/15 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            className="shrink-0 rounded-xl bg-[var(--theme-bg-muted)] px-3 py-2 text-sm text-text-secondary transition-colors hover:bg-[var(--theme-bg-elevated)] hover:text-text-primary disabled:cursor-not-allowed disabled:opacity-50"
           >
             {creating ? "Creating..." : "Create snapshot now"}
           </button>
         </div>
 
         {loading ? (
-          <p className="mt-4 text-xs text-[#71717a]">Loading snapshots...</p>
+          <p className="mt-4 text-xs text-text-muted">Loading snapshots...</p>
         ) : snapshots.length === 0 ? (
-          <p className="mt-4 text-xs text-[#71717a]">
+          <p className="mt-4 text-xs text-text-muted">
             Your first snapshot appears automatically after the library starts changing.
           </p>
         ) : (
@@ -147,29 +147,29 @@ export function DesktopSnapshotsSection() {
               return (
                 <div
                   key={snapshot.id}
-                  className="flex flex-col gap-3 rounded-xl border border-[rgba(255,255,255,0.06)] bg-black/20 px-3 py-3 sm:flex-row sm:items-center sm:justify-between"
+                  className="flex flex-col gap-3 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-input)] px-3 py-3 sm:flex-row sm:items-center sm:justify-between"
                 >
                   <div className="min-w-0">
                     <div className="flex flex-wrap items-center gap-2">
-                      <p className="text-sm text-white">
+                      <p className="text-sm text-text-primary">
                         {dateFormatter.format(snapshot.createdAt)}
                       </p>
-                      <span className="rounded-full bg-white/10 px-2 py-0.5 text-[11px] uppercase tracking-wide text-[#71717a]">
+                      <span className="rounded-full bg-[var(--theme-bg-muted)] px-2 py-0.5 text-[11px] uppercase tracking-wide text-text-muted">
                         {snapshot.reason}
                       </span>
                     </div>
-                    <p className="mt-1 text-xs text-[#71717a]">
+                    <p className="mt-1 text-xs text-text-muted">
                       {snapshot.itemCount.toLocaleString()} items, {snapshot.recordCount.toLocaleString()} normalized records,{" "}
                       {formatByteSize(snapshot.byteSize)}
                     </p>
-                    <p className="mt-1 text-[11px] font-mono text-[#52525b]">
+                    <p className="mt-1 text-[11px] font-mono text-text-muted">
                       Snapshot ...{snapshot.id.slice(-8)}
                     </p>
                   </div>
                   <button
                     onClick={() => void handleRestoreSnapshot(snapshot)}
                     disabled={creating || restoringId !== null}
-                    className="shrink-0 rounded-xl bg-[#8b5cf6]/15 px-3 py-2 text-sm text-[#c4b5fd] transition-colors hover:bg-[#8b5cf6]/25 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+                    className="shrink-0 rounded-xl theme-accent-button px-3 py-2 text-sm transition-colors disabled:cursor-not-allowed disabled:opacity-50"
                   >
                     {isRestoring ? "Restoring..." : "Restore"}
                   </button>

--- a/packages/desktop/src/components/FacebookSettingsSection.tsx
+++ b/packages/desktop/src/components/FacebookSettingsSection.tsx
@@ -182,7 +182,7 @@ function Toggle({
             data-testid={testId ? `${testId}-switch` : undefined}
             onClick={() => onChange(!checked)}
             className={`relative h-5 w-9 shrink-0 rounded-full transition-colors ${
-              checked ? "bg-[#8b5cf6]" : "bg-white/10"
+              checked ? "bg-[var(--theme-accent-secondary)]" : "bg-[var(--theme-bg-muted)]"
             }`}
           >
             <span
@@ -861,7 +861,7 @@ export function FacebookSettingsSection({
                         <span
                           aria-label={`Refreshing group: ${title}`}
                           data-testid={`facebook-group-${group.id}-refreshing`}
-                          className="h-3 w-3 shrink-0 rounded-full border border-[#8b5cf6]/50 border-t-[#c4b5fd] animate-spin"
+                          className="h-3 w-3 shrink-0 rounded-full border border-[var(--theme-border-strong)] border-t-[var(--theme-accent-secondary)] animate-spin"
                         />
                       ) : null
                     }

--- a/packages/desktop/src/components/UpdateNotification.tsx
+++ b/packages/desktop/src/components/UpdateNotification.tsx
@@ -34,7 +34,7 @@ export function UpdateNotification({
 
   return (
     <div className="fixed bottom-4 right-4 z-[120] max-w-sm animate-slide-up">
-      <div className="rounded-2xl bg-[var(--freed-surface)] p-4 shadow-lg border border-[rgba(139,92,246,0.3)]">
+      <div className="rounded-2xl bg-[var(--freed-surface)] p-4 shadow-lg border border-[var(--theme-border-strong)]">
         <div className="flex items-start gap-3">
           <div className="shrink-0 mt-0.5">
             <UpdateIcon phase={state.phase} />
@@ -69,7 +69,7 @@ export function UpdateNotification({
         {state.phase === "downloading" && (
           <UpdateProgressBar
             percent={state.percent}
-            trackClassName="mt-3 h-1.5 overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]"
+            trackClassName="mt-3 h-1.5 overflow-hidden rounded-full bg-[var(--theme-bg-muted)]"
             fillClassName="h-full rounded-full bg-gradient-to-r from-[var(--glow-blue)] to-[var(--glow-purple)]"
           />
         )}
@@ -136,7 +136,7 @@ function UpdateContent({
           })()}
           <button
             onClick={onInstall}
-            className="mt-2 text-xs font-semibold px-3 py-1.5 rounded-md bg-gradient-to-r from-[var(--glow-blue)] to-[var(--glow-purple)] text-white hover:brightness-110 transition-all"
+            className="mt-2 text-xs font-semibold px-3 py-1.5 rounded-md [background:var(--theme-button-primary-background)] text-[var(--theme-button-primary-text)] hover:brightness-110 transition-all"
           >
             Download &amp; Install
           </button>
@@ -159,7 +159,7 @@ function UpdateContent({
           </p>
           <button
             onClick={onRelaunch}
-            className="mt-2 text-xs font-semibold px-3 py-1.5 rounded-md bg-gradient-to-r from-[var(--glow-blue)] to-[var(--glow-purple)] text-white hover:brightness-110 transition-all"
+            className="mt-2 text-xs font-semibold px-3 py-1.5 rounded-md [background:var(--theme-button-primary-background)] text-[var(--theme-button-primary-text)] hover:brightness-110 transition-all"
           >
             Restart Now
           </button>
@@ -167,7 +167,7 @@ function UpdateContent({
       );
     case "error":
       return (
-        <p className="text-sm text-red-400">
+        <p className="text-sm theme-icon-danger">
           Update failed: {state.message}
         </p>
       );

--- a/packages/desktop/src/components/XSettingsSection.tsx
+++ b/packages/desktop/src/components/XSettingsSection.tsx
@@ -496,9 +496,9 @@ export function XSettingsSection({
               <li>Log in to <span className="text-white font-medium">x.com</span> in Chrome</li>
               <li>Open DevTools with <kbd className="px-1 py-0.5 bg-white/10 rounded text-[10px]">⌥⌘I</kbd></li>
               <li>Click the <span className="text-white">Application</span> tab</li>
-              <li>Expand <span className="text-white">Cookies</span> and select <span className="font-mono text-[10px] text-[#c4b5fd]">https://x.com</span></li>
-              <li>Copy the value for <span className="font-mono text-[#c4b5fd]">ct0</span></li>
-              <li>Copy the value for <span className="font-mono text-[#c4b5fd]">auth_token</span></li>
+              <li>Expand <span className="text-white">Cookies</span> and select <span className="font-mono text-[10px] text-[var(--theme-accent-secondary)]">https://x.com</span></li>
+              <li>Copy the value for <span className="font-mono text-[var(--theme-accent-secondary)]">ct0</span></li>
+              <li>Copy the value for <span className="font-mono text-[var(--theme-accent-secondary)]">auth_token</span></li>
             </ol>
           </div>
 
@@ -507,7 +507,7 @@ export function XSettingsSection({
             placeholder="ct0 value"
             value={ct0}
             onChange={(e) => setCt0(e.target.value)}
-            className="w-full text-sm px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.1)] rounded-xl text-white placeholder-[#52525b] focus:outline-none focus:border-[#8b5cf6]/50"
+            className="w-full text-sm px-3 py-2 theme-input rounded-xl focus:outline-none"
           />
           <input
             type="text"
@@ -515,7 +515,7 @@ export function XSettingsSection({
             value={authToken}
             onChange={(e) => setAuthToken(e.target.value)}
             onKeyDown={(e) => { if (e.key === "Enter") handleManualConnect(); }}
-            className="w-full text-sm px-3 py-2 bg-white/5 border border-[rgba(255,255,255,0.1)] rounded-xl text-white placeholder-[#52525b] focus:outline-none focus:border-[#8b5cf6]/50"
+            className="w-full text-sm px-3 py-2 theme-input rounded-xl focus:outline-none"
           />
 
           {formError && <p className="text-xs text-red-400">{formError}</p>}
@@ -525,7 +525,7 @@ export function XSettingsSection({
               data-testid="x-manual-connect"
               onClick={handleManualConnect}
               disabled={!ct0 || !authToken}
-              className="flex-1 text-sm px-3 py-2 rounded-xl bg-[#8b5cf6]/15 text-[#8b5cf6] hover:bg-[#8b5cf6]/25 disabled:opacity-40 transition-colors"
+              className="flex-1 text-sm px-3 py-2 rounded-xl theme-accent-button disabled:opacity-40 transition-colors"
             >
               Connect
             </button>
@@ -555,7 +555,7 @@ export function XSettingsSection({
         </p>
         <button
           onClick={handleSignIn}
-          className="w-full text-sm px-4 py-2.5 rounded-xl bg-[#8b5cf6]/15 text-[#8b5cf6] hover:bg-[#8b5cf6]/25 transition-colors"
+          className="w-full text-sm px-4 py-2.5 rounded-xl theme-accent-button transition-colors"
         >
           {needsReconnect ? "Reconnect X" : "Sign in to X"}
         </button>

--- a/packages/ui/src/components/PullToRefresh.tsx
+++ b/packages/ui/src/components/PullToRefresh.tsx
@@ -88,10 +88,10 @@ export function PullToRefresh({
           }`}
           style={{
             transform: `rotate(${progress * 360}deg)`,
-            background: `conic-gradient(from 0deg, #8b5cf6 ${progress * 100}%, transparent ${progress * 100}%)`,
+            background: `conic-gradient(from 0deg, var(--theme-accent-secondary) ${progress * 100}%, transparent ${progress * 100}%)`,
           }}
         >
-          <div className="w-6 h-6 rounded-full bg-[#0a0a0a]" />
+          <div className="w-6 h-6 rounded-full bg-[var(--theme-bg-root)]" />
         </div>
       </div>
 


### PR DESCRIPTION
(AI Generated).

The update notification kept a purple outline in every theme. Use the selected theme's border, progress track, button colors, and error color. Replace the same fixed purple accents in snapshot restore actions, X settings inputs and actions, Facebook switches and loading indicators, and the exported pull-to-refresh component. Snapshot surfaces and text now also follow light themes.

Validation: the local feature gate passed, including 170 shared UI tests, 421 PWA tests, 841 Desktop tests, 23 provider e2e tests, and 9 Desktop smoke tests. A temporary rendered probe checked all four update states across all six themes; screenshots were reviewed and the probe was removed.

Native compilation and the local app bundle also passed with updater artifact generation disabled; signed updater artifacts are produced by CI.

The X and Facebook changes affect local CSS classes only. Provider handlers, requests, cookies, navigation, and timing are unchanged.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `e15af5f20f6e81daa99e23ef1cfa8c14bb3c8288`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `theme-aware-update-tokens`
- Provider review decision: `diff_authorized`
- Provider review artifact: `087892dd295bf598fac163535f74e04a57b3db1a2ee81a8fe0202a13b08028c7`
- Providers: facebook, x
- Observable behavior: Only local CSS class names change in XSettingsSection.tsx and FacebookSettingsSection.tsx. Event handlers, requests, navigation, timing, cookies, headers, extraction and provider activity are unchanged.
- Fingerprinting risk: No added provider fingerprinting risk from local theme styling.
- Lowest profile alternative: Verify in the mocked Desktop browser with synthetic fixtures and no provider contact.

Files bound into this provider review:
- `packages/desktop/src/components/FacebookSettingsSection.tsx`
- `packages/desktop/src/components/XSettingsSection.tsx`