### PR TITLE
chore: migrate OpenAI defaults to GPT-6 Astra

### DIFF
--- a/docs/PHASE-10-POLISH.md
+++ b/docs/PHASE-10-POLISH.md
@@ -522,3 +522,8 @@ Reward security researchers for responsible disclosure.
 ## Deliverable
 
 Polished, accessible app with AI-powered features and thriving community infrastructure.
+
+OpenAI model default reviewed September 7, 2026: new OpenAI selections use
+`gpt-6-astra`. Existing saved models remain unchanged. Astra summaries use low
+reasoning with a bounded completion budget; Ollama retains its local request
+parameters. Live output quality and account access require API validation.

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -55,7 +55,7 @@
     {
       "id": 10,
       "status": "upcoming",
-      "reviewedAt": "2026-09-06",
+      "reviewedAt": "2026-09-07",
       "source": "docs/PHASE-10-POLISH.md"
     },
     {

--- a/packages/desktop/src/lib/ai-summarizer.test.ts
+++ b/packages/desktop/src/lib/ai-summarizer.test.ts
@@ -48,6 +48,50 @@ describe("ai summarizer", () => {
     });
   });
 
+  it.each([
+    { provider: "openai" as const, model: "gpt-6-astra", astra: true },
+    { provider: "openai" as const, model: "gpt-4o-mini", astra: false },
+    { provider: "ollama" as const, model: "gpt-6-astra", astra: false },
+  ])("keeps request parameters compatible for $provider / $model", async ({ provider, model, astra }) => {
+    const mockFetch = vi.fn<typeof fetch>(async () => new Response(JSON.stringify({
+      choices: [{ message: { content: JSON.stringify({
+        summary: "Short summary", topics: ["ai"], sentiment: "neutral",
+      }) } }],
+    })));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await summarize("x".repeat(9_000), { ...OPENAI_PREFS, provider, model }, "test-key");
+
+    expect(result?.summary).toBe("Short summary");
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0]!;
+    expect(url).toBe(provider === "openai"
+      ? "https://api.openai.com/v1/chat/completions"
+      : "http://localhost:11434/v1/chat/completions");
+    const body = JSON.parse(init!.body as string);
+    expect(body.model).toBe(model);
+    expect(body.messages[1].content).toHaveLength(8_000);
+    if (astra) {
+      expect(body.reasoning_effort).toBe("low");
+      expect(body.max_completion_tokens).toBe(4_096);
+      for (const key of ["temperature", "max_tokens", "top_p", "logprobs", "top_logprobs", "tools"]) {
+        expect(body).not.toHaveProperty(key);
+      }
+    } else {
+      expect(body.temperature).toBe(0.3);
+      expect(body.max_tokens).toBe(512);
+      expect(body).not.toHaveProperty("reasoning_effort");
+      expect(body).not.toHaveProperty("max_completion_tokens");
+    }
+  });
+
+  it("returns no summary and does not retry an unavailable Astra model", async () => {
+    const mockFetch = vi.fn<typeof fetch>(async () => new Response("model_not_found", { status: 404 }));
+    vi.stubGlobal("fetch", mockFetch);
+    await expect(summarize("Article", { ...OPENAI_PREFS, model: "gpt-6-astra" }, "test-key")).resolves.toBeNull();
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
   it("does not count a provider request when required credentials are absent", async () => {
     const mockFetch = vi.fn<typeof fetch>();
     vi.stubGlobal("fetch", mockFetch);

--- a/packages/desktop/src/lib/ai-summarizer.ts
+++ b/packages/desktop/src/lib/ai-summarizer.ts
@@ -44,6 +44,7 @@ async function callOpenAICompatible(
   text: string,
   authHeader: string,
   signal?: AbortSignal,
+  useAstra = false,
 ): Promise<string> {
   const resp = await fetch(`${baseUrl}/chat/completions`, {
     method: "POST",
@@ -57,8 +58,11 @@ async function callOpenAICompatible(
         { role: "system", content: SYSTEM_PROMPT },
         { role: "user", content: text.slice(0, 8_000) },
       ],
-      temperature: 0.3,
-      max_tokens: 512,
+      // Astra requires reasoning-compatible parameters. Keep Ollama and
+      // explicitly selected legacy models on their existing request contract.
+      ...(useAstra
+        ? { reasoning_effort: "low", max_completion_tokens: 4_096 }
+        : { temperature: 0.3, max_tokens: 512 }),
     }),
     signal,
   });
@@ -205,6 +209,7 @@ export async function summarize(
           text,
           `Bearer ${apiKey}`,
           options.signal,
+          model === "gpt-6-astra",
         );
         break;
       }

--- a/packages/ui/src/components/settings/AISection.tsx
+++ b/packages/ui/src/components/settings/AISection.tsx
@@ -39,7 +39,7 @@ const DEFAULT_MODELS: Record<AIProvider, string> = {
   none: "",
   integrated: "",
   ollama: "qwen2.5:1.5b",
-  openai: "gpt-4o-mini",
+  openai: "gpt-6-astra",
   anthropic: "claude-haiku-4-5",
   gemini: "gemini-2.0-flash",
 };

--- a/release-notes/README.md
+++ b/release-notes/README.md
@@ -87,7 +87,7 @@ Freed Desktop update prompts use the deck line only. They do not render bullet l
 ## Environment
 
 - `OPENAI_API_KEY`: optional, used to generate stronger draft notes
-- `OPENAI_RELEASE_NOTES_MODEL`: optional, defaults to `gpt-5.4`
+- `OPENAI_RELEASE_NOTES_MODEL`: optional, defaults to `gpt-6-astra`
 - `OPENAI_RELEASE_NOTES_TIMEOUT_MS`: optional, defaults to `20000`
 - `RELEASE_NOTES_GITHUB_TIMEOUT_MS`: optional, defaults to `15000`
 - `RELEASE_NOTES_MAX_PR_DETAILS`: optional, defaults to `60`

--- a/scripts/prepare-release-notes.mjs
+++ b/scripts/prepare-release-notes.mjs
@@ -50,7 +50,7 @@ const DEV_SUFFIX = "-dev";
 
 const GITHUB_API = "https://api.github.com";
 const OPENAI_API = "https://api.openai.com/v1/chat/completions";
-const OPENAI_MODEL = process.env.OPENAI_RELEASE_NOTES_MODEL || "gpt-5.4";
+const OPENAI_MODEL = process.env.OPENAI_RELEASE_NOTES_MODEL || "gpt-6-astra";
 const OPENAI_TIMEOUT_MS = Math.max(
   1_000,
   Number.parseInt(process.env.OPENAI_RELEASE_NOTES_TIMEOUT_MS || "20000", 10) ||
@@ -1307,6 +1307,7 @@ async function generateWithOpenAI(promptInput) {
       signal: controller.signal,
       body: JSON.stringify({
         model: OPENAI_MODEL,
+        ...(OPENAI_MODEL === "gpt-6-astra" ? { reasoning_effort: "low" } : {}),
         messages: [
           { role: "system", content: system },
           {


### PR DESCRIPTION
(AI Generated).

New OpenAI selections in Freed Desktop and release-note generation now default to GPT-6 Astra. Astra summaries use low reasoning and a bounded completion budget without unsupported sampling parameters. Release notes map the prior model's default reasoning to low.

Existing saved model choices, release-note model overrides, Ollama requests, JSON output contracts, and request cadence remain intact. Production receives the release helper through normal dev promotion. Public roadmap status is unchanged.

Validation: `npm run validate:feature` passed, including typechecks, PWA build, 426 PWA unit tests, 852 Desktop unit tests, nine headless smoke tests, release and roadmap checks. A synthetic release request probe verified Astra defaults, low reasoning, legacy overrides, and strict JSON. No API key was available for live Astra verification. Machine doctor reported pre-existing missing host automation kernel guard files; host state was not modified.

Migration guidance: https://developers.openai.com/api/docs/guides/latest-model

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `075688ff7285681b2b787600c149409616986938`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `astra-migration-20260907`
- Provider review decision: `behavior_approved`
- Provider review artifact: `04860185bc7e86a82de0ea9ac65612b8a52e891460cc3bbe72fcd8b988e71acc`
- Providers: other
- Observable behavior: OpenAI summary defaults change from gpt-4o-mini to gpt-6-astra, with low reasoning and a 4096-token completion cap including reasoning. Release notes change from gpt-5.4 to Astra low reasoning. Existing Chat Completions endpoints and contact cadence remain unchanged.
- Fingerprinting risk: OpenAI sees the changed model and generation parameters. This is normal authenticated API use; it adds no browser fingerprinting or social provider traffic. Processing time and cost can change.
- Lowest profile alternative: Validate synthetic request bodies offline with no additional API calls; retain explicit model selections and existing request cadence.

Files bound into this provider review:
- `packages/desktop/src/lib/ai-summarizer.ts`
- `packages/ui/src/components/settings/AISection.tsx`