### PR TITLE
fix: bind soak samples to app executable

### DIFF
--- a/docs/SOAK-AND-TRIGGERS.md
+++ b/docs/SOAK-AND-TRIGGERS.md
@@ -25,7 +25,10 @@ An installed soak observes a real Freed Desktop build over hours using terminal 
   collector, recovers only a safely identified stale owner, and releases only
   its own lock token. It samples the app process, the machine-wide WebKit
   process table, and `runtime-health.jsonl` into a soak directory under
-  `~/.freed/automation/soaks/`. Each saved cursor binds the physical file
+  `~/.freed/automation/soaks/`. `--app-binary` matches the operating system
+  executable path, never its argument vector. The collector excludes its own
+  process tree and treats multiple matching application processes as a sample
+  error instead of guessing. Each saved cursor binds the physical file
   generation and a SHA-256 digest of the complete source prefix, so daily
   replacement or truncate-regrow cannot skip new records when the new file is
   already as large as the old offset. The collector points

--- a/scripts/soak-collect.mjs
+++ b/scripts/soak-collect.mjs
@@ -113,7 +113,7 @@ Options:
   --soak-dir <path>          Soak directory. Defaults to ~/.freed/automation/soaks/<timestamp>.
   --pointer <path>           Active-soak pointer file. Defaults to ~/.freed/automation/current-soak-dir.
   --app-data <path>          App data dir holding runtime-health.jsonl. Defaults to the installed Freed Desktop dir.
-  --app-binary <substring>   Main process match. Defaults to "Freed.app/Contents/MacOS".
+  --app-binary <substring>   Main executable path match. Defaults to "Freed.app/Contents/MacOS".
   --artifact-digest <sha256> Optional installed artifact digest to bind into evidence.
   --scenario <name>           Workload scenario for measured baseline comparability.
   --provider-cohort <id>      Provider cohort for measured baseline comparability.
@@ -242,7 +242,9 @@ export function parseArgs(argv, now = new Date()) {
   return args;
 }
 
-// Parses `ps axo pid=,ppid=,rss=,command=` output into rows.
+// Parses `ps axo pid=,ppid=,rss=,comm=` output into rows. `comm` is the
+// executable path, not the argument vector, so collector arguments cannot
+// impersonate the installed application.
 export function parsePsTable(psOutput) {
   return String(psOutput ?? "")
     .split("\n")
@@ -263,9 +265,37 @@ export function parsePsTable(psOutput) {
     .filter(Boolean);
 }
 
+export function collectorProcessTreePids(psRows, collectorPid) {
+  const excluded = new Set([collectorPid]);
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const row of psRows) {
+      if (!excluded.has(row.pid) && excluded.has(row.ppid)) {
+        excluded.add(row.pid);
+        changed = true;
+      }
+    }
+  }
+  return excluded;
+}
+
 // Builds one metrics row (plus the WebKit process sub-table) from a ps table.
-export function buildSample(psRows, { appBinary, tsMs }) {
-  const appRow = psRows.find((row) => row.command.includes(appBinary)) ?? null;
+export function buildSample(
+  psRows,
+  { appBinary, tsMs, collectorPid = process.pid },
+) {
+  const excludedPids = collectorProcessTreePids(psRows, collectorPid);
+  const appRows = psRows.filter(
+    (row) =>
+      !excludedPids.has(row.pid) && row.command.includes(appBinary),
+  );
+  if (appRows.length > 1) {
+    throw new Error(
+      `Freed Desktop process identity is ambiguous for ${appBinary}.`,
+    );
+  }
+  const appRow = appRows[0] ?? null;
   const webContent = psRows.filter((row) =>
     row.command.includes("com.apple.WebKit.WebContent"),
   );
@@ -996,7 +1026,7 @@ function waitForDetachedAcceptance(collectorLock, args) {
 function takeSample(args, cursor, now = Date.now()) {
   let psOutput = "";
   try {
-    psOutput = execFileSync("ps", ["axo", "pid=,ppid=,rss=,command="], {
+    psOutput = execFileSync("ps", ["axo", "pid=,ppid=,rss=,comm="], {
       encoding: "utf8",
       maxBuffer: 32 * 1024 * 1024,
     });

--- a/scripts/soak.test.mjs
+++ b/scripts/soak.test.mjs
@@ -273,6 +273,56 @@ test("parsePsTable and buildSample split app, WebContent, and other WebKit proce
   assert.equal(tsv.trim().split("\t").length, METRICS_COLUMNS.length);
 });
 
+test("soak collector excludes itself and descendants from app identity", () => {
+  const appBinary = "Freed Preview.app/Contents/MacOS/freed-desktop";
+  const rows = [
+    {
+      pid: 24584,
+      ppid: 1,
+      rssKb: 1_000,
+      command: "/Users/test/.nvm/bin/node",
+      arguments: `node soak-collect.mjs --app-binary ${appBinary}`,
+    },
+    {
+      pid: 24585,
+      ppid: 24584,
+      rssKb: 2_000,
+      command: `/Applications/${appBinary}`,
+    },
+    {
+      pid: 59726,
+      ppid: 1,
+      rssKb: 500_000,
+      command: `/Applications/${appBinary}`,
+    },
+  ];
+
+  const sample = buildSample(rows, {
+    appBinary,
+    collectorPid: 24584,
+    tsMs: 1_700_000_000_000,
+  });
+  assert.equal(sample.appPid, 59726);
+  assert.equal(sample.appRssKb, 500_000);
+
+  assert.throws(
+    () =>
+      buildSample(
+        [
+          ...rows,
+          {
+            pid: 59727,
+            ppid: 1,
+            rssKb: 400_000,
+            command: `/Volumes/Test/${appBinary}`,
+          },
+        ],
+        { appBinary, collectorPid: 24584, tsMs: 1_700_000_000_000 },
+      ),
+    /process identity is ambiguous/,
+  );
+});
+
 test("soak-collect parseArgs derives a soaks dir under ~/.freed/automation", () => {
   const args = parseCollectArgs([], new Date("2026-07-02T10:00:00Z"));
   assert.ok(args.soakDir.includes(path.join(".freed", "automation", "soaks")));


### PR DESCRIPTION
(AI Generated).

## Summary
- Match the installed application by operating-system executable path instead of the full argument vector.
- Exclude the collector PID and all descendants, and reject ambiguous application identities.
- Close issue #1770 with installed evidence that the collector PID no longer wins the custom app substring collision.

## Testing
- node --test scripts/soak.test.mjs, 64 tests passed.
- npm run validate:feature passed.
- Installed one-shot smoke recorded Freed Preview PID 95455 while collector PID 96058 closed cleanly.