### PR TITLE
fix: stabilize phone landscape layout and scrolling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Never discard launcher changes to make it fresh. Preserve and report unexpected 
 
 ## Authorization levels
 
-When authorization is required and the owner has not set a level, ask exactly:
+Default to Level 2 (Build). Ask only when a different level is needed to safely or efficiently complete the requested task. Finish authorized work before asking. To change levels, ask exactly:
 
 > What authorization level should this task proceed at?
 >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Never discard launcher changes to make it fresh. Preserve and report unexpected 
 
 ## Authorization levels
 
-Default to Level 2 (Build). Ask only when a different level is needed to safely or efficiently complete the requested task. Finish authorized work before asking. To change levels, ask exactly:
+Default to Level 2 (Build). Finish authorized work first. Ask exactly the following only when safe or efficient task completion needs another level:
 
 > What authorization level should this task proceed at?
 >
@@ -31,7 +31,7 @@ Default to Level 2 (Build). Ask only when a different level is needed to safely 
 >
 > Reply with a number.
 
-Do not request authorization for one isolated action or append exclusions and safety boilerplate.
+Ask for task authority, without isolated permissions, exclusions, or safety boilerplate.
 
 1. **Inspect:** Read-only diagnosis, evidence capture, and planning.
 2. **Build:** Level 1 plus local edits, tests, previews, synthetic fixtures, and reversible local files.
@@ -43,7 +43,7 @@ Do not request authorization for one isolated action or append exclusions and sa
 
 Each level includes lower levels. The newest explicit level controls for the stated task. Do not ask again for included actions. Clarification about ambiguous scope is not an authorization challenge.
 
-Use these numbers in owner-facing authorization requests and status. Internal labels such as `observe-only`, `plan-only`, `pr-only`, and `merge-safe` never replace them.
+Use numbered levels in owner-facing requests and status; internal actor labels never replace them.
 
 ## Load only the applicable instructions
 

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -14,6 +14,8 @@
 :root {
   --safe-area-top: env(safe-area-inset-top, 0px);
   --safe-area-bottom: env(safe-area-inset-bottom, 0px);
+  --safe-area-left: env(safe-area-inset-left, 0px);
+  --safe-area-right: env(safe-area-inset-right, 0px);
 
   /* Updated by JS in main.tsx to track the area above the software keyboard.
      Used by BottomSheet and any other overlay that must stay fully visible
@@ -181,8 +183,6 @@ body {
   -moz-osx-font-smoothing: grayscale;
   line-height: 1.6;
   overscroll-behavior: none;
-  padding-left: env(safe-area-inset-left);
-  padding-right: env(safe-area-inset-right);
   width: 100%;
   max-width: 100%;
 }
@@ -195,32 +195,40 @@ body {
    lets feed content spill past that boundary into the document so window
    scroll works. html/body are set to overflow:visible so the window can
    actually scroll the overflowed content. Desktop layout is unchanged. */
-@media (max-width: 767px) {
-  html {
-    height: auto;
-    overflow: visible;
-    overflow-x: clip;
-    /* Must be on html (not just body) — iOS Safari applies the pull-to-refresh
-       gesture at the root element level when overflow:visible is set here. */
-    overscroll-behavior: none;
-  }
+/* Use the same device classification as AppShell and FeedList. A phone in
+   landscape still owns document scrolling, even above the desktop breakpoint. */
+html:has(.app-theme-shell[data-mobile-device="true"]) {
+  height: auto;
+  overflow: visible;
+  overflow-x: clip;
+  /* Must be on html (not just body) — iOS Safari applies the pull-to-refresh
+     gesture at the root element level when overflow:visible is set here. */
+  overscroll-behavior: none;
+  /* Virtualizer corrections must settle immediately, never animate. */
+  scroll-behavior: auto;
+}
 
-  body {
-    height: auto;
-    overflow: visible;
-    overflow-x: clip;
-    overscroll-behavior: none;
-  }
+body:has(.app-theme-shell[data-mobile-device="true"]) {
+  height: auto;
+  overflow: visible;
+  overflow-x: clip;
+  overscroll-behavior: none;
+}
 
-  #root {
-    /* Definite height lets flex children fill the viewport (no color gap).
-       overflow:visible lets feed content extend past 100dvh into the
-       document so window scroll fires and the address bar can collapse. */
-    height: 100svh;
-    height: 100dvh;
-    overflow: visible;
-    overflow-x: clip;
-  }
+#root:has(.app-theme-shell[data-mobile-device="true"]) {
+  /* Definite height lets flex children fill the viewport (no color gap).
+     overflow:visible lets feed content extend past 100dvh into the
+     document so window scroll fires and the address bar can collapse. */
+  height: 100svh;
+  height: 100dvh;
+  overflow: visible;
+  overflow-x: clip;
+}
+
+/* Keep the reading width inset while the shell and toolbar paint edge to edge. */
+.app-theme-shell > .app-content-frame {
+  padding-left: var(--safe-area-left);
+  padding-right: var(--safe-area-right);
 }
 
 #root {

--- a/packages/pwa/tests/safari-viewport.spec.ts
+++ b/packages/pwa/tests/safari-viewport.spec.ts
@@ -214,6 +214,76 @@ test.describe("Safari viewport layout — iPhone 14 / WebKit", () => {
     await acceptLegalGateIfPresent(page);
   });
 
+  test("rotation retains document scrolling and safe-area toolbar", async ({ page }, testInfo) => {
+    // Crossing 767px must not replace the feed's scroll owner.
+    await page.waitForFunction(() => {
+      const store = (window as unknown as Record<string, unknown>).__FREED_STORE__ as
+        { getState: () => { isInitialized: boolean } } | undefined;
+      return store?.getState().isInitialized;
+    });
+    await page.evaluate(async () => {
+      const library = (window as unknown as Record<string, unknown>).__FREED_LIBRARY_CORE__ as
+        { addItems: (items: unknown[]) => Promise<void> };
+      const now = Date.now();
+      const items = Array.from({ length: 40 }, (_, index) => ({
+        globalId: `rss:rotation:${index}`, platform: "rss", contentType: "article",
+        capturedAt: now, publishedAt: now - index * 60000,
+        author: { id: "rotation", handle: "rotation", displayName: "Rotation Fixture" },
+        content: {
+          text: `Rotation article ${index}. ` + "Local synthetic content for checking phone scrolling. ".repeat(10),
+          mediaUrls: [], mediaTypes: [],
+        },
+        userState: { hidden: false, saved: false, archived: false, tags: [] },
+        topics: [], sourceUrl: `https://example.com/rotation/${index}`,
+      }));
+      for (const item of items) await library.addItems([item]);
+    });
+    await expect(page.locator("[data-feed-row-index]").first()).toBeVisible();
+    const originalList = await page.locator("[data-feed-row-index]").first().evaluateHandle(
+      element => element.parentElement!.parentElement!,
+    );
+    for (const viewport of [{ width: 844, height: 390 }, { width: 390, height: 844 }]) {
+      await page.setViewportSize(viewport);
+      // Emulation has no hardware insets. Supply landscape safe-area geometry.
+      await page.evaluate(({ width }) => {
+        document.documentElement.style.setProperty("--safe-area-left", width > 767 ? "47px" : "0px");
+        document.documentElement.style.setProperty("--safe-area-right", width > 767 ? "47px" : "0px");
+      }, viewport);
+      await expect.poll(() => page.evaluate(() => getComputedStyle(document.documentElement).overflowY)).toBe("visible");
+      expect(await originalList.evaluate(element => element.isConnected)).toBe(true);
+      const geometry = await page.evaluate(() => {
+        const toolbar = document.querySelector('[data-testid="workspace-toolbar"]')!;
+        const frame = document.querySelector('[data-testid="workspace-content-frame"]')!;
+        const rect = toolbar.getBoundingClientRect();
+        return {
+          left: rect.left, right: rect.right,
+          toolbarPadding: parseFloat(getComputedStyle(toolbar).paddingLeft),
+          contentPadding: parseFloat(getComputedStyle(frame).paddingLeft),
+          smooth: getComputedStyle(document.documentElement).scrollBehavior,
+          overflow: document.documentElement.scrollWidth > innerWidth,
+        };
+      });
+      expect(geometry.left).toBe(0);
+      expect(geometry.right).toBe(viewport.width);
+      expect(geometry.contentPadding).toBe(viewport.width > 767 ? 47 : 0);
+      expect(geometry.toolbarPadding).toBe(viewport.width > 767 ? 47 : 12);
+      expect(geometry.smooth).toBe("auto");
+      expect(geometry.overflow).toBe(false);
+      await page.evaluate(() => window.scrollTo({ top: 600, behavior: "instant" }));
+      await expect.poll(() => page.evaluate(() => window.scrollY)).toBe(600);
+      const positions = await page.evaluate(async () => {
+        const samples: number[] = [];
+        for (let i = 0; i < 12; i++) {
+          await new Promise(requestAnimationFrame);
+          samples.push(scrollY);
+        }
+        return samples;
+      });
+      expect(Math.max(...positions) - Math.min(...positions)).toBeLessThanOrEqual(1);
+      await page.screenshot({ path: testInfo.outputPath(`rotation-${viewport.width}.png`) });
+    }
+  });
+
   test("dvh and lvh resolve to non-zero pixel values", async ({ page }) => {
     const m = await getLayoutMetrics(page);
     expect(m.dvhPx).toBeGreaterThan(400);

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -13,7 +13,7 @@ import { LoadingState } from "../LoadingState.js";
 import { useReadOnScrollTracker } from "./useReadOnScrollTracker.js";
 import type { FeedItem as FeedItemType } from "@freed/shared";
 import { useAppStore, usePlatform } from "../../context/PlatformContext.js";
-import { useIsMobile } from "../../hooks/useIsMobile.js";
+import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
 import {
   DESKTOP_FEED_CARD_HEIGHT_BY_DENSITY,
   useFeedCardDensity,
@@ -346,7 +346,8 @@ export function FeedList({
   // Mobile window-scroll container (used to compute scrollMargin for the virtualizer)
   const windowListRef = useRef<HTMLDivElement>(null);
 
-  const isMobile = useIsMobile();
+  // Scroll ownership must survive rotation, just like AppShell's layout mode.
+  const isMobile = useIsMobileDevice();
   const feedCardHorizontalGutter = isMobile
     ? 0
     : DESKTOP_FEED_CARD_HORIZONTAL_GUTTER;

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -501,7 +501,7 @@ export function AppShell({ children }: AppShellProps) {
       {/* On actual mobile devices, the layout flows naturally in the document so
           Safari can collapse its address bar when the feed scrolls. Desktop devices
           keep the fixed-height shell even when the viewport is narrow. */}
-      <div className={`app-theme-shell relative flex min-w-0 flex-1 flex-col ${isMobileDevice ? "" : "min-h-0"}`}>
+      <div data-mobile-device={isMobileDevice} className={`app-theme-shell relative flex min-w-0 flex-1 flex-col ${isMobileDevice ? "" : "min-h-0"}`}>
         {showAtmosphere ? <BackgroundAtmosphere /> : null}
         <Header
           mobileSidebarOpen={mobileSidebarOpen}
@@ -519,7 +519,8 @@ export function AppShell({ children }: AppShellProps) {
 
         <div
           ref={contentFrameRef}
-          className={`relative z-10 flex flex-1 ${contentFrameSpacingClass} ${
+          data-testid="workspace-content-frame"
+          className={`app-content-frame relative z-10 flex flex-1 ${contentFrameSpacingClass} ${
             isMobileDevice ? "" : "min-h-0 overflow-hidden"
           }`}
         >

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -1191,9 +1191,9 @@ export function Header({
   const toolbarContainerStyle = {
     ...(headerDragRegion ? dragStyle : {}),
     // Keep narrow-screen controls clear of rounded device edges and safe areas.
-    ...(isMobile && !headerDragRegion ? {
-      paddingLeft: "max(12px, env(safe-area-inset-left))",
-      paddingRight: "max(12px, env(safe-area-inset-right))",
+    ...(isMobileDevice && !headerDragRegion ? {
+      paddingLeft: "max(12px, var(--safe-area-left, env(safe-area-inset-left, 0px)))",
+      paddingRight: "max(12px, var(--safe-area-right, env(safe-area-inset-right, 0px)))",
     } : {}),
     boxSizing: "border-box",
     height: px(topToolbarHeightPx),


### PR DESCRIPTION
(AI Generated).

Phone rotation crossed the 767px breakpoint and switched the feed to element scrolling while the app shell retained document layout. Keep both the feed and PWA overflow tied to mobile device identity, and disable animated document-scroll corrections. Move safe-area padding to the content frame so reading width stays inset while the toolbar and themed background extend to both edges; keep toolbar controls clear of device corners.

Default repository authorization to Level 2 and ask only when a different level is needed. This instruction change targets dev; main receives it through normal promotion and www requires its own lane update.

Validation: local feature checks passed; the final instruction budget check passed after condensing authorization wording; seven WebKit iPhone viewport tests including rotation and safe-area geometry; two Chromium app-shell and reader smoke tests; independent synthetic authorization scenarios. Physical iPhone gestures remain unverified. The host automation preflight reports pre-existing missing guard files; the manual publication path and product checks do not use those actors.