### PR TITLE
fix: select friend title during showcase capture

### DIFF
--- a/scripts/capture-showcase-local.mjs
+++ b/scripts/capture-showcase-local.mjs
@@ -300,7 +300,9 @@ try {
       // Search through the real directory so this located sample friend is
       // mounted regardless of the current activity ordering or virtualization.
       await page.getByRole("textbox", { name: "Search friends", exact: true }).fill("Sela Current");
-      await page.locator('[data-testid="friend-overview-virtual-row"] > [role="button"]').filter({ hasText: "Sela Current" }).first().click();
+      // The card center can land on its relationship slider at some font/layout
+      // metrics. Select its title, which bubbles through the normal card handler.
+      await page.locator('[data-testid="friend-overview-virtual-row"] > [role="button"]').getByText("Sela Current", { exact: true }).click();
       await page.locator('[data-testid="friends-sidebar"]').getByText("Recent activity", { exact: true }).waitFor();
       try {
         await page.locator('[data-testid="friends-sidebar"] [data-testid="map-surface"][data-map-ready="true"][data-map-tiles-ready="true"]').waitFor({ timeout: 30_000 });

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -501,6 +501,8 @@ test("production releases publish an exact-tag PWA showcase with reviewed media"
   const capture = readFileSync(path.join(scriptsDir, "capture-showcase-local.mjs"), "utf8");
   assert.match(capture, /Explore Freed Demo/);
   assert.match(capture, /await selectTheme\(page, capture.theme\)/);
+  assert.match(capture, /getByText\("Sela Current", \{ exact: true \}\)\.click\(\)/,
+    "friend detail capture must select the title, not the card center containing its slider");
   assert.doesNotMatch(capture, /page\.reload\(/);
   assert.match(capture, /unexpectedRequestUrls\.size > 0/);
   assert.match(capture, /remoteMediaUrls:/);


### PR DESCRIPTION
(AI Generated).

## Summary
- Target the friend title instead of the center of its card so the embedded relationship slider cannot consume the showcase selection click.

## Testing
- 19 release governance tests passed; validate:feature passed; production demo build and all six Ember captures passed.