### PR TITLE
fix: make desktop nightly probes platform explicit

### DIFF
--- a/packages/desktop/tests/e2e/clipboard-save-shortcut.spec.ts
+++ b/packages/desktop/tests/e2e/clipboard-save-shortcut.spec.ts
@@ -5,6 +5,19 @@ const LIBRARY_DETAIL_RUNTIME_PATH = resolveViteFsModulePath(
   import.meta.url,
 );
 
+const shortcutPlatforms = [
+  { name: "macOS", platform: "MacIntel", shortcut: "Control+Option+Command+S", keycaps: ["⌃", "⌥", "⌘", "S"], recorded: "Control+Option+F", recordedKeycaps: ["⌃", "⌥", "F"] },
+  { name: "Linux", platform: "Linux x86_64", shortcut: "Control+Alt+S", keycaps: ["Control", "Alt", "S"], recorded: "Control+Alt+F", recordedKeycaps: ["Control", "Alt", "F"] },
+  { name: "Windows", platform: "Win32", shortcut: "Control+Alt+S", keycaps: ["Control", "Alt", "S"], recorded: "Control+Alt+F", recordedKeycaps: ["Control", "Alt", "F"] },
+];
+
+async function setShortcutPlatform(page: import("@playwright/test").Page, platform: string): Promise<void> {
+  await page.addInitScript((value) => {
+    Object.defineProperty(navigator, "platform", { configurable: true, value });
+    Object.defineProperty(navigator, "userAgent", { configurable: true, value: `Mozilla/5.0 (${value})` });
+  }, platform);
+}
+
 async function waitForRegisteredShortcut(page: import("@playwright/test").Page): Promise<string> {
   await page.waitForFunction(() => {
     const w = window as unknown as {
@@ -73,25 +86,28 @@ async function expectRecorderOnRight(
   expect(Math.abs(recorderBox.y - labelBox.y)).toBeLessThan(24);
 }
 
-test("global clipboard shortcut opens Save Content with a clipboard URL", async ({ app, page, ipc }) => {
-  await app.goto();
-  await app.waitForReady();
+for (const platform of shortcutPlatforms) {
+  test(`global clipboard shortcut opens Save Content with a clipboard URL on ${platform.name}`, async ({ app, page, ipc }) => {
+    await setShortcutPlatform(page, platform.platform);
+    await app.goto();
+    await app.waitForReady();
 
-  const shortcut = await waitForRegisteredShortcut(page);
-  expect(shortcut).toBe("Control+Option+Command+S");
+    const shortcut = await waitForRegisteredShortcut(page);
+    expect(shortcut).toBe(platform.shortcut);
 
-  await page.evaluate(() => {
-    (window as unknown as { __TAURI_MOCK_CLIPBOARD_TEXT__?: string })
-      .__TAURI_MOCK_CLIPBOARD_TEXT__ = " https://example.com/from-clipboard ";
+    await page.evaluate(() => {
+      (window as unknown as { __TAURI_MOCK_CLIPBOARD_TEXT__?: string })
+        .__TAURI_MOCK_CLIPBOARD_TEXT__ = " https://example.com/from-clipboard ";
+    });
+    await triggerShortcut(page, shortcut);
+
+    await expect(page.getByText("Save Content", { exact: true })).toBeVisible();
+    await expect(page.getByLabel("Article or page URL")).toHaveValue("https://example.com/from-clipboard");
+
+    const invocations = await ipc.invocations();
+    expect(invocations.some((call) => call.cmd === "show_window")).toBe(true);
   });
-  await triggerShortcut(page, shortcut);
-
-  await expect(page.getByText("Save Content", { exact: true })).toBeVisible();
-  await expect(page.getByLabel("Article or page URL")).toHaveValue("https://example.com/from-clipboard");
-
-  const invocations = await ipc.invocations();
-  expect(invocations.some((call) => call.cmd === "show_window")).toBe(true);
-});
+}
 
 test("global clipboard shortcut opens Save Content blank for non-URL clipboard text", async ({ app, page }) => {
   await app.goto();
@@ -244,45 +260,45 @@ test("saving and editing content persists preview details and searchable notes",
   await expect(page.getByText("Saved Reader Transition").first()).toBeVisible();
 });
 
-test("Settings records, disables, and resets the Save Content shortcut", async ({ app, page }) => {
-  await page.setViewportSize({ width: 1492, height: 700 });
-  const settingsDialog = await openSettingsDialog(app, page);
-  await settingsDialog.getByRole("button", { name: "Shortcuts", exact: true }).click();
+for (const platform of shortcutPlatforms) {
+  test(`Settings records, disables, and resets the Save Content shortcut on ${platform.name}`, async ({ app, page }) => {
+    await setShortcutPlatform(page, platform.platform);
+    await page.setViewportSize({ width: 1492, height: 700 });
+    const settingsDialog = await openSettingsDialog(app, page);
+    await settingsDialog.getByRole("button", { name: "Shortcuts", exact: true }).click();
 
-  const recorder = settingsDialog.getByRole("button", { name: "Record Save Content shortcut" });
-  const label = settingsDialog.getByText("Save Content", { exact: true });
-  const card = settingsDialog.getByTestId("settings-shortcuts-save-content-card");
-  await expect(card).toHaveClass(/theme-card-soft/);
-  await expect(card).not.toHaveClass(/border-border|bg-bg-surface/);
-  await expect(recorder).toContainText("⌃⌥⌘S");
-  await expect(recorder.locator("kbd")).toHaveText(["⌃", "⌥", "⌘", "S"]);
-  await expectKeycapsInSingleRow(recorder);
-  await expectRecorderOnRight(label, recorder);
+    const recorder = settingsDialog.getByRole("button", { name: "Record Save Content shortcut" });
+    const label = settingsDialog.getByText("Save Content", { exact: true });
+    const card = settingsDialog.getByTestId("settings-shortcuts-save-content-card");
+    await expect(card).toHaveClass(/theme-card-soft/);
+    await expect(card).not.toHaveClass(/border-border|bg-bg-surface/);
+    await expect(recorder.locator("kbd")).toHaveText(platform.keycaps);
+    await expectKeycapsInSingleRow(recorder);
+    await expectRecorderOnRight(label, recorder);
 
-  await recorder.click();
-  await expect(recorder).toBeFocused();
-  await page.keyboard.press("Control+Alt+F");
-  await expect(recorder).toContainText("⌃⌥F");
-  await expect(recorder.locator("kbd")).toHaveText(["⌃", "⌥", "F"]);
-  await expectKeycapsInSingleRow(recorder);
+    await recorder.click();
+    await expect(recorder).toBeFocused();
+    await page.keyboard.press("Control+Alt+F");
+    await expect(recorder.locator("kbd")).toHaveText(platform.recordedKeycaps);
+    await expectKeycapsInSingleRow(recorder);
 
-  await settingsDialog.getByRole("button", { name: "Disable" }).click();
-  await expect(recorder).toContainText("Disabled");
-  await expect(recorder.locator("kbd")).toHaveCount(0);
+    await settingsDialog.getByRole("button", { name: "Disable" }).click();
+    await expect(recorder).toContainText("Disabled");
+    await expect(recorder.locator("kbd")).toHaveCount(0);
 
-  await settingsDialog.getByRole("button", { name: "Reset to default" }).click();
-  await expect(recorder).toContainText("⌃⌥⌘S");
-  await expect(recorder.locator("kbd")).toHaveText(["⌃", "⌥", "⌘", "S"]);
+    await settingsDialog.getByRole("button", { name: "Reset to default" }).click();
+    await expect(recorder.locator("kbd")).toHaveText(platform.keycaps);
 
-  const calls = await page.evaluate(() => {
-    const w = window as unknown as {
-      __TAURI_MOCK_GLOBAL_SHORTCUT_CALLS__?: Array<{ action: string; shortcut?: string }>;
-    };
-    return w.__TAURI_MOCK_GLOBAL_SHORTCUT_CALLS__ ?? [];
+    const calls = await page.evaluate(() => {
+      const w = window as unknown as {
+        __TAURI_MOCK_GLOBAL_SHORTCUT_CALLS__?: Array<{ action: string; shortcut?: string }>;
+      };
+      return w.__TAURI_MOCK_GLOBAL_SHORTCUT_CALLS__ ?? [];
+    });
+    expect(calls.some((call) => call.action === "register" && call.shortcut === platform.recorded)).toBe(true);
+    expect(calls.some((call) => call.action === "unregister" && call.shortcut === platform.recorded)).toBe(true);
   });
-  expect(calls.some((call) => call.action === "register" && call.shortcut === "Control+Option+F")).toBe(true);
-  expect(calls.some((call) => call.action === "unregister" && call.shortcut === "Control+Option+F")).toBe(true);
-});
+}
 
 test("Settings hides shortcut controls on touch-only devices", async ({ app, page }) => {
   await page.addInitScript(() => {

--- a/packages/desktop/tests/e2e/perf-feed.spec.ts
+++ b/packages/desktop/tests/e2e/perf-feed.spec.ts
@@ -25,6 +25,26 @@ const SCROLL_LONG_TASK_WORST_MS_BUDGET = 120;
 const SCROLL_FRAME_P95_MS_BUDGET = 50;
 const SCROLL_DROPPED_FRAME_BUDGET = 10;
 
+async function readyFeedScrollContainer(page: Page) {
+  const container = page.getByTestId("feed-list-scroll-container");
+  await expect(container.locator(".feed-card").first()).toBeVisible();
+  // Import completion acknowledges storage and aggregate counts, not painted
+  // feed rows or loaded fonts. Keep that startup work outside the scroll window.
+  await page.evaluate(async () => {
+    await document.fonts.ready;
+    await new Promise<void>((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(() => resolve()));
+    });
+  });
+  const state = await container.evaluate((element) => ({
+    clientHeight: element.clientHeight,
+    scrollHeight: element.scrollHeight,
+    scrollTop: element.scrollTop,
+  }));
+  expect(state.scrollHeight).toBeGreaterThan(state.clientHeight);
+  return { container, initialScrollTop: state.scrollTop };
+}
+
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
 /**
@@ -371,9 +391,7 @@ test.describe("Scroll performance", () => {
     await app.waitForReady();
     await app.injectRssItems(ITEM_COUNT_LARGE);
 
-    // Desktop FeedList uses class="flex-1 min-h-0 overflow-auto ... minimal-scroll"
-    const scrollContainer = page.locator(".minimal-scroll").first();
-    await scrollContainer.waitFor({ state: "visible" });
+    const { container: scrollContainer, initialScrollTop } = await readyFeedScrollContainer(page);
 
     // Capture long-tasks (>50ms) via PerformanceObserver before scrolling.
     await page.evaluate(() => {
@@ -399,6 +417,7 @@ test.describe("Scroll performance", () => {
       await page.waitForTimeout(100);
     });
     const scrollEndedAt = await page.evaluate(() => performance.now());
+    expect(await scrollContainer.evaluate((element) => element.scrollTop)).toBeGreaterThan(initialScrollTop);
 
     const longTaskData = await page.evaluate(({ scrollStartedAt, scrollEndedAt }) => {
       const tasks = (window as Record<string, unknown>).__PERF_LONG_TASKS__ as PerformanceEntry[];
@@ -771,19 +790,7 @@ test.describe("FPS harness (rAF-based frame measurement)", () => {
     await app.waitForReady();
     await app.injectRssItems(ITEM_COUNT_LARGE);
 
-    const scrollContainer = page.getByTestId("feed-list-scroll-container");
-    await scrollContainer.waitFor({ state: "visible" });
-    const initialScrollState = await scrollContainer.evaluate((element) => {
-      const scrollable = element as HTMLElement;
-      return {
-        clientHeight: scrollable.clientHeight,
-        scrollHeight: scrollable.scrollHeight,
-        scrollTop: scrollable.scrollTop,
-      };
-    });
-    expect(initialScrollState.scrollHeight).toBeGreaterThan(
-      initialScrollState.clientHeight,
-    );
+    const { container: scrollContainer, initialScrollTop } = await readyFeedScrollContainer(page);
 
     const fps = await measureFps(
       page,
@@ -800,7 +807,24 @@ test.describe("FPS harness (rAF-based frame measurement)", () => {
     const finalScrollTop = await scrollContainer.evaluate((element) =>
       (element as HTMLElement).scrollTop,
     );
-    expect(finalScrollTop).toBeGreaterThan(initialScrollState.scrollTop);
+    expect(finalScrollTop).toBeGreaterThan(initialScrollTop);
+    await test.info().attach("feed-scroll-measurement", {
+      contentType: "application/json",
+      body: JSON.stringify({
+        browser: page.context().browser()?.version(),
+        environment: await page.evaluate(() => ({
+          platform: navigator.platform,
+          userAgent: navigator.userAgent,
+          hardwareConcurrency: navigator.hardwareConcurrency,
+          devicePixelRatio: window.devicePixelRatio,
+          visibilityState: document.visibilityState,
+        })),
+        itemCount: ITEM_COUNT_LARGE,
+        initialScrollTop,
+        finalScrollTop,
+        fps,
+      }, null, 2),
+    });
     if (fps.p95Ms === null || fps.droppedFrames === null) {
       test.info().annotations.push({
         type: "inconclusive telemetry",


### PR DESCRIPTION
(AI Generated).

## Summary

Follow-up to #1884 and #1855. The merged-source Desktop job in [run 34202659486](https://github.com/freed-project/freed/actions/runs/34202659486/job/101984811165) passed 227 tests and failed three.

* Replace host-dependent macOS expectations with explicit macOS, Linux, and Windows fixtures for the existing clipboard shortcut startup and settings workflows. Product shortcuts are unchanged.
* Require rendered feed cards and loaded fonts before measuring scroll performance. Use the feed-specific scroll container in both probes and assert actual movement. The LongTask probe previously selected the first generic scroll panel.
* Attach browser, platform, frame sample count, and scroll displacement to the FPS measurement. Keep all existing performance budgets unchanged.

The original FPS scenario also passed locally. Measurement readiness is corrected, but the Linux performance failure is not yet proven resolved. Keep #1855 open until the complete Desktop job passes on freshly merged source.

## Validation

* Strict machine doctor passed.
* `npm run validate:feature` passed: root typecheck, 860 Desktop unit tests, and 10 Desktop smoke tests.
* All six explicit shortcut platform cases passed.
* Both corrected scroll scenarios passed three repetitions each in 23.2 seconds. FPS p95 was 10.1 to 16.7 ms with zero dropped frames.
* No product, provider, durable data, release, or installed-build changes.