### PR TITLE
docs: preserve reviewed README showcase placement

### DIFF
--- a/docs/RELEASE-SHOWCASE.md
+++ b/docs/RELEASE-SHOWCASE.md
@@ -68,7 +68,8 @@ all themes on the live site after each production release, even when stable
 latest-release URLs make a website code change unnecessary. A local preview
 URL, missing asset, older release hash, or fixed mixed-theme GIF fails closeout.
 
-Keep the Scriptorium embed immediately below the `FREEDme` heading in README.md.
+Keep the Scriptorium embed below the `Freed.wtf` link and above the first
+horizontal rule in README.md.
 Once its release asset exists and has passed public verification, use:
 
 ```markdown


### PR DESCRIPTION
(AI Generated).

Keep the website lane's release instructions consistent with the owner's revised README placement: the Scriptorium animation belongs below the Freed.wtf link and above the first horizontal rule. The README itself is updated in #1868.

Validation: instruction validator and git diff whitespace check passed. Documentation only; no website code or assets changed.
