### PR TITLE
perf: yield during desktop mock snapshot encoding

### DIFF
--- a/packages/desktop/src/__mocks__/tauri-init.js
+++ b/packages/desktop/src/__mocks__/tauri-init.js
@@ -43,14 +43,51 @@ export function tauriInitScript() {
       items: {},
       persons: {},
     };
-    function persistSqliteState() {
+    async function persistSqliteState() {
       try {
-        window.name = SQLITE_LIBRARY_WINDOW_PREFIX + JSON.stringify(sqliteState());
+        var state = sqliteState();
+        var fields = [];
+        var sliceStartedAt = performance.now();
+        for (var field of Object.keys(state)) {
+          var value = state[field];
+          var encoded;
+          if (['items', 'accounts', 'feeds', 'persons'].includes(field)) {
+            var rows = [];
+            for (var id of Object.keys(value)) {
+              var row = JSON.stringify(value[id]);
+              if (row !== undefined) rows.push(JSON.stringify(id) + ':' + row);
+              if (performance.now() - sliceStartedAt >= 4) {
+                await new Promise(function(resolve) { setTimeout(resolve, 0); });
+                sliceStartedAt = performance.now();
+              }
+            }
+            encoded = '{' + rows.join(',') + '}';
+          } else {
+            encoded = JSON.stringify(value);
+          }
+          if (encoded !== undefined) fields.push(JSON.stringify(field) + ':' + encoded);
+        }
+        window.name = SQLITE_LIBRARY_WINDOW_PREFIX + '{' + fields.join(',') + '}';
       } catch (error) {
         window.__TAURI_MOCK_SQLITE_PERSIST_ERROR__ = String(error);
         // Large performance fixtures may exceed browser storage. They do not
         // rely on reload persistence, so keep their authoritative mock in RAM.
       }
+    }
+    // Native IPC does not stringify the entire fixture on the renderer thread.
+    // Yield while encoding the browser-only reload snapshot, but serialize all
+    // writers and do not acknowledge any mutation before its snapshot is saved.
+    var sqliteMutationTail = Promise.resolve();
+    function serializedSqliteMutation(mutate) {
+      return function(args) {
+        var result = sqliteMutationTail.then(async function() {
+          var receipt = mutate(args);
+          await persistSqliteState();
+          return receipt;
+        });
+        sqliteMutationTail = result.catch(function() {});
+        return result;
+      };
     }
     function sqliteState() {
       return window.__TAURI_MOCK_SQLITE_LIBRARY__;
@@ -154,7 +191,6 @@ export function tauriInitScript() {
       var first = envelopes[0];
       envelopes.forEach(applyNormalizedEnvelope);
       sqliteState().revision += 1;
-      persistSqliteState();
       return {
         transactionId: first.transaction_id,
         actorId: first.actor_id,
@@ -368,7 +404,6 @@ export function tauriInitScript() {
       var previousRevision = sqliteState().revision;
       envelopes.forEach(applyNormalizedEnvelope);
       sqliteState().revision = previousRevision + 1;
-      persistSqliteState();
       return {
         transactionId: first.transaction_id,
         transactionDigest: first.transaction_digest,
@@ -1860,7 +1895,6 @@ export function tauriInitScript() {
         entity.graphUpdatedAt = mutation.updatedAt;
       }
       if (changed) state.revision += 1;
-      persistSqliteState();
       return {
         changed: changed,
         layoutRevision: state.revision,
@@ -1923,11 +1957,10 @@ export function tauriInitScript() {
       return null;
     }
     window.__TAURI_MOCK_HANDLERS__ = {
-      ensure_fresh_normalized_desktop_library: () => {
+      ensure_fresh_normalized_desktop_library: serializedSqliteMutation(() => {
         sqliteState().active = true;
-        persistSqliteState();
         return true;
-      },
+      }),
       describe_normalized_library_cloud_identity: normalizedLibraryCloudIdentity,
       query_normalized_library: sqliteNormalizedQuery,
       normalized_library_primary_mutation_context: normalizedPrimaryMutationContext,
@@ -1943,14 +1976,14 @@ export function tauriInitScript() {
         operationSigningBodyDigest: args.request.operationSigningBodyDigest,
         signature: 'd'.repeat(128),
       }),
-      enqueue_normalized_library_follower_intent: enqueueNormalizedFollowerIntent,
-      commit_normalized_library_transaction: commitNormalizedLibraryTransaction,
+      enqueue_normalized_library_follower_intent: serializedSqliteMutation(enqueueNormalizedFollowerIntent),
+      commit_normalized_library_transaction: serializedSqliteMutation(commitNormalizedLibraryTransaction),
       begin_normalized_scope_action: beginNormalizedScopeAction,
       append_normalized_scope_action: appendNormalizedScopeAction,
       finalize_normalized_scope_action: finalizeNormalizedScopeAction,
       page_normalized_scope_action: pageNormalizedScopeAction,
       close_normalized_scope_action: closeNormalizedScopeAction,
-      mutate_normalized_device_graph_layout: mutateDeviceGraphLayout,
+      mutate_normalized_device_graph_layout: serializedSqliteMutation(mutateDeviceGraphLayout),
       mutate_normalized_device_contacts: mutateDeviceContacts,
       query_normalized_device_contact_status: deviceContactStatus,
       query_normalized_device_contact_match_page: (args) => {

--- a/packages/desktop/src/__mocks__/tauri-init.test.ts
+++ b/packages/desktop/src/__mocks__/tauri-init.test.ts
@@ -1,7 +1,78 @@
-import { expect, it } from "vitest";
+import { expect, it, vi } from "vitest";
 import { generateSampleLibraryData } from "@freed/shared";
 import { decodeLibraryCoreItemScanCursorV1 } from "@freed/shared/library-core";
 import { tauriInitScript } from "./tauri-init.js";
+
+it("serializes yielding mock writes and saves each complete snapshot before acknowledgment", async () => {
+  vi.useFakeTimers();
+  try {
+    let time = 0;
+    const runtime = { name: "" } as {
+      name: string;
+      __TAURI_MOCK_SQLITE_LIBRARY__: {
+        revision: number;
+        items: Record<string, { globalId: string; userState: { readAt?: number } }>;
+      };
+      __TAURI_MOCK_HANDLERS__: Record<string, (args?: unknown) => Promise<unknown>>;
+    };
+    const boot = (target: unknown) => new Function("window", "performance", tauriInitScript())(
+      target, { now: () => time += 5 },
+    );
+    boot(runtime);
+    runtime.__TAURI_MOCK_SQLITE_LIBRARY__.items = {
+      first: { globalId: "first", userState: {} },
+      second: { globalId: "second", userState: {} },
+    };
+    const initialize = runtime.__TAURI_MOCK_HANDLERS__.ensure_fresh_normalized_desktop_library();
+    await vi.runAllTimersAsync();
+    await initialize;
+    const initialSnapshot = runtime.name;
+    const commit = (entityId: string, readAt: number) =>
+      runtime.__TAURI_MOCK_HANDLERS__.commit_normalized_library_transaction({
+        request: {
+          canonicalEnvelopeJson: [JSON.stringify({
+            entity_id: entityId,
+            operation_type: "feed_item_read_assignment",
+            payload: { read_at_ms: readAt },
+          })],
+        },
+      });
+    const acknowledged: string[] = [];
+    const first = commit("first", 123).then(() => acknowledged.push(runtime.name));
+    const second = commit("second", 456).then(() => acknowledged.push(runtime.name));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(runtime.name).toBe(initialSnapshot);
+    expect(acknowledged).toEqual([]);
+    expect(runtime.__TAURI_MOCK_SQLITE_LIBRARY__.items.second.userState.readAt).toBeUndefined();
+    await vi.runAllTimersAsync();
+    await Promise.all([first, second]);
+    const restored = acknowledged.map(name => {
+      const target = { name } as typeof runtime;
+      boot(target);
+      return target.__TAURI_MOCK_SQLITE_LIBRARY__;
+    });
+    expect(restored[0].revision).toBe(1);
+    expect(restored[0].items.first.userState.readAt).toBe(123);
+    expect(restored[0].items.second.userState.readAt).toBeUndefined();
+    expect(restored[1]).toEqual(runtime.__TAURI_MOCK_SQLITE_LIBRARY__);
+    expect(restored[1].revision).toBe(2);
+    expect(restored[1].items.second.userState.readAt).toBe(456);
+    // A rejected command must not poison the serialization queue.
+    await expect(runtime.__TAURI_MOCK_HANDLERS__.mutate_normalized_device_graph_layout({
+      mutation: { mutationId: "person_position_set_v1", entityId: "missing" },
+    })).rejects.toThrow("target is unavailable");
+    const next = commit("first", 789);
+    await vi.runAllTimersAsync();
+    await next;
+    const afterFailure = { name: runtime.name } as typeof runtime;
+    boot(afterFailure);
+    expect(afterFailure.__TAURI_MOCK_SQLITE_LIBRARY__).toEqual(runtime.__TAURI_MOCK_SQLITE_LIBRARY__);
+    expect(afterFailure.__TAURI_MOCK_SQLITE_LIBRARY__.items.first.userState.readAt).toBe(789);
+  } finally {
+    vi.useRealTimers();
+  }
+});
 
 it("preview cleanup scans the entire showcase with bounded source-bound cursors", () => {
   const runtime = {} as {

--- a/packages/desktop/tests/e2e/README.md
+++ b/packages/desktop/tests/e2e/README.md
@@ -68,8 +68,11 @@ checks, including the React Profiler case. External benchmark servers must use `
 production render-mode marker; a development preview fails the benchmark
 precondition. No performance limits are relaxed by this routing.
 
-Mock Library transactions retain their existing synchronous reload snapshots.
-Native SQLite commit acknowledgments and durability are unchanged.
+Mock Library writes are serialized and save the same complete reload snapshot
+before acknowledging a mutation. Encoding yields between bounded work slices so
+full-fixture serialization does not monopolize the renderer during scrolling.
+No snapshot is deferred until navigation. Native SQLite commit acknowledgments
+and durability are unchanged.
 
 ## Test-specific state and assertions
 


### PR DESCRIPTION
(AI Generated).

## Summary

Follow-up to #1855. The last complete Linux Desktop run passed 233 cases and failed the scroll LongTask count with three tasks against the unchanged limit of two. Frame delivery passed. The browser mock still serialized its entire fixture synchronously after every transaction, unlike native IPC.

* Encode the same complete reload snapshot in short work slices, yielding when a 4 ms slice is exhausted.
* Serialize the four existing mock writers through one queue and finish snapshot persistence before returning their receipts. There is no navigation-only persistence, cache, replay journal, or new restore format.
* Verify forced yields, ordered concurrent writes, exact immediate restoration after each acknowledgment, and queue recovery after a rejected command with a deterministic unit test.

Native SQLite, PWA storage, provider requests, timing, cookies, headers, storage epochs, activation manifests, releases, and installations are unchanged. Existing mock persistence-error recording remains unchanged. All performance budgets and existing reload assertions remain intact.

## Validation

* Strict doctor and refreshed main-backflow check passed.
* Feature validation passed root typecheck, 862 Desktop unit tests, ten retired-runtime guard tests, and ten Desktop smoke cases.
* Four unchanged reload workflows and both original scroll probes passed together in 23.6 seconds. Frame p95 was 10.2 ms with zero dropped frames.
* The complete local suite passed all 234 tests in 8.9 minutes with no retries. Scroll recorded zero long tasks, frame p95 10.2 ms, and zero dropped frames.
* No provider-visible committed diff.

Keep #1855 open until a fresh complete merged-source Linux Desktop run passes. Local results do not substitute for that requirement.