### PR TITLE
fix: preserve Darwin automation history replay

### DIFF
--- a/docs/AUTOMATION-CONTROL-PLANE.md
+++ b/docs/AUTOMATION-CONTROL-PLANE.md
@@ -1650,6 +1650,19 @@ prepared, replaced, or audited transaction keeps outcome-ledger health false
 until recovery reaches `complete`, so a crash cannot quietly reopen the global
 behavior slot.
 
+Completed transaction replay permits one Darwin-specific identity transition.
+APFS may renumber its device after a reboot or operating system update while
+preserving the same directories and inodes. A completed repair remains valid
+only when both recorded parent directories shared one device, both current
+parents share one device, and each parent's inode, mode, and owner still match
+exactly. Completed lease evidence uses the same narrow rule: a historical
+device is accepted only from a completed, same-token credential source inside
+the automation state root, while the archived inode, mode, ownership, content,
+and namespace digest remain exact. This exception does not apply to Linux or
+to fenced, prepared, replaced, or audited transactions. Current filesystem
+admission and all active transaction generation checks continue to require one
+exact local device.
+
 Use the dedicated CLI. Plan before acquiring the owner lease:
 
 ```bash

--- a/scripts/automation-control.test.mjs
+++ b/scripts/automation-control.test.mjs
@@ -49,6 +49,7 @@ import {
   appendOutcomeControlEvent,
   automationControlPaths,
   bindPublisherLeaseHead as bindPublisherLeaseHeadLive,
+  completedDarwinLeaseHistoricalDevices,
   conservativeLeaseCleanupArchiveReservation,
   consumeLeaseArchiveHelperInvocationCountForTest,
   consumeLeaseCleanupRequirementsForTest,
@@ -135,6 +136,64 @@ import {
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_PATH = path.join(__dirname, "automation-control.mjs");
 const ACTOR_CONTROL_PATH = path.join(__dirname, "automation-actor-control.mjs");
+
+test("completed Darwin lease history admits only state-root device evidence", () => {
+  const stateRoot = "/private/state";
+  const target = {
+    phase: "complete",
+    tokenDigest: "a".repeat(64),
+    capability: null,
+  };
+  const related = [
+    {
+      phase: "complete",
+      tokenDigest: target.tokenDigest,
+      capability: {
+        sourceDevice: "16777234",
+        sourcePath: `${stateRoot}/confirmations/owner.json`,
+      },
+    },
+    {
+      phase: "complete",
+      tokenDigest: "b".repeat(64),
+      capability: {
+        sourceDevice: "23",
+        sourcePath: `${stateRoot}/other.json`,
+      },
+    },
+    {
+      phase: "complete",
+      tokenDigest: target.tokenDigest,
+      capability: {
+        sourceDevice: "24",
+        sourcePath: "/private/unrelated/owner.json",
+      },
+    },
+  ];
+
+  assert.deepEqual(
+    completedDarwinLeaseHistoricalDevices(target, related, {
+      platform: "darwin",
+      stateRoot,
+    }),
+    ["16777234"],
+  );
+  assert.deepEqual(
+    completedDarwinLeaseHistoricalDevices(target, related, {
+      platform: "linux",
+      stateRoot,
+    }),
+    [],
+  );
+  assert.deepEqual(
+    completedDarwinLeaseHistoricalDevices(
+      { ...target, phase: "prepared" },
+      related,
+      { platform: "darwin", stateRoot },
+    ),
+    [],
+  );
+});
 
 function acquireLeaseLive(options) {
   const policy = AUTOMATION_ACTOR_POLICIES[options.owner];

--- a/scripts/lib/automation-control.mjs
+++ b/scripts/lib/automation-control.mjs
@@ -15104,6 +15104,77 @@ function leaseStateDirectoryGenerationDigest(
   });
 }
 
+function identityWithDevice(identity, device) {
+  return Object.freeze({ ...identity, dev: BigInt(device) });
+}
+
+function pathIsWithinRoot(filePath, rootPath) {
+  if (typeof filePath !== "string" || !path.isAbsolute(filePath)) return false;
+  const relative = path.relative(rootPath, filePath);
+  return (
+    relative === "" ||
+    (!relative.startsWith("..") && !path.isAbsolute(relative))
+  );
+}
+
+export function completedDarwinLeaseHistoricalDevices(
+  transaction,
+  relatedTransactions = [],
+  { platform = process.platform, stateRoot } = {},
+) {
+  if (
+    platform !== "darwin" ||
+    transaction?.phase !== "complete" ||
+    typeof stateRoot !== "string" ||
+    !path.isAbsolute(stateRoot)
+  ) {
+    return Object.freeze([]);
+  }
+  const tokenDigest = transaction.tokenDigest;
+  const devices = new Set();
+  for (const candidate of [transaction, ...relatedTransactions]) {
+    const capability = candidate?.capability;
+    if (
+      candidate?.phase !== "complete" ||
+      candidate?.tokenDigest !== tokenDigest ||
+      capability === null ||
+      capability === undefined ||
+      !/^\d+$/.test(String(capability.sourceDevice ?? "")) ||
+      !pathIsWithinRoot(capability.sourcePath, stateRoot)
+    ) {
+      continue;
+    }
+    devices.add(String(capability.sourceDevice));
+  }
+  return Object.freeze([...devices].sort());
+}
+
+function leaseStateDirectoryGenerationNameMatches(
+  entryName,
+  namespace,
+  paths,
+  transaction,
+  purpose,
+  directoryIdentity,
+  descriptor,
+  historicalDevices = [],
+) {
+  const devices = [
+    directoryIdentity.dev.toString(),
+    ...historicalDevices.map(String),
+  ];
+  return [...new Set(devices)].some((device) => {
+    const digest = leaseStateDirectoryGenerationDigest(
+      paths,
+      transaction,
+      purpose,
+      identityWithDevice(directoryIdentity, device),
+      descriptor,
+    );
+    return entryName === `${namespace}.${digest}.lease`;
+  });
+}
+
 function readBoundedLeaseDirectoryEntries(
   directoryPath,
   {
@@ -18150,6 +18221,7 @@ function admitParsedLeaseCleanupEvidence(
   archiveScope,
   directory,
   selected,
+  historicalDevices = [],
 ) {
   const snapshot = privateBatchFileSnapshot(selected);
   const quarantinePath = path.join(directory.path, selected.name);
@@ -18168,6 +18240,7 @@ function admitParsedLeaseCleanupEvidence(
       quarantinePath,
       specification,
       snapshot,
+      historicalDevices,
     ),
   );
   if (atomicMatches.length > 1) {
@@ -18248,6 +18321,7 @@ function admitParsedLeaseCleanupEvidence(
         quarantinePath,
         originalPath,
         snapshot,
+        historicalDevices,
       )
     ) {
       throw new AutomationControlError(
@@ -18285,6 +18359,7 @@ function admitParsedLeaseCleanupEvidence(
       quarantinePath,
       spec.filePath,
       snapshot,
+      historicalDevices,
     ),
   );
   if (matches.length !== 1) {
@@ -19003,6 +19078,21 @@ function inspectLeaseTransactionEventHistoryInternal({
         transaction,
       ]),
     );
+    const relatedTransactions = validatedTransactions.map(
+      (entry) => entry.transaction,
+    );
+    const historicalDevicesByOperationId = new Map(
+      validatedTransactions.map(({ transaction }) => [
+        transaction.operationId,
+        completedDarwinLeaseHistoricalDevices(
+          transaction,
+          relatedTransactions,
+          {
+            stateRoot: paths.stateRoot,
+          },
+        ),
+      ]),
+    );
     const admittedParsedCleanupEvidence = new Map();
     if (topologyReady && pendingTransactionArtifactCount === 0) {
       for (const archiveScope of ["transaction", "receipt"]) {
@@ -19040,6 +19130,7 @@ function inspectLeaseTransactionEventHistoryInternal({
                   archiveScope,
                   directory,
                   selected,
+                  historicalDevicesByOperationId.get(operationId) ?? [],
                 );
                 const operationEvidence =
                   admittedParsedCleanupEvidence.get(operationId) ?? [];
@@ -19112,14 +19203,18 @@ function inspectLeaseTransactionEventHistoryInternal({
           recordDigest: candidate.record?.digest ?? null,
           recordSize: Number(candidate.record?.size ?? 0),
         });
-        const expectedDigest = leaseStateDirectoryGenerationDigest(
-          paths,
-          transaction,
-          "release",
-          privateBatchDirectoryIdentity(candidate),
-          descriptor,
-        );
-        if (candidate.name !== `${namespace}.${expectedDigest}.lease`) {
+        if (
+          !leaseStateDirectoryGenerationNameMatches(
+            candidate.name,
+            namespace,
+            paths,
+            transaction,
+            "release",
+            privateBatchDirectoryIdentity(candidate),
+            descriptor,
+            historicalDevicesByOperationId.get(transaction.operationId) ?? [],
+          )
+        ) {
           issues.push(
             `lease transaction receipt ${transaction.operationId} retired authority directory changed generation`,
           );
@@ -30678,21 +30773,37 @@ function leaseCleanupQuarantinePathMatches(
   filePath,
   cleanupOperationId,
   snapshot,
+  historicalDevices = [],
 ) {
-  if (
-    leaseCleanupQuarantinePath(filePath, cleanupOperationId, snapshot) ===
-    archivePath
-  ) {
-    return true;
+  for (const device of [
+    snapshot.identity.dev.toString(),
+    ...historicalDevices.map(String),
+  ]) {
+    const candidate = Object.freeze({
+      ...snapshot,
+      identity: identityWithDevice(snapshot.identity, device),
+    });
+    if (
+      leaseCleanupQuarantinePath(filePath, cleanupOperationId, candidate) ===
+      archivePath
+    ) {
+      return true;
+    }
+    const legacyDigest = legacyLeaseCleanupGenerationDigest(
+      filePath,
+      candidate,
+    );
+    if (
+      legacyDigest !== null &&
+      path.join(
+        leaseCleanupQuarantineDirectory(filePath),
+        `${cleanupOperationId}.${legacyDigest}.json`,
+      ) === archivePath
+    ) {
+      return true;
+    }
   }
-  const legacyDigest = legacyLeaseCleanupGenerationDigest(filePath, snapshot);
-  return (
-    legacyDigest !== null &&
-    path.join(
-      leaseCleanupQuarantineDirectory(filePath),
-      `${cleanupOperationId}.${legacyDigest}.json`,
-    ) === archivePath
-  );
+  return false;
 }
 
 function leaseAtomicArchiveSpecifications(paths, transaction, archiveScope) {
@@ -30806,31 +30917,44 @@ function leaseAtomicArchiveSpecificationMatches(
   archivePath,
   specification,
   snapshot,
+  historicalDevices = [],
 ) {
   const archiveDirectory = path.dirname(archivePath);
-  const currentDigest = leaseCleanupGenerationDigest(
-    specification.temporaryPath,
-    snapshot,
-  );
-  if (
-    path.join(
-      archiveDirectory,
-      `${specification.selectionPrefix}.${currentDigest}.json`,
-    ) === archivePath
-  ) {
-    return true;
+  for (const device of [
+    snapshot.identity.dev.toString(),
+    ...historicalDevices.map(String),
+  ]) {
+    const candidate = Object.freeze({
+      ...snapshot,
+      identity: identityWithDevice(snapshot.identity, device),
+    });
+    const currentDigest = leaseCleanupGenerationDigest(
+      specification.temporaryPath,
+      candidate,
+    );
+    if (
+      path.join(
+        archiveDirectory,
+        `${specification.selectionPrefix}.${currentDigest}.json`,
+      ) === archivePath
+    ) {
+      return true;
+    }
+    const legacyDigest = legacyLeaseCleanupGenerationDigest(
+      specification.temporaryPath,
+      candidate,
+    );
+    if (
+      legacyDigest !== null &&
+      path.join(
+        archiveDirectory,
+        `${specification.selectionPrefix}.${legacyDigest}.json`,
+      ) === archivePath
+    ) {
+      return true;
+    }
   }
-  const legacyDigest = legacyLeaseCleanupGenerationDigest(
-    specification.temporaryPath,
-    snapshot,
-  );
-  return (
-    legacyDigest !== null &&
-    path.join(
-      archiveDirectory,
-      `${specification.selectionPrefix}.${legacyDigest}.json`,
-    ) === archivePath
-  );
+  return false;
 }
 
 function leaseCleanupArchivePrefixes(paths, transaction, archiveScope) {
@@ -30851,6 +30975,7 @@ function leaseCleanupQuarantinePathMatchesTransaction(
   archivePath,
   filePath,
   snapshot,
+  historicalDevices = [],
 ) {
   if (
     leaseCleanupQuarantinePathMatches(
@@ -30858,6 +30983,7 @@ function leaseCleanupQuarantinePathMatchesTransaction(
       filePath,
       transaction.operationId,
       snapshot,
+      historicalDevices,
     )
   ) {
     return true;
@@ -30880,7 +31006,12 @@ function leaseCleanupQuarantinePathMatchesTransaction(
   ).find((candidate) => candidate.target === "wal" && candidate.kind === "WAL");
   return (
     specification !== undefined &&
-    leaseAtomicArchiveSpecificationMatches(archivePath, specification, snapshot)
+    leaseAtomicArchiveSpecificationMatches(
+      archivePath,
+      specification,
+      snapshot,
+      historicalDevices,
+    )
   );
 }
 

--- a/scripts/lib/outcome-ledger-repair-validation.mjs
+++ b/scripts/lib/outcome-ledger-repair-validation.mjs
@@ -388,13 +388,25 @@ function requireIdentityRecord(value, label, { allowedModes = [0o600] } = {}) {
   };
 }
 
-function identityMatchesFile(identity, file, expectedBytes, { prefix = false } = {}) {
+export function repairPublicationIdentityMatchesFile(
+  identity,
+  file,
+  expectedBytes,
+  {
+    prefix = false,
+    allowDarwinDeviceRenumbering = false,
+    platform = process.platform,
+  } = {},
+) {
   const contentMatches = prefix
     ? file.bytes.length >= expectedBytes.length &&
       file.bytes.subarray(0, expectedBytes.length).equals(expectedBytes)
     : file.bytes.equals(expectedBytes);
+  const deviceMatches =
+    file.identity.dev === identity.device ||
+    (allowDarwinDeviceRenumbering && platform === "darwin");
   return (
-    file.identity.dev === identity.device &&
+    deviceMatches &&
     file.identity.ino === identity.inode &&
     file.identity.uid === identity.uid &&
     file.identity.mode === identity.mode &&
@@ -838,6 +850,41 @@ function requireBoundEventPlanParent(value, label) {
   return value;
 }
 
+function parentIdentityWithoutDevice(value) {
+  return { ino: value.ino, mode: value.mode, uid: value.uid };
+}
+
+export function repairEventPlanParentsMatch(
+  {
+    recordedHistoryParent,
+    currentHistoryParent,
+    recordedReplacementParent,
+    currentReplacementParent,
+    completedAdmission,
+  },
+  { platform = process.platform } = {},
+) {
+  const historyMatchesExactly =
+    stableJson(recordedHistoryParent) === stableJson(currentHistoryParent);
+  const replacementMatchesExactly =
+    stableJson(recordedReplacementParent) ===
+    stableJson(currentReplacementParent);
+  if (historyMatchesExactly && replacementMatchesExactly) return true;
+  if (!completedAdmission || platform !== "darwin") return false;
+  if (
+    recordedHistoryParent.dev !== recordedReplacementParent.dev ||
+    currentHistoryParent.dev !== currentReplacementParent.dev
+  ) {
+    return false;
+  }
+  return (
+    stableJson(parentIdentityWithoutDevice(recordedHistoryParent)) ===
+      stableJson(parentIdentityWithoutDevice(currentHistoryParent)) &&
+    stableJson(parentIdentityWithoutDevice(recordedReplacementParent)) ===
+      stableJson(parentIdentityWithoutDevice(currentReplacementParent))
+  );
+}
+
 function deterministicRepairEvent(plan, boundary) {
   return {
     schemaVersion: AUTOMATION_CONTROL_SCHEMA_VERSION,
@@ -959,10 +1006,13 @@ function validateBoundRepairEventPlan(plan, candidate, bundle, eventHistory) {
     (!plan.completedAdmission &&
       stableJson(candidate.replacementGeneration) !==
         stableJson(currentReplacementGeneration)) ||
-    stableJson(candidate.replacementParent) !==
-      stableJson(currentReplacementParent) ||
-    stableJson(candidate.historyParent) !==
-      stableJson(currentHistoryParent)
+    !repairEventPlanParentsMatch({
+      recordedHistoryParent: candidate.historyParent,
+      currentHistoryParent,
+      recordedReplacementParent: candidate.replacementParent,
+      currentReplacementParent,
+      completedAdmission: plan.completedAdmission,
+    })
   ) {
     throw new Error("repair event plan authority generations changed");
   }
@@ -1365,7 +1415,12 @@ function validateLedgerPublication(plan, bundle, tree, material, allowed) {
   if (archive !== null) allowed.add(expectedIntent.archiveName);
   const archiveIsSource =
     archive !== null &&
-    identityMatchesFile(predecessor, archive, material.source.bytes);
+    repairPublicationIdentityMatchesFile(
+      predecessor,
+      archive,
+      material.source.bytes,
+      { allowDarwinDeviceRenumbering: plan.completedAdmission },
+    );
   const canonicalIsSource =
     sourceLedger &&
     ledger.identity.dev === predecessor.device &&
@@ -1745,11 +1800,29 @@ function validateTransitionLineage(plan, canonical, tree, allowed) {
     );
     if (archive !== null) allowed.add(expectedIntent.archiveName);
     const archiveIsPredecessor =
-      archive !== null && identityMatchesFile(predecessor, archive, predecessorBytes);
+      archive !== null &&
+      repairPublicationIdentityMatchesFile(
+        predecessor,
+        archive,
+        predecessorBytes,
+        { allowDarwinDeviceRenumbering: plan.completedAdmission },
+      );
     const stagingIsPredecessor =
-      staging !== null && identityMatchesFile(predecessor, staging, predecessorBytes);
+      staging !== null &&
+      repairPublicationIdentityMatchesFile(
+        predecessor,
+        staging,
+        predecessorBytes,
+        { allowDarwinDeviceRenumbering: plan.completedAdmission },
+      );
     const stagingIsSuccessor =
-      staging !== null && identityMatchesFile(successor, staging, successorBytes);
+      staging !== null &&
+      repairPublicationIdentityMatchesFile(
+        successor,
+        staging,
+        successorBytes,
+        { allowDarwinDeviceRenumbering: plan.completedAdmission },
+      );
     if (index < currentIndex - 1) {
       if (!archiveIsPredecessor || staging !== null) {
         throw new Error(`transaction ${toPhase} predecessor is not durably archived`);
@@ -1760,14 +1833,28 @@ function validateTransitionLineage(plan, canonical, tree, allowed) {
       if (!finalized && !postExchange) {
         throw new Error(`transaction ${toPhase} recovery topology is invalid`);
       }
-      if (!identityMatchesFile(successor, canonical, successorBytes)) {
+      if (
+        !repairPublicationIdentityMatchesFile(
+          successor,
+          canonical,
+          successorBytes,
+          { allowDarwinDeviceRenumbering: plan.completedAdmission },
+        )
+      ) {
         throw new Error(`transaction ${toPhase} successor is not canonical`);
       }
     } else if (index === currentIndex) {
       if (archive !== null || !stagingIsSuccessor) {
         throw new Error(`transaction ${toPhase} pre-exchange topology is invalid`);
       }
-      if (!identityMatchesFile(predecessor, canonical, predecessorBytes)) {
+      if (
+        !repairPublicationIdentityMatchesFile(
+          predecessor,
+          canonical,
+          predecessorBytes,
+          { allowDarwinDeviceRenumbering: plan.completedAdmission },
+        )
+      ) {
         throw new Error(`transaction ${toPhase} predecessor is not canonical`);
       }
     } else {

--- a/scripts/outcome-ledger-repair.test.mjs
+++ b/scripts/outcome-ledger-repair.test.mjs
@@ -53,6 +53,10 @@ import {
   repairOutcomeLedger,
 } from "./lib/outcome-ledger-repair.mjs";
 import {
+  repairEventPlanParentsMatch,
+  repairPublicationIdentityMatchesFile,
+} from "./lib/outcome-ledger-repair-validation.mjs";
+import {
   OUTCOME_LEDGER_REPAIR_MAX_BYTES,
   OUTCOME_LEDGER_REPAIR_MAX_LINE_BYTES,
   OUTCOME_LEDGER_REPAIR_MAX_LINES,
@@ -88,6 +92,128 @@ const MOVE_HELPER_PATH = path.join(
   "lib",
   "lease-archive-move.py",
 );
+
+test("completed Darwin repair replay admits only coherent device renumbering", () => {
+  const recordedHistoryParent = {
+    dev: "16777234",
+    ino: "101",
+    mode: 0o40700,
+    uid: 501,
+  };
+  const recordedReplacementParent = {
+    dev: "16777234",
+    ino: "202",
+    mode: 0o40700,
+    uid: 501,
+  };
+  const currentHistoryParent = {
+    ...recordedHistoryParent,
+    dev: "16777232",
+  };
+  const currentReplacementParent = {
+    ...recordedReplacementParent,
+    dev: "16777232",
+  };
+  const parents = {
+    recordedHistoryParent,
+    currentHistoryParent,
+    recordedReplacementParent,
+    currentReplacementParent,
+    completedAdmission: true,
+  };
+  assert.equal(
+    repairEventPlanParentsMatch(parents, { platform: "darwin" }),
+    true,
+  );
+  assert.equal(
+    repairEventPlanParentsMatch(parents, { platform: "linux" }),
+    false,
+  );
+  assert.equal(
+    repairEventPlanParentsMatch(
+      { ...parents, completedAdmission: false },
+      { platform: "darwin" },
+    ),
+    false,
+  );
+  assert.equal(
+    repairEventPlanParentsMatch(
+      {
+        ...parents,
+        currentReplacementParent: {
+          ...currentReplacementParent,
+          dev: "16777231",
+        },
+      },
+      { platform: "darwin" },
+    ),
+    false,
+  );
+  assert.equal(
+    repairEventPlanParentsMatch(
+      {
+        ...parents,
+        currentHistoryParent: { ...currentHistoryParent, ino: "999" },
+      },
+      { platform: "darwin" },
+    ),
+    false,
+  );
+
+  const bytes = Buffer.from("durable repair evidence\n", "utf8");
+  const identity = {
+    device: "16777234",
+    inode: "303",
+    uid: 501,
+    mode: 0o100600,
+    linkCount: 1,
+    size: bytes.length,
+    digest: createHash("sha256").update(bytes).digest("hex"),
+  };
+  const file = {
+    bytes,
+    identity: {
+      dev: "16777232",
+      ino: identity.inode,
+      uid: identity.uid,
+      mode: identity.mode,
+      nlink: identity.linkCount,
+      size: identity.size,
+    },
+  };
+  assert.equal(
+    repairPublicationIdentityMatchesFile(identity, file, bytes, {
+      allowDarwinDeviceRenumbering: true,
+      platform: "darwin",
+    }),
+    true,
+  );
+  assert.equal(
+    repairPublicationIdentityMatchesFile(identity, file, bytes, {
+      allowDarwinDeviceRenumbering: true,
+      platform: "linux",
+    }),
+    false,
+  );
+  assert.equal(
+    repairPublicationIdentityMatchesFile(
+      identity,
+      { ...file, identity: { ...file.identity, ino: "404" } },
+      bytes,
+      { allowDarwinDeviceRenumbering: true, platform: "darwin" },
+    ),
+    false,
+  );
+  assert.equal(
+    repairPublicationIdentityMatchesFile(
+      identity,
+      { ...file, bytes: Buffer.from("changed\n", "utf8") },
+      bytes,
+      { allowDarwinDeviceRenumbering: true, platform: "darwin" },
+    ),
+    false,
+  );
+});
 
 function sha256(value) {
   return createHash("sha256").update(value).digest("hex");


### PR DESCRIPTION
(AI Generated).

## Summary
- Keep completed outcome repair receipts valid when Darwin renumbers one APFS device while directory identity remains exact.
- Recover historical lease archive device identity only from completed same-token credential evidence inside the automation state root.
- Keep active transactions, non-Darwin platforms, unrelated tokens, inode changes, permission changes, ownership changes, content changes, and topology changes fail-closed.

## Testing
- Focused completed Darwin replay tests pass.
- Real retained control history reports zero identity issues and produces an exact outcome repair plan preserving all 3 entries.
- npm run validate:feature, 145 checks passed.