### PR TITLE
fix: verify decision archives through open handles

### DIFF
--- a/scripts/task-decisions.mjs
+++ b/scripts/task-decisions.mjs
@@ -20,8 +20,9 @@ function git(root, args, gitBin = "git", allowed = [0]) {
 
 function readLog(root) {
   const file = path.join(root, NAME);
-  if (!fs.existsSync(file) && !fs.lstatSync(file, { throwIfNoEntry: false })) return null;
-  const fd = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  let fd;
+  try { fd = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW); }
+  catch (error) { if (error.code === "ENOENT") return null; throw error; }
   try {
     const stat = fs.fstatSync(fd);
     if (!stat.isFile() || stat.nlink !== 1 || stat.size > 1024 * 1024) {
@@ -91,10 +92,13 @@ export function preserveDecisions(root, { archiveRoot = path.join(os.homedir(), 
   const directory = privateDirectory(destination);
   const file = path.join(directory, `${digest(root).slice(0, 12)}-${digest(contents)}.md`);
   try { fs.writeFileSync(file, contents, { flag: "wx", mode: 0o600 }); } catch (error) { if (error.code !== "EEXIST") throw error; }
-  const stat = fs.lstatSync(file);
-  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || (stat.mode & 0o077) !== 0 || !fs.readFileSync(file).equals(contents)) {
-    throw new Error("Decision archive verification failed; retain the worktree.");
-  }
+  const fd = fs.openSync(file, fs.constants.O_RDONLY | fs.constants.O_NOFOLLOW);
+  try {
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile() || stat.nlink !== 1 || (stat.mode & 0o077) !== 0 || !fs.readFileSync(fd).equals(contents)) {
+      throw new Error("Decision archive verification failed; retain the worktree.");
+    }
+  } finally { fs.closeSync(fd); }
   return file;
 }
 

--- a/scripts/task-decisions.test.mjs
+++ b/scripts/task-decisions.test.mjs
@@ -61,13 +61,15 @@ test("preservation is private, verified, idempotent, outside the worktree, and r
   const archiveRoot = path.join(root, "archive");
   const file = preserveDecisions(repo, { archiveRoot });
   assert.equal(preserveDecisions(repo, { archiveRoot }), file);
-  assert.equal(fs.statSync(file).mode & 0o077, 0);
+  const fd = fs.openSync(file, fs.constants.O_RDWR | fs.constants.O_NOFOLLOW);
+  t.after(() => fs.closeSync(fd));
+  assert.equal(fs.fstatSync(fd).mode & 0o077, 0);
   assert.equal(fs.statSync(archiveRoot).mode & 0o077, 0);
-  assert.deepEqual(fs.readFileSync(file), fs.readFileSync(path.join(repo, name)));
+  assert.deepEqual(fs.readFileSync(fd), fs.readFileSync(path.join(repo, name)));
   assert.throws(() => preserveDecisions(repo, { archiveRoot: path.join(repo, "archive") }), /outside/);
   fs.symlinkSync(archiveRoot, path.join(root, "redirect"));
   assert.throws(() => preserveDecisions(repo, { archiveRoot: path.join(root, "redirect") }), /symbolic/);
-  fs.writeFileSync(file, "corrupted");
+  fs.writeFileSync(fd, "corrupted");
   assert.throws(() => preserveDecisions(repo, { archiveRoot }), /verification/);
 });
 


### PR DESCRIPTION
(AI Generated).

Verify private decision logs and archived copies through the same open file descriptor, using O_NOFOLLOW. This removes filesystem check/use race patterns reported by CodeQL in the corresponding product change and keeps both lane helpers aligned. Update fixture reads and corruption checks to use the same handle.

Validation: six focused privacy, cleanup, and website publisher tests passed. Website build inputs are unchanged from the passing PR #1873 build; current-head website CI also runs the production build.
