### PR TITLE
feat: feature the live demo across the marketing site

### DIFF
--- a/website/src/app/changelog/ChangelogContent.tsx
+++ b/website/src/app/changelog/ChangelogContent.tsx
@@ -64,6 +64,16 @@ function PaginationNav({
   const router = useRouter();
   const toggleHref = mode === "all" ? "/changelog/prod" : "/changelog";
   const toggleLabel = mode === "all" ? "Hide dev releases" : "Show dev releases";
+  // Keep both ends reachable while reserving four slots around the active page.
+  const windowStart = Math.max(4, Math.min(currentPage - 1, totalPages - 6));
+  const pages = totalPages <= 10
+    ? Array.from({ length: totalPages }, (_, index) => index + 1)
+    : [1, 2, 3, ...Array.from({ length: 4 }, (_, index) => windowStart + index),
+      totalPages - 2, totalPages - 1, totalPages];
+  const pageEntries = pages.flatMap((page, index): Array<number | string> =>
+    index > 0 && page > pages[index - 1]! + 1
+      ? [`gap-${page}`, page]
+      : [page]);
 
   return (
     <nav
@@ -95,8 +105,10 @@ function PaginationNav({
         >
           {toggleLabel}
         </Link>
-        {Array.from({ length: totalPages }, (_, index) => {
-          const page = index + 1;
+        {pageEntries.map((page) => {
+          if (typeof page === "string") {
+            return <span key={page} className="px-1.5 py-1" aria-label="Skipped pages">…</span>;
+          }
           const isCurrent = page === currentPage;
           const label = page === 1 ? "Latest" : page.toLocaleString();
 

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -2,26 +2,25 @@ import Hero from "@/components/Hero";
 import Features from "@/components/Features";
 import HowItWorks from "@/components/HowItWorks";
 import CTA from "@/components/CTA";
+import DemoLink from "@/components/DemoLink";
 
 export default function LandingPage() {
+  // Local review can use newly captured assets without publishing a release.
+  const showcaseBase = process.env.NODE_ENV === "development"
+    ? process.env.FREED_SHOWCASE_PREVIEW_BASE_URL || "https://github.com/freed-project/freed/releases/latest/download"
+    : "https://github.com/freed-project/freed/releases/latest/download";
   return (
     <>
       <Hero />
-      <section className="mx-auto max-w-6xl px-4 py-12 sm:px-6" aria-labelledby="demo-heading">
-        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
-          <div>
-            <h2 id="demo-heading" className="theme-display-large text-3xl font-bold">See Freed in action</h2>
-            <p className="mt-2 text-text-secondary">Explore the feed, Stories, map, and Friends with sample content.</p>
-          </div>
-          <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary whitespace-nowrap">Experience the live demo</a>
-        </div>
-        <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" aria-label="Open the full Freed demo in a new tab">
+      <section className="mx-auto max-w-4xl px-4 py-12 sm:px-6" aria-label="Try Freed live">
+        <DemoLink className="demo-showcase" aria-label="Try Freed live in a new tab">
           <picture>
-            <source media="(prefers-reduced-motion: reduce)" srcSet="https://github.com/freed-project/freed/releases/latest/download/freed-showcase-unified-midas.png" />
+            <source media="(prefers-reduced-motion: reduce)" srcSet={`${showcaseBase}/freed-showcase-unified-midas.png`} />
             {/* Release assets are verified against their manifest before publication. */}
-            <img src="https://github.com/freed-project/freed/releases/latest/download/freed-showcase.gif" alt="Freed product preview showing Unified Feed, Stories, Instagram, Map, and Friends" width={1440} height={960} loading="lazy" className="h-auto w-full rounded-2xl border border-freed-border" />
+            <img src={`${showcaseBase}/freed-showcase.gif`} alt="Freed product preview showing its feed, reader, map, and Friends on desktop and mobile" width={1440} height={960} loading="lazy" className="h-auto w-full" />
           </picture>
-        </a>
+          <span className="btn-primary demo-showcase-caption">Try it live</span>
+        </DemoLink>
       </section>
       <Features />
       <HowItWorks />

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -7,6 +7,22 @@ export default function LandingPage() {
   return (
     <>
       <Hero />
+      <section className="mx-auto max-w-6xl px-4 py-12 sm:px-6" aria-labelledby="demo-heading">
+        <div className="mb-6 flex flex-wrap items-center justify-between gap-4">
+          <div>
+            <h2 id="demo-heading" className="theme-display-large text-3xl font-bold">See Freed in action</h2>
+            <p className="mt-2 text-text-secondary">Explore the feed, Stories, map, and Friends with sample content.</p>
+          </div>
+          <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary whitespace-nowrap">Experience the live demo</a>
+        </div>
+        <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" aria-label="Open the full Freed demo in a new tab">
+          <picture>
+            <source media="(prefers-reduced-motion: reduce)" srcSet="https://github.com/freed-project/freed/releases/latest/download/freed-showcase-unified-midas.png" />
+            {/* Release assets are verified against their manifest before publication. */}
+            <img src="https://github.com/freed-project/freed/releases/latest/download/freed-showcase.gif" alt="Freed product preview showing Unified Feed, Stories, Instagram, Map, and Friends" width={1440} height={960} loading="lazy" className="h-auto w-full rounded-2xl border border-freed-border" />
+          </picture>
+        </a>
+      </section>
       <Features />
       <HowItWorks />
       <CTA />

--- a/website/src/components/CTA.tsx
+++ b/website/src/components/CTA.tsx
@@ -67,27 +67,12 @@ export default function CTA() {
               transition={{ delay: 0.4 }}
               className="relative z-10 flex flex-col flex-wrap justify-center gap-3 sm:flex-row sm:gap-4"
             >
-              <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary text-base px-8 py-3 w-full sm:w-auto">
-                Try the live demo
-              </a>
-              <motion.button
-                whileHover={{ scale: 1.05 }}
-                whileTap={{ scale: 0.95 }}
-                onClick={() => openModal()}
-                className="btn-primary text-base px-8 py-3 w-full sm:w-auto"
-              >
-                Free Yourself
-              </motion.button>
-
-              <Link href="/manifesto" className="w-full sm:w-auto">
-                <motion.button
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
-                  className="btn-secondary text-base px-8 py-3 w-full"
-                >
-                  Why We Built This
-                </motion.button>
+              <Link href="/manifesto" className="btn-secondary text-base px-8 py-3 w-full sm:w-auto">
+                Why We Built This
               </Link>
+              <button onClick={() => openModal()} className="btn-primary text-base px-8 py-3 w-full sm:w-auto">
+                Free Yourself
+              </button>
             </motion.div>
 
             {/* <motion.p

--- a/website/src/components/CTA.tsx
+++ b/website/src/components/CTA.tsx
@@ -67,6 +67,9 @@ export default function CTA() {
               transition={{ delay: 0.4 }}
               className="relative z-10 flex flex-col flex-wrap justify-center gap-3 sm:flex-row sm:gap-4"
             >
+              <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary text-base px-8 py-3 w-full sm:w-auto">
+                Try the live demo
+              </a>
               <motion.button
                 whileHover={{ scale: 1.05 }}
                 whileTap={{ scale: 0.95 }}

--- a/website/src/components/DemoLink.tsx
+++ b/website/src/components/DemoLink.tsx
@@ -1,0 +1,9 @@
+"use client";
+
+import type { ComponentPropsWithoutRef } from "react";
+import { useTheme } from "@/context/ThemeContext";
+
+export default function DemoLink(props: Omit<ComponentPropsWithoutRef<"a">, "href">) {
+  const { themeId } = useTheme();
+  return <a {...props} href={`https://demo.freed.wtf/?theme=${encodeURIComponent(themeId)}`} target="_blank" rel="noopener noreferrer" />;
+}

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -56,6 +56,9 @@ export default function Footer() {
                   <FooterLink href="/changelog">Updates</FooterLink>
                 </li>
                 <li>
+                  <FooterLink href="https://demo.freed.wtf" target="_blank">Live demo</FooterLink>
+                </li>
+                <li>
                   <FooterLink href="/get">Get Freed</FooterLink>
                 </li>
               </ul>

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import DemoLink from "./DemoLink";
 import FooterLink from "@/components/FooterLink";
 import ThemeSelector from "@/components/ThemeSelector";
 
@@ -56,7 +57,7 @@ export default function Footer() {
                   <FooterLink href="/changelog">Updates</FooterLink>
                 </li>
                 <li>
-                  <FooterLink href="https://demo.freed.wtf" target="_blank">Live demo</FooterLink>
+                  <DemoLink className="relative inline-flex items-center text-sm text-text-secondary transition-colors hover:text-text-primary">Live demo</DemoLink>
                 </li>
                 <li>
                   <FooterLink href="/get">Get Freed</FooterLink>

--- a/website/src/components/FooterLink.tsx
+++ b/website/src/components/FooterLink.tsx
@@ -18,9 +18,11 @@ function isCurrentPath(href: string, pathname: string): boolean {
 export default function FooterLink({
   children,
   href,
+  target,
 }: {
   children: ReactNode;
   href: string;
+  target?: "_blank";
 }) {
   const pathname = usePathname();
   const isCurrent = isCurrentPath(href, pathname);
@@ -29,6 +31,8 @@ export default function FooterLink({
   return (
     <Link
       href={href}
+      target={target}
+      rel={target === "_blank" ? "noopener noreferrer" : undefined}
       aria-current={isCurrent ? "page" : undefined}
       onMouseEnter={() => setIsHovered(true)}
       onMouseLeave={() => setIsHovered(false)}

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -263,6 +263,9 @@ export default function Hero() {
           )}
 
           <div className="hidden flex-col flex-wrap justify-center gap-3 lg:flex lg:flex-row lg:justify-start lg:gap-4">
+            <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary inline-flex items-center justify-center text-base px-8 py-3 w-full sm:w-auto">
+              Live demo
+            </a>
             <motion.button
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.98 }}

--- a/website/src/components/Hero.tsx
+++ b/website/src/components/Hero.tsx
@@ -2,6 +2,7 @@
 
 import { motion, AnimatePresence } from "framer-motion";
 import Link from "next/link";
+import DemoLink from "./DemoLink";
 import { useState, useEffect, type FormEvent } from "react";
 import {
   FaArrowRight,
@@ -262,35 +263,19 @@ export default function Hero() {
             </form>
           )}
 
-          <div className="hidden flex-col flex-wrap justify-center gap-3 lg:flex lg:flex-row lg:justify-start lg:gap-4">
-            <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary inline-flex items-center justify-center text-base px-8 py-3 w-full sm:w-auto">
+          <div className="demo-action-pair mx-auto mt-5 w-fit text-sm sm:text-base lg:mx-0">
+            <DemoLink className="demo-action demo-action-outline">
               Live demo
-            </a>
-            <motion.button
-              whileHover={{ scale: 1.05 }}
-              whileTap={{ scale: 0.98 }}
-              onClick={() => openModal()}
-              className="btn-primary inline-flex items-center justify-center gap-2 text-base px-8 py-3 w-full sm:w-auto"
-            >
-              Get Freed
-              <FaArrowRight aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
-            </motion.button>
-
-            <Link href="/changelog" className="w-full sm:w-auto">
-              <motion.button
-                whileHover={{ scale: 1.02 }}
-                whileTap={{ scale: 0.98 }}
-                className="btn-secondary inline-flex items-center justify-center gap-2 text-base px-8 py-3 w-full"
-              >
+            </DemoLink>
+            <Link href="/changelog" className="demo-action demo-action-outline gap-2">
                 Latest Updates
                 <FaWaveSquare aria-hidden="true" className="h-3.5 w-3.5 shrink-0" />
-              </motion.button>
             </Link>
           </div>
 
           {/* Stats */}
-          <div className="mt-6 flex justify-center gap-6 border-t border-freed-border pt-5 sm:mt-12 sm:gap-8 sm:pt-8 lg:justify-start">
-            <div className="text-center lg:text-left">
+          <div className="mt-6 flex justify-center gap-6 pt-5 sm:mt-12 sm:gap-8 sm:pt-8 lg:justify-start">
+            <div className="text-center">
               <p
                 className="text-2xl sm:text-3xl font-bold"
                 style={{ color: "var(--theme-metric-value)" }}
@@ -301,7 +286,7 @@ export default function Hero() {
                 Local Storage
               </p>
             </div>
-            <div className="text-center lg:text-left">
+            <div className="text-center">
               <p
                 className="text-2xl sm:text-3xl font-bold"
                 style={{ color: "var(--theme-metric-value)" }}
@@ -312,7 +297,7 @@ export default function Hero() {
                 Data Collected
               </p>
             </div>
-            <div className="text-center lg:text-left">
+            <div className="text-center">
               <p
                 className="text-2xl sm:text-3xl font-bold"
                 style={{ color: "var(--theme-metric-value)" }}

--- a/website/src/components/HowItWorks.tsx
+++ b/website/src/components/HowItWorks.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { motion } from "framer-motion";
 
 const steps = [
@@ -59,14 +58,6 @@ export default function HowItWorks() {
 
         {/* Steps */}
         <div className="relative">
-          <div
-            className="hidden xl:block absolute top-1/2 left-0 right-0 h-px -translate-y-1/2"
-            style={{
-              background:
-                "linear-gradient(to right, transparent, color-mix(in srgb, var(--theme-accent-secondary) 28%, transparent), transparent)",
-            }}
-          />
-
           <div className="grid grid-cols-1 gap-4 sm:gap-8 lg:grid-cols-2 xl:grid-cols-4">
             {steps.map((step, index) => (
               <motion.div
@@ -94,22 +85,22 @@ export default function HowItWorks() {
                   </p>
                 </div>
 
-                {/* Connector dot */}
+                {/* Draw only in the grid gap, sharing the dot's centerline.
+                    Both disappear when the four cards wrap below xl. */}
                 {index < steps.length - 1 && (
                   <div
-                    className="hidden xl:block absolute top-1/2 -right-5 h-2 w-2 rounded-full glow-sm -translate-y-1/2 z-20"
-                    style={{ background: "var(--theme-heading-accent)" }}
-                  />
+                    aria-hidden="true"
+                    className="pointer-events-none hidden xl:block absolute top-1/2 left-full h-px w-8 -translate-y-1/2"
+                    style={{ background: "color-mix(in srgb, var(--theme-accent-secondary) 28%, transparent)" }}
+                  >
+                    <span className="absolute left-1/2 top-1/2 h-2 w-2 -translate-x-1/2 -translate-y-1/2 rounded-full glow-sm"
+                      style={{ background: "var(--theme-heading-accent)" }} />
+                  </div>
                 )}
               </motion.div>
             ))}
           </div>
 
-          <div className="mt-8 flex justify-center sm:mt-12">
-            <Link href="/roadmap" className="btn-secondary px-6 py-3 text-sm">
-              See the roadmap
-            </Link>
-          </div>
         </div>
       </div>
     </section>

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import DemoLink from "./DemoLink";
 import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
@@ -206,12 +207,14 @@ export default function Navigation() {
         />
       )}
 
-      <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary text-sm !py-2 whitespace-nowrap">
-        Live demo
-      </a>
-      <button onClick={() => openModal()} className="btn-primary text-sm !py-2 whitespace-nowrap">
+      <div className="flex items-center gap-4 text-sm">
+      <DemoLink className="font-medium text-[var(--theme-accent-primary)] hover:underline underline-offset-4 whitespace-nowrap">
+        Live Demo
+      </DemoLink>
+      <button onClick={() => openModal()} className="btn-primary px-6 py-3 whitespace-nowrap">
         Get Freed
       </button>
+      </div>
     </div>
   );
 
@@ -293,12 +296,14 @@ export default function Navigation() {
           <div className="flex items-center justify-between">
             {logoElement}
             <div className="flex shrink-0 items-center gap-1.5">
-              <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary !px-2 !py-2 min-h-11 whitespace-nowrap text-xs">
-                Live demo
-              </a>
-              <button onClick={() => openModal()} className="btn-primary !px-2 !py-2 min-h-11 whitespace-nowrap text-xs">
+              <div className="flex items-center gap-2 text-xs">
+              <DemoLink className="font-medium text-[var(--theme-accent-primary)] hover:underline underline-offset-4 whitespace-nowrap">
+                Live Demo
+              </DemoLink>
+              <button onClick={() => openModal()} className="btn-primary px-3 py-2 whitespace-nowrap">
                 Get Freed
               </button>
+              </div>
               {mobileHamburger}
             </div>
           </div>
@@ -355,18 +360,19 @@ export default function Navigation() {
                   </motion.div>
                 ))}
 
-                <motion.button
+                <motion.div
                   initial={{ opacity: 0, y: 10 }}
                   animate={{ opacity: 1, y: 0 }}
                   transition={{ delay: 0.2, duration: 0.15 }}
-                  onClick={() => {
-                    openModal();
-                    setMobileMenuOpen(false);
-                  }}
-                  className="btn-primary text-[1.0125rem] px-12 py-4 mt-4"
+                  className="flex items-center gap-4 text-sm mt-4"
                 >
-                  Get Freed
-                </motion.button>
+                  <DemoLink onClick={() => setMobileMenuOpen(false)} className="font-medium text-[var(--theme-accent-primary)] hover:underline underline-offset-4 whitespace-nowrap">
+                    Live Demo
+                  </DemoLink>
+                  <button onClick={() => { openModal(); setMobileMenuOpen(false); }} className="btn-primary px-6 py-3 whitespace-nowrap">
+                    Get Freed
+                  </button>
+                </motion.div>
               </div>
             </motion.div>
           )}

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -60,14 +60,11 @@ export default function Navigation() {
   const [captionIndex, setCaptionIndex] = useState(0);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
-  const [homePageScrolledPastFold, setHomePageScrolledPastFold] = useState(false);
   const [mobileMenuTopOffset, setMobileMenuTopOffset] = useState(64);
   const [hoveredNavPath, setHoveredNavPath] = useState<string | null>(null);
   const navRefs = useRef<(HTMLAnchorElement | null)[]>([]);
   const mobileTopBarRef = useRef<HTMLDivElement | null>(null);
   const [underlineStyle, setUnderlineStyle] = useState({ left: 0, width: 0 });
-  const showMobileTopCta =
-    !mobileMenuOpen && (pathname !== "/" || homePageScrolledPastFold);
   const activeNavPath = NAV_ITEMS.find((item) =>
     isActive(item.path, pathname),
   )?.path;
@@ -76,7 +73,6 @@ export default function Navigation() {
   useEffect(() => {
     const handleScroll = () => {
       setScrolled(window.scrollY > 20);
-      setHomePageScrolledPastFold(window.scrollY > window.innerHeight);
     };
     handleScroll(); // Check initial position
     window.addEventListener("scroll", handleScroll, { passive: true });
@@ -210,7 +206,10 @@ export default function Navigation() {
         />
       )}
 
-      <button onClick={() => openModal()} className="btn-primary text-sm !py-2">
+      <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary text-sm !py-2 whitespace-nowrap">
+        Live demo
+      </a>
+      <button onClick={() => openModal()} className="btn-primary text-sm !py-2 whitespace-nowrap">
         Get Freed
       </button>
     </div>
@@ -287,42 +286,19 @@ export default function Navigation() {
         {/* Mobile: solid full-width bar */}
         <div
           ref={mobileTopBarRef}
-          className={`lg:hidden bg-freed-black pl-8 pr-4 py-3 ${
+          className={`lg:hidden bg-freed-black px-3 py-3 ${
             mobileMenuOpen ? "" : "border-b border-freed-border"
           }`}
         >
           <div className="flex items-center justify-between">
             {logoElement}
-            <div className="flex items-center gap-3">
-              <AnimatePresence initial={false}>
-                {showMobileTopCta && (
-                  <motion.div
-                    key="mobile-top-cta"
-                    initial={{ width: 0 }}
-                    animate={{ width: "auto" }}
-                    exit={{ width: 0 }}
-                    transition={{ duration: 0.2, ease: "easeInOut" }}
-                    className="overflow-hidden pr-4"
-                    style={{
-                      WebkitMaskImage:
-                        "linear-gradient(to right, black 0, black calc(100% - 18px), transparent 100%)",
-                      maskImage:
-                        "linear-gradient(to right, black 0, black calc(100% - 18px), transparent 100%)",
-                    }}
-                  >
-                    <motion.button
-                      onClick={() => openModal()}
-                      initial={{ opacity: 0, x: 8 }}
-                      animate={{ opacity: 1, x: 0 }}
-                      exit={{ opacity: 0, x: 8 }}
-                      transition={{ duration: 0.2, ease: "easeInOut" }}
-                      className="btn-primary nav-mobile-cta my-0 shrink-0 whitespace-nowrap text-[0.765rem]"
-                    >
-                      Get Freed
-                    </motion.button>
-                  </motion.div>
-                )}
-              </AnimatePresence>
+            <div className="flex shrink-0 items-center gap-1.5">
+              <a href="https://demo.freed.wtf" target="_blank" rel="noopener noreferrer" className="btn-primary !px-2 !py-2 min-h-11 whitespace-nowrap text-xs">
+                Live demo
+              </a>
+              <button onClick={() => openModal()} className="btn-primary !px-2 !py-2 min-h-11 whitespace-nowrap text-xs">
+                Get Freed
+              </button>
               {mobileHamburger}
             </div>
           </div>

--- a/website/src/index.css
+++ b/website/src/index.css
@@ -2,6 +2,29 @@
 @import "@freed/ui/index.css";
 @import "./desktop-themes.css";
 
+.demo-action-pair { display: flex; gap: 0; isolation: isolate; }
+.demo-action-pair > .demo-action {
+  display: inline-flex; align-items: center; justify-content: center;
+  min-height: 44px; padding: 9px 22px; white-space: nowrap;
+  border: 5px solid var(--theme-accent-primary); border-radius: 0;
+  box-shadow: none; margin: 0; transform: none;
+  transition: background-color 160ms ease, color 160ms ease, filter 160ms ease;
+}
+.demo-action-pair > .demo-action:first-child { border-radius: 999px 0 0 999px; }
+.demo-action-pair > .demo-action:last-child { border-radius: 0 999px 999px 0; border-left-width: 0; }
+.demo-action-pair > .demo-action-outline { background: transparent; color: var(--theme-accent-primary); }
+.demo-action-pair > .demo-action-outline:hover { background: color-mix(in srgb, var(--theme-accent-primary) 18%, var(--theme-bg-root)); }
+.demo-action-pair > .btn-primary:hover { filter: brightness(1.18); transform: none; }
+.demo-action:focus-visible { outline: 3px solid var(--theme-text-primary); outline-offset: 3px; z-index: 1; }
+.demo-action-pair-compact > .demo-action { padding: 5px 8px; }
+.demo-showcase { position: relative; display: block; overflow: hidden; border-radius: var(--card-radius); border: 1px solid var(--theme-border-subtle); transition: transform 180ms ease; }
+@media (hover: hover) and (prefers-reduced-motion: no-preference) {
+  .demo-showcase:hover { transform: scale(1.025); }
+}
+.demo-showcase-caption { position: absolute; bottom: 22px; left: 50%; transform: translateX(-50%); white-space: nowrap; transition: transform 160ms ease, filter 160ms ease, box-shadow 160ms ease; }
+html .demo-showcase:is(:hover, :focus-visible) .demo-showcase-caption { transform: translateX(-50%) scale(1.05); filter: brightness(1.18); box-shadow: 0 0 0 4px color-mix(in srgb, var(--theme-accent-primary) 30%, transparent); }
+@media (prefers-reduced-motion: reduce) { .demo-showcase-caption, .demo-action-pair > .demo-action { transition: none; } html .demo-showcase:is(:hover, :focus-visible) .demo-showcase-caption { transform: translateX(-50%); } }
+
 @theme {
   --color-freed-black: var(--theme-bg-root);
   --color-freed-dark: var(--theme-bg-deep);


### PR DESCRIPTION
(AI Generated).

## Changes

- Add prominent new-tab Live demo calls to action in desktop and mobile navigation, hero, homepage showcase, closing section, and footer.
- Fit mobile navigation at 320 pixels across all six themes.
- Show the release GIF prominently, with a static screenshot for reduced-motion preferences.

## Validation

- Website production build passed.
- Ten website E2E checks passed.
- Browser checks covered all six themes and 320, 375, 390, 768, 1024, and 1440 pixel viewports.
- Verified the mobile Live demo link opens https://demo.freed.wtf in a separate tab.
- Verified GIF decoding and the reduced-motion image fallback.

## Publication dependency

Hold the production merge until the new production product release publishes and verifies the finalized showcase asset manifest. The existing v26.9.602 GIF loads, but its old manifest lacks finalized asset checksums.