### PR TITLE
fix: stop feed reloads from restarting ranking

### DIFF
--- a/packages/desktop/src/lib/store-startup-migrations.test.ts
+++ b/packages/desktop/src/lib/store-startup-migrations.test.ts
@@ -327,6 +327,35 @@ describe("store startup migrations", () => {
     expect(mockStartOutboxProcessor).toHaveBeenCalledTimes(1);
   });
 
+  it("does not report weight changes when SQLite reloads identical preferences", async () => {
+    const { useAppStore } = await import("./store");
+    await useAppStore.getState().initialize();
+    const subscriber = mockSubscribe.mock.calls.at(-1)![0];
+    const initial = useAppStore.getState().preferences;
+    const weightChanged = vi.fn();
+    const unsubscribe = useAppStore.subscribe((state, previous) => {
+      if (state.preferences.weights !== previous.preferences.weights) weightChanged();
+    });
+    try {
+      // Ranking completion and unrelated item changes both reload full DTOs.
+      subscriber(createLibraryState(), { source: "state_update" });
+      subscriber(createLibraryState(), { source: "item_patch" });
+      expect(weightChanged).not.toHaveBeenCalled();
+      expect(useAppStore.getState().preferences).toBe(initial);
+      const changed = createLibraryState();
+      changed.preferences.weights.authors = { ada: 90 };
+      subscriber(changed, { source: "preferences_patch" });
+      expect(weightChanged).toHaveBeenCalledTimes(1);
+      expect(useAppStore.getState().preferences.ai).toBe(initial.ai);
+      expect(useAppStore.getState().preferences.weights.authors).toEqual({ ada: 90 });
+      subscriber(createLibraryState(), { source: "preferences_patch" });
+      expect(weightChanged).toHaveBeenCalledTimes(2);
+      expect(useAppStore.getState().preferences.weights.authors).toEqual({});
+    } finally {
+      unsubscribe();
+    }
+  });
+
   it("increments Library and Saved sources only for their relevant SQLite changes", async () => {
     const { useAppStore } = await import("./store");
 

--- a/packages/desktop/src/lib/store.ts
+++ b/packages/desktop/src/lib/store.ts
@@ -436,6 +436,34 @@ function isMergeablePreferenceObject(value: unknown): value is Record<string, un
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * Reuse equal preference branches after a full SQLite snapshot reload.
+ * Object identity drives background watchers, so a fresh DTO must not pretend
+ * the ranking policy changed. Iterate the new keys so removals still apply.
+ */
+function reconcilePreferenceSnapshot<T>(current: T, incoming: T): T {
+  if (Object.is(current, incoming)) return current;
+  if (Array.isArray(current) && Array.isArray(incoming)) {
+    const next = incoming.map((value, index) =>
+      reconcilePreferenceSnapshot(current[index], value),
+    );
+    const unchanged = next.length === current.length &&
+      next.every((value, index) => value === current[index]);
+    return (unchanged ? current : next) as T;
+  }
+  if (!isMergeablePreferenceObject(current) || !isMergeablePreferenceObject(incoming)) {
+    return incoming;
+  }
+  const keys = Object.keys(incoming);
+  const entries = keys.map((key) => [
+    key,
+    reconcilePreferenceSnapshot(current[key], incoming[key]),
+  ] as const);
+  const unchanged = keys.length === Object.keys(current).length &&
+    entries.every(([key, value]) => Object.hasOwn(current, key) && value === current[key]);
+  return (unchanged ? current : Object.fromEntries(entries)) as T;
+}
+
 function mergePreferenceUpdate<T extends object>(
   current: T,
   update: Partial<T>,
@@ -739,6 +767,7 @@ export const useAppStore = create<AppState>((set, get) => ({
         librarySubscriptionTeardown = subscribeDesktopLibraryRuntime((state, event) => {
           if (!storeAcceptingResetSensitiveWork || isFactoryResetInProgress()) return;
           const prev = get();
+          const preferences = reconcilePreferenceSnapshot(prev.preferences, state.preferences);
           const libraryItemVersion =
             event.source === "item_patch" || event.source === "state_update"
               ? prev.libraryItemVersion + 1
@@ -756,7 +785,7 @@ export const useAppStore = create<AppState>((set, get) => ({
           // on the current bounded Saved generation.
           const savedFeedRankingWeightsChanged =
             event.source === "preferences_patch" &&
-            state.preferences.weights !== prev.preferences.weights;
+            preferences.weights !== prev.preferences.weights;
           const savedFeedVersion =
             event.source === "state_update" ||
             savedFeedRankingWeightsChanged ||
@@ -783,6 +812,7 @@ export const useAppStore = create<AppState>((set, get) => ({
                 : prev.savedFeedPresentationPatch;
           let next: Partial<AppState> = {
             ...runtimeStatePatch(state),
+            preferences,
             libraryItemVersion,
             savedFeedPresentationPatch,
             savedFeedVersion,

--- a/packages/desktop/tests/e2e/feed-card-ui.spec.ts
+++ b/packages/desktop/tests/e2e/feed-card-ui.spec.ts
@@ -1120,3 +1120,31 @@ test("feed cards show compact event metadata from semantic enrichment", async ({
   await expect(eventCard).toBeVisible();
   await expect(eventCard).toContainText(/Event/);
 });
+
+
+test("failed feed refresh shows a retry action instead of an empty Library", async ({ app }) => {
+  await app.goto();
+  await app.waitForReady();
+  await injectCardUiItems(app.page);
+  await expect(app.page.locator("article").first()).toBeVisible();
+  await app.page.evaluate(() => {
+    const w = window as Record<string, unknown>;
+    const handlers = w.__TAURI_MOCK_HANDLERS__ as Record<string, (args: any) => unknown>;
+    const original = handlers.query_normalized_library;
+    w.__RESTORE_FEED_QUERY__ = () => { handlers.query_normalized_library = original; };
+    handlers.query_normalized_library = (args) => {
+      if (args.request?.queryId === "feed_browse_page_v3") throw new Error("forced feed failure");
+      return original(args);
+    };
+    const store = w.__FREED_STORE__ as { getState(): { setFilter(filter: unknown): void } };
+    store.getState().setFilter({ platform: "facebook" });
+  });
+  await expect(app.page.getByRole("alert")).toContainText("Unable to load this feed.");
+  await expect(app.page.getByText("Welcome to Freed", { exact: true })).toHaveCount(0);
+  await app.page.evaluate(() => {
+    ((window as Record<string, unknown>).__RESTORE_FEED_QUERY__ as () => void)();
+  });
+  await app.page.getByRole("button", { name: "Try again", exact: true }).click();
+  await expect(app.page.getByRole("alert")).toHaveCount(0);
+  await expect(app.page.locator("article").filter({ hasText: FACEBOOK_TITLE }).first()).toBeVisible();
+});

--- a/packages/ui/src/components/feed/FeedView.tsx
+++ b/packages/ui/src/components/feed/FeedView.tsx
@@ -565,6 +565,7 @@ export function FeedView() {
   ]);
   const {
     feed: boundedFeed,
+    retry: retryBoundedFeed,
     loadMore: loadMoreBoundedItems,
     loadPrevious: loadPreviousBoundedItems,
     patchItems: patchBoundedItems,
@@ -1204,7 +1205,14 @@ export function FeedView() {
 
   return (
     <div className="h-full flex flex-col">
-      {!selectedItem && <FeedList
+      {!selectedItem && boundedFeedEligible && boundedFeedStatusIsCurrent && boundedFeed.status === "failed" ? (
+        <div role="alert" className="flex flex-1 flex-col items-center justify-center gap-3 p-6 text-center">
+          <p>Unable to load this feed.</p>
+          <button type="button" className="theme-accent-button rounded-xl px-5 py-2.5 text-sm font-medium" onClick={retryBoundedFeed}>
+            Try again
+          </button>
+        </div>
+      ) : !selectedItem && <FeedList
         items={visibleItems}
         onItemClick={openItemDirect}
         focusedIndex={focusedIndex}

--- a/packages/ui/src/components/feed/useBoundedFeedItems.test.tsx
+++ b/packages/ui/src/components/feed/useBoundedFeedItems.test.tsx
@@ -51,6 +51,7 @@ function Harness({
   maxResidentPages?: number;
   onReady: (value: {
     feed: BoundedFeedItemsState;
+    retry(): void;
     loadMore(): void;
     loadPrevious(): void;
     patchItems(update: (item: FeedItem) => FeedItem | null): void;
@@ -166,7 +167,7 @@ describe("useBoundedFeedItems", () => {
     expect(close).toHaveBeenCalledOnce();
   });
 
-  it("closes a reader whose first bounded page fails and exposes legacy fallback", async () => {
+  it("closes a reader whose first bounded page fails without retrying unknown errors", async () => {
     mount();
     const close = vi.fn(async () => undefined);
     const openReader = vi.fn(async () => ({
@@ -193,6 +194,53 @@ describe("useBoundedFeedItems", () => {
     });
     expect(current?.feed.items).toEqual([]);
     expect(close).toHaveBeenCalledOnce();
+  });
+
+  it.each([false, true])("bounds source-race retries and recovers only complete pages (exhausted=%s)", async (exhausted) => {
+    vi.useFakeTimers();
+    mount();
+    const race = new Error("SQLite Library changed while optimistic fields were loading");
+    const openReader = vi.fn<NonNullable<PlatformConfig["openBoundedFeedReader"]>>()
+      .mockRejectedValue(race);
+    if (!exhausted) {
+      openReader.mockRejectedValueOnce(race).mockResolvedValueOnce({
+        totalCount: 1,
+        readNext: async () => [item("complete")],
+        close: async () => undefined,
+      });
+    }
+    let current: ReturnType<typeof useBoundedFeedItems> | null = null;
+    try {
+      await act(async () => {
+        root!.render(<Harness openReader={openReader} onReady={(value) => { current = value; }} />);
+      });
+      expect(current?.feed.status).toBe("loading");
+      await act(async () => { await vi.advanceTimersByTimeAsync(250); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(500); });
+      await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+      expect(openReader).toHaveBeenCalledTimes(exhausted ? 3 : 2);
+      expect(current?.feed.status).toBe(exhausted ? "failed" : "ready");
+      expect(current?.feed.items.map((entry) => entry.globalId)).toEqual(exhausted ? [] : ["complete"]);
+      if (exhausted) {
+        openReader.mockResolvedValue({ totalCount: 0, readNext: async () => [], close: async () => undefined });
+        await act(async () => { current?.retry(); });
+        expect(current?.feed.status).toBe("ready");
+        expect(openReader).toHaveBeenCalledTimes(4);
+      }
+    } finally { vi.useRealTimers(); }
+  });
+
+  it("cancels a scheduled source-race retry on unmount", async () => {
+    vi.useFakeTimers();
+    mount();
+    const openReader = vi.fn().mockRejectedValue(new Error("SQLite Library changed while optimistic fields were loading"));
+    try {
+      await act(async () => { root!.render(<Harness openReader={openReader} onReady={() => undefined} />); });
+      await act(async () => { root!.unmount(); });
+      root = null;
+      await act(async () => { await vi.advanceTimersByTimeAsync(5_000); });
+      expect(openReader).toHaveBeenCalledOnce();
+    } finally { vi.useRealTimers(); }
   });
 
   it("replaces and closes the reader when the authoritative source changes", async () => {

--- a/packages/ui/src/components/feed/useBoundedFeedItems.ts
+++ b/packages/ui/src/components/feed/useBoundedFeedItems.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { addDebugEvent } from "../../lib/debug-store.js";
 import type { FeedItem, FilterOptions } from "@freed/shared";
 import type {
   BoundedFeedPage,
@@ -67,10 +68,13 @@ export function useBoundedFeedItems({
   sourceVersion: number;
 }): {
   readonly feed: BoundedFeedItemsState;
+  retry(): void;
   loadMore(): void;
   loadPrevious(): void;
   patchItems(update: (item: FeedItem) => FeedItem | null): void;
 } {
+  const [retryVersion, setRetryVersion] = useState(0);
+  const retry = useCallback(() => setRetryVersion((value) => value + 1), []);
   const readerRef = useRef<BoundedFeedReader | null>(null);
   const loadRef = useRef<Promise<void> | null>(null);
   const pagesRef = useRef<ResidentPage[]>([]);
@@ -125,6 +129,8 @@ export function useBoundedFeedItems({
 
   useEffect(() => {
     let cancelled = false;
+    let attempts = 0;
+    let retryTimer: ReturnType<typeof setTimeout> | null = null;
     let openedReader: BoundedFeedReader | null = null;
     loadRef.current = null;
     resetWindow();
@@ -145,75 +151,92 @@ export function useBoundedFeedItems({
       hasMore: false,
       hasPrevious: false,
     }));
-    void openReader(activeFilter, rankingClockMs)
-      .then(async (reader) => {
-        openedReader = reader;
-        if (cancelled) {
-          await closeReader(reader);
-          return;
-        }
-        readerRef.current = reader;
-        const firstPage: BoundedFeedPage = reader.readPage
-          ? await reader.readPage(null, "next")
-          : {
-              items: await reader.readNext(),
-              nextCursor: null,
-              previousCursor: null,
-            };
-        if (cancelled || readerRef.current !== reader) {
-          await closeReader(reader);
-          return;
-        }
-        if (
-          firstPage.items.length > maxPageItems ||
-          firstPage.items.length > reader.totalCount ||
-          (firstPage.items.length === 0 && reader.totalCount > 0)
-        ) {
-          readerRef.current = null;
-          resetWindow();
-          await closeReader(reader);
-          setFeed({
-            status: "failed",
-            items: [],
-            hasMore: false,
-            hasPrevious: false,
-            windowStartIndex: 0,
-            totalCount: 0,
-          });
-          return;
-        }
-        pagesRef.current = [
-          {
-            items: [...firstPage.items],
-            sourceCount: firstPage.items.length,
-            previousCursor: firstPage.previousCursor,
-            nextCursor: firstPage.nextCursor,
-          },
-        ];
-        windowStartIndexRef.current = 0;
-        windowEndIndexRef.current = firstPage.items.length;
-        publishWindow(reader.totalCount);
-      })
-      .catch(() => {
-        const failedReader = openedReader;
-        openedReader = null;
-        if (failedReader) void closeReader(failedReader);
-        if (!cancelled) {
-          readerRef.current = null;
-          resetWindow();
-          setFeed({
-            status: "failed",
-            items: [],
-            hasMore: false,
-            hasPrevious: false,
-            windowStartIndex: 0,
-            totalCount: 0,
-          });
-        }
-      });
+    const openPage = () => {
+      attempts += 1;
+      void openReader(activeFilter, rankingClockMs)
+        .then(async (reader) => {
+          openedReader = reader;
+          if (cancelled) {
+            await closeReader(reader);
+            return;
+          }
+          readerRef.current = reader;
+          const firstPage: BoundedFeedPage = reader.readPage
+            ? await reader.readPage(null, "next")
+            : {
+                items: await reader.readNext(),
+                nextCursor: null,
+                previousCursor: null,
+              };
+          if (cancelled || readerRef.current !== reader) {
+            await closeReader(reader);
+            return;
+          }
+          if (
+            firstPage.items.length > maxPageItems ||
+            firstPage.items.length > reader.totalCount ||
+            (firstPage.items.length === 0 && reader.totalCount > 0)
+          ) {
+            readerRef.current = null;
+            resetWindow();
+            await closeReader(reader);
+            setFeed({
+              status: "failed",
+              items: [],
+              hasMore: false,
+              hasPrevious: false,
+              windowStartIndex: 0,
+              totalCount: 0,
+            });
+            return;
+          }
+          pagesRef.current = [
+            {
+              items: [...firstPage.items],
+              sourceCount: firstPage.items.length,
+              previousCursor: firstPage.previousCursor,
+              nextCursor: firstPage.nextCursor,
+            },
+          ];
+          windowStartIndexRef.current = 0;
+          windowEndIndexRef.current = firstPage.items.length;
+          publishWindow(reader.totalCount);
+          if (attempts > 1) {
+            addDebugEvent("change", `[feed-reader] source race recovered after ${attempts.toLocaleString()} attempts`);
+          }
+        })
+        .catch((error: unknown) => {
+          const failedReader = openedReader;
+          openedReader = null;
+          if (failedReader) void closeReader(failedReader);
+          if (!cancelled) {
+            readerRef.current = null;
+            const message = error instanceof Error ? error.message : String(error);
+            // Retry only a recognized source race, always from a fresh reader.
+            // Never accept rows and overlays from different SQLite revisions.
+            const sourceRace = message === "SQLite Library changed while optimistic fields were loading" || message.includes("CURSOR_STALE");
+            if (sourceRace && attempts < 3) {
+              retryTimer = setTimeout(openPage, attempts * 250);
+              return;
+            }
+            addDebugEvent("error", `[feed-reader] open failed category=${sourceRace ? "source-race" : "query"} attempts=${attempts.toLocaleString()}`);
+            resetWindow();
+            setFeed({
+              status: "failed",
+              items: [],
+              hasMore: false,
+              hasPrevious: false,
+              windowStartIndex: 0,
+              totalCount: 0,
+            });
+          }
+        });
+    };
+    openPage();
 
     return () => {
       cancelled = true;
+      if (retryTimer !== null) clearTimeout(retryTimer);
       const reader = readerRef.current;
       readerRef.current = null;
       if (reader) void closeReader(reader);
@@ -229,6 +252,7 @@ export function useBoundedFeedItems({
     rankingClockMs,
     resetWindow,
     sourceVersion,
+    retryVersion,
   ]);
 
   const loadMore = useCallback(() => {
@@ -386,5 +410,5 @@ export function useBoundedFeedItems({
     [],
   );
 
-  return { feed, loadMore, loadPrevious, patchItems };
+  return { feed, retry, loadMore, loadPrevious, patchItems };
 }


### PR DESCRIPTION
(AI Generated).

SQLite state reloads reconstructed unchanged preferences, which notified weight watchers and queued another ranking pass when the previous pass completed. Reuse equal preference branches, while preserving real edits and deletions, to stop this feedback loop.

Feed readers now retry a recognized SQLite source race at most three times. A failed query shows a retry action instead of the empty-Library welcome screen. Source fences and bounded page limits remain enforced.

Validation: reproduced false weight notifications before the fix; focused store and ranking tests pass; feed hook tests cover recovery, exhaustion and cancellation; a headless browser test forces a query failure and restores visible cards with Retry. Full feature validation includes Desktop and PWA builds, unit suites, provider fixtures and startup smoke tests.

The local native app compiles and opens the existing Library, but its unsigned identity cannot access the existing actor signing key. Runtime CPU effect requires verification with the signed dev artifact. No provider requests, cadence, authentication or extraction behavior changes.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `7a7beead6554f0cb1597258596eb3df578a02c99`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `feed-cpu-20260906`
- Provider review decision: `diff_authorized`
- Provider review artifact: `3c5814ac8283c1cc798f3bec0993de649fd47b1705d85cbd67fe121478724053`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Provider requests, navigation, capture cadence, retries, authentication, cookies, headers and extraction are unchanged. The classified store path reuses equal decoded preference branches so unchanged values do not masquerade as new ranking weights. Real preference changes still notify subscribers.
- Fingerprinting risk: No new provider behavior. Native provider and scheduler implementations are unchanged.
- Lowest profile alternative: Keep provider behavior unchanged and validate preference identity plus feed recovery using offline fixtures.

Files bound into this provider review:
- `packages/desktop/src/lib/store.ts`