### PR TITLE
fix: preserve production receipts during promotion

### DIFF
--- a/scripts/prepare-release-promotion.mjs
+++ b/scripts/prepare-release-promotion.mjs
@@ -135,7 +135,7 @@ function applyPromotionPatch({ cwd, patch, indexFile = null }) {
   }
 }
 
-function verifyPreparedSnapshot({ cwd, fromRef, expectedFiles, indexFile }) {
+function verifyPreparedSnapshot({ cwd, fromRef, baseRef, expectedFiles, indexFile }) {
   const env = { ...process.env, GIT_INDEX_FILE: indexFile };
   const stagedFiles = runGit(["diff", "--cached", "--name-only", "--no-renames"], {
     cwd,
@@ -155,6 +155,7 @@ function verifyPreparedSnapshot({ cwd, fromRef, expectedFiles, indexFile }) {
   const remaining = listPromotionBranchDiffFiles({
     fromRef,
     toRef: preparedTree,
+    baseRef,
     cwd,
   });
   if (remaining.length > 0) {
@@ -176,6 +177,7 @@ function prepareInTemporaryIndex({ cwd, fromRef, baseRef, files, patch }) {
     return verifyPreparedSnapshot({
       cwd,
       fromRef,
+      baseRef,
       expectedFiles: files,
       indexFile,
     });

--- a/scripts/release-promotion-shared.mjs
+++ b/scripts/release-promotion-shared.mjs
@@ -49,6 +49,7 @@ export const PROMOTION_CONTROL_FILES = [
   "scripts/deploy-pwa-production-snapshot.sh",
   "scripts/promote-dev-to-main.sh",
   "scripts/promote-dev-to-main.test.mjs",
+  "scripts/prepare-release-promotion.mjs",
   "scripts/release-promotion-shared.mjs",
   "scripts/release-promotion.test.mjs",
   "scripts/release-workflow-matrix.test.mjs",
@@ -173,7 +174,12 @@ export function listPromotionDiffFiles({ fromRef, toRef, cwd }) {
   );
 }
 
-export function listPromotionBranchDiffFiles({ fromRef, toRef, cwd }) {
+export function listPromotionBranchDiffFiles({
+  fromRef,
+  toRef,
+  baseRef = "origin/main",
+  cwd,
+}) {
   const promotionScopeFiles = listChangedFiles({
     fromRef,
     toRef,
@@ -186,11 +192,18 @@ export function listPromotionBranchDiffFiles({ fromRef, toRef, cwd }) {
     cwd,
     pathspec: PROMOTION_WEBSITE_CONFIG_FILES,
   });
-  const releaseNoteFiles = listChangedFiles({
-    fromRef,
-    toRef,
-    cwd,
-    pathspec: RELEASE_ONLY_PREFIXES,
+  // Production receipts belong to main. A dev snapshot may predate their
+  // reverse integration, but promotion must never erase or rewrite them.
+  const releaseNoteFiles = uniqueSorted([
+    ...listChangedFiles({ fromRef, toRef, cwd, pathspec: RELEASE_ONLY_PREFIXES }),
+    ...listChangedFiles({
+      fromRef: baseRef, toRef, cwd, pathspec: RELEASE_ONLY_PREFIXES,
+    }),
+  ]).filter((filePath) => {
+    const expected =
+      readBlobId(baseRef, filePath, { cwd }) ??
+      readBlobId(fromRef, filePath, { cwd });
+    return readBlobId(toRef, filePath, { cwd }) !== expected;
   });
 
   return uniqueSorted([
@@ -234,7 +247,11 @@ export function listPromotionBranchPatchFiles({ fromRef, toRef, cwd }) {
   ]).filter(
     (filePath) =>
       !BRANCH_SPECIFIC_RELEASE_LANE_FILES.has(filePath) &&
-      !isPromotionControlFile(filePath),
+      !isPromotionControlFile(filePath) &&
+      !(
+        RELEASE_ONLY_PREFIXES.some((prefix) => filePath.startsWith(prefix)) &&
+        readBlobId(toRef, filePath, { cwd })
+      ),
   );
 }
 

--- a/scripts/release-promotion.test.mjs
+++ b/scripts/release-promotion.test.mjs
@@ -154,6 +154,7 @@ function runNode(scriptPath, args) {
 }
 
 test("the promotion control definition preserves itself", () => {
+  assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/prepare-release-promotion.mjs"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release-promotion-shared.mjs"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/deploy-pwa-production-snapshot.sh"));
   assert.ok(PROMOTION_CONTROL_FILES.includes("scripts/release.sh"));
@@ -387,6 +388,8 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     "scripts/release-governance.test.mjs",
     "export const releaseLane = 'production';\n",
   );
+  writeRepoFile(cwd, "release-notes/releases/v26.7.700.json", '{"approved":true}\n');
+  writeRepoFile(cwd, "release-notes/releases/v26.7.700.md", "# Published release\n");
   commitAll(cwd, "release: preserve main version");
   updateOriginRef(cwd, "main");
 
@@ -464,6 +467,8 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
 
   assert.equal(prepared.status, 0, prepared.stderr);
   assert.match(prepared.stdout, /Prepared 9 product paths for promotion/);
+  assert.equal(git(cwd, ["show", ":release-notes/releases/v26.7.700.json"]), '{"approved":true}');
+  assert.equal(git(cwd, ["show", ":release-notes/releases/v26.7.700.md"]), "# Published release");
   assert.equal(
     git(cwd, ["show", ":packages/pwa/src/app.ts"]),
     "export const value = 'next dev snapshot';",
@@ -530,6 +535,15 @@ test("prepare-release-promotion copies the dev product snapshot across squashed 
     "--to-ref=HEAD",
   ]);
   assert.equal(releaseValidated.status, 0, releaseValidated.stderr);
+  // Missing reverse integration must not permit deleting or editing a
+  // production receipt while the product snapshot otherwise matches.
+  for (const change of ["rewrite", "delete"]) {
+    const receipt = "release-notes/releases/v26.7.700.json";
+    if (change === "rewrite") writeRepoFile(cwd, receipt, '{"approved":false}\n');
+    else rmSync(path.join(cwd, receipt));
+    commitAll(cwd, `chore: ${change} production receipt`);
+    assert.deepEqual(listPromotionBranchDiffFiles({ fromRef: "origin/dev", toRef: "HEAD", cwd }), [receipt]);
+  }
 });
 
 test("validate-main-backflow ignores squashed promotion content already in dev history", (t) => {
@@ -1355,7 +1369,7 @@ test("validate-main-pr rejects a promotion whose parent is no longer current mai
   commitAll(cwd, "chore: promote dev into main for production release");
 
   git(cwd, ["checkout", "main"]);
-  writeRepoFile(cwd, "release-notes/releases/v0.0.1.json", "{\n}\n");
+  writeRepoFile(cwd, "packages/pwa/package.json", '{"version":"0.0.1"}\n');
   commitAll(cwd, "release: advance main");
   updateOriginRef(cwd, "main");
   git(cwd, ["checkout", promotionBranch]);

--- a/scripts/validate-main-pr.mjs
+++ b/scripts/validate-main-pr.mjs
@@ -253,6 +253,7 @@ function main() {
   const driftFiles = listPromotionBranchDiffFiles({
     fromRef: options.snapshotRef,
     toRef: options.headRef,
+    baseRef: options.baseRef,
     cwd: options.cwd,
   });
 


### PR DESCRIPTION
(AI Generated).

## Summary
- Preserve main-owned release receipts when the selected dev snapshot predates reverse integration, while rejecting receipt edits and deletions.
- Treat the promotion preparer as a current release control without changing the fixed application snapshot.

## Testing
- 50 focused promotion tests passed; validate:feature passed.