### PR TITLE
fix: unify feed cards and polish friends presentation

### DIFF
--- a/packages/desktop/src/App.tsx
+++ b/packages/desktop/src/App.tsx
@@ -1456,7 +1456,8 @@ function App() {
       addRssFeed,
       importOPMLFeeds,
       exportFeedsAsOPML,
-      headerDragRegion: true,
+      // Browser previews have no native window controls to reserve space for.
+      headerDragRegion: isTauri(),
       startWindowDrag:
         import.meta.env.VITE_TEST_TAURI === "1" || isTauri()
           ? () => getCurrentWindow().startDragging()

--- a/packages/ui/src/components/feed/FeedItem.test.tsx
+++ b/packages/ui/src/components/feed/FeedItem.test.tsx
@@ -107,6 +107,16 @@ function setMemoryPressure(
 }
 
 beforeEach(() => {
+  // JSDOM does not implement the card's browser measurement APIs.
+  vi.stubGlobal("ResizeObserver", class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  });
+  Object.defineProperty(document, "fonts", {
+    configurable: true,
+    value: { ready: Promise.resolve(), addEventListener: vi.fn(), removeEventListener: vi.fn() },
+  });
   useDebugStore.setState({ runtimeMemory: null });
   setMobileNavigator(false);
   setTouchOnlyPointer(false);
@@ -188,6 +198,28 @@ describe("FeedItem read styling", () => {
 });
 
 describe("FeedItem card text previews", () => {
+  it.each([
+    { contentType: "post" as const, compact: false, layout: "split" },
+    { contentType: "story" as const, compact: false, layout: "photo" },
+    { contentType: "post" as const, compact: true, layout: "photo" },
+    { contentType: "story" as const, compact: true, layout: "photo" },
+  ])("shares the card structure for $contentType with compact=$compact", ({ contentType, compact, layout }) => {
+    const html = renderFeedItemToStaticMarkup(makeItem({
+      contentType,
+      location: { name: "Shared location", source: "geo_tag" },
+      content: { linkPreview: { title: "Shared title", url: "https://example.com" } },
+    }), { compact });
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    const card = container.querySelector("article")!;
+    expect(container.querySelectorAll("article")).toHaveLength(1);
+    expect(card.dataset.feedCardLayout).toBe(layout);
+    expect(card.querySelectorAll("h3")).toHaveLength(1);
+    expect(card.textContent).toContain("Shared location");
+    expect(card.style.contain).toBe("layout paint style");
+    expect(compact ? card.classList.contains("aspect-square") : card.style.height !== "").toBe(true);
+  });
+
   it("renders a bounded text preview for long regular posts", () => {
     const longText = `${"Opening sentence ".repeat(120)}needle-tail`;
     const html = renderFeedItemToStaticMarkup(
@@ -240,7 +272,7 @@ describe("FeedItem story media", () => {
       </PlatformProvider>,
     );
     expect(render(sample, true)).toContain("https://example.com/story.jpg");
-    expect(render(sample, true)).not.toContain("data:image/svg+xml,");
+    expect(render(sample, true)).not.toContain('src="data:image/svg+xml,');
     expect(render({
       ...sample,
       globalId: "instagram:sample:preview:author:media",
@@ -377,7 +409,7 @@ describe("FeedItem story media", () => {
     }
   });
 
-  it("renders regular card actions in a shared centered icon box", async () => {
+  it("omits card action buttons even when action callbacks are supplied", async () => {
     (globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     const container = document.createElement("div");
     document.body.appendChild(container);
@@ -408,18 +440,12 @@ describe("FeedItem story media", () => {
         );
       });
 
-      const actionLabels = ["Like", "Comment on Instagram", "Bookmark", "Archive", "Open"];
+      const actionLabels = ["Like", "Bookmark", "Archive"];
+      expect(container.querySelector('button[aria-label="Comment on Instagram"]')).toBeNull();
+      expect(container.querySelector('button[aria-label="Open"]')).toBeNull();
       for (const label of actionLabels) {
         const button = container.querySelector(`button[aria-label="${label}"]`) as HTMLButtonElement | null;
-        expect(button).toBeInstanceOf(HTMLButtonElement);
-        expect(button?.className).toContain("h-7");
-        expect(button?.className).toContain("items-center");
-        expect(button?.className).toContain("justify-center");
-
-        const icon = button?.querySelector("svg");
-        expect(icon?.getAttribute("class")).toContain("h-4");
-        expect(icon?.getAttribute("class")).toContain("w-4");
-        expect(icon?.getAttribute("class")).toContain("shrink-0");
+        expect(button).toBeNull();
       }
     } finally {
       await act(async () => {

--- a/packages/ui/src/components/feed/FeedItem.tsx
+++ b/packages/ui/src/components/feed/FeedItem.tsx
@@ -1,14 +1,13 @@
 import { memo, useEffect, useLayoutEffect, useRef, useState, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { formatDistanceToNow } from "date-fns";
-import { PLATFORM_LABELS, type FeedItem as FeedItemType } from "@freed/shared";
+import type { FeedItem as FeedItemType } from "@freed/shared";
 import { usePlatform } from "../../context/PlatformContext.js";
-import type { FeedCardDensity } from "../../lib/feed-card-density.js";
+import { DESKTOP_FEED_CARD_HEIGHT_BY_DENSITY, type FeedCardDensity } from "../../lib/feed-card-density.js";
 import { useDebugStore, type RuntimeMemorySnapshot } from "../../lib/debug-store.js";
 import { useHasTouchOnlyPointer } from "../../hooks/useHasTouchOnlyPointer.js";
 import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
 import { ChannelAvatar } from "../ChannelAvatar.js";
 import { isSamplePreviewItem } from "../../lib/sample-preview-media.js";
-import { Tooltip } from "../Tooltip.js";
 import {
   RssIcon,
   XIcon,
@@ -27,6 +26,8 @@ import {
 
 interface FeedItemProps {
   item: FeedItemType;
+  /** Text-only activity preview, using the same bounded card structure. */
+  summary?: boolean;
   onClick?: () => void;
   showEngagement?: boolean;
   showReadInGrayscale?: boolean;
@@ -52,7 +53,7 @@ interface FeedItemProps {
    * ratio (capped at 288px). Defaults to 288 if omitted.
    */
   storyHeight?: number;
-  /** Fixed primary-feed card height. Used by desktop virtualization. */
+  /** Fixed primary-feed card height, shared by desktop and mobile virtualization. */
   fixedHeight?: number;
 }
 
@@ -61,16 +62,11 @@ function feedCardTransitionName(globalId: string): string {
 }
 
 const cls = "w-3.5 h-3.5";
-const feedActionButtonClass = "inline-flex h-7 min-w-7 items-center justify-center gap-1 rounded-lg px-1.5 text-xs leading-none transition-colors";
-const feedIconActionButtonClass = "inline-flex h-7 w-7 items-center justify-center rounded-lg p-0 transition-colors";
-const feedActionIconClass = "block h-4 w-4 shrink-0";
-const feedActionStatusIconClass = "block h-2.5 w-2.5 shrink-0";
 const SWIPE_THRESHOLD = 72;
 const EVENT_CHIP_THRESHOLD = 0.7;
 const COMPACT_CARD_TEXT_LIMIT = 500;
 const COMPACT_CARD_WORD_LIMIT = 45;
 const FIXED_CARD_TEXT_LIMIT = 900;
-const FULL_CARD_TEXT_LIMIT = 1_500;
 const FEED_IMAGE_SHED_APP_PRESSURE_BYTES = 2.25 * 1024 * 1024 * 1024;
 const FEED_IMAGE_SHED_WEBKIT_BYTES = 1.5 * 1024 * 1024 * 1024;
 const FEED_IMAGE_SHED_APP_HIGH_FRACTION = 0.85;
@@ -106,44 +102,6 @@ const platformIcons: Record<string, ReactNode> = {
   substack: <SubstackIcon className={cls} />,
   medium: <MediumIcon className={cls} />,
   saved: <BookmarkIcon className={cls} />,
-};
-
-const PLATFORM_REACTIONS: Partial<Record<FeedItemType["platform"], ReadonlyArray<{ emoji: string; label: string }>>> = {
-  facebook: [
-    { emoji: "👍", label: "Like" },
-    { emoji: "❤️", label: "Love" },
-    { emoji: "😂", label: "Haha" },
-    { emoji: "😮", label: "Wow" },
-    { emoji: "😢", label: "Sad" },
-    { emoji: "😡", label: "Angry" },
-  ],
-  linkedin: [
-    { emoji: "👍", label: "Like" },
-    { emoji: "🎉", label: "Celebrate" },
-    { emoji: "🤝", label: "Support" },
-    { emoji: "😂", label: "Funny" },
-    { emoji: "❤️", label: "Love" },
-    { emoji: "💡", label: "Insightful" },
-    { emoji: "🤔", label: "Curious" },
-  ],
-  github: [
-    { emoji: "👍", label: "+1" },
-    { emoji: "👎", label: "-1" },
-    { emoji: "😄", label: "Laugh" },
-    { emoji: "🎉", label: "Hooray" },
-    { emoji: "😕", label: "Confused" },
-    { emoji: "❤️", label: "Heart" },
-    { emoji: "🚀", label: "Rocket" },
-    { emoji: "👀", label: "Eyes" },
-  ],
-  youtube: [
-    { emoji: "👍", label: "Like" },
-    { emoji: "👎", label: "Dislike" },
-  ],
-  reddit: [
-    { emoji: "⬆️", label: "Upvote" },
-    { emoji: "⬇️", label: "Downvote" },
-  ],
 };
 
 const FEED_CARD_LAYOUT_CONTAINMENT_STYLE = {
@@ -186,26 +144,6 @@ function useFeedImageBudget(feedMediaPreviews: "inline" | "reader-only"): {
   };
 }
 
-function likeState(item: FeedItemType): "none" | "noted" | "synced" | "failed" {
-  const us = item.userState;
-  if (!us.liked) return "none";
-  if (us.likedSyncedAt === -1) return "failed";
-  if (us.likedSyncedAt && us.likedSyncedAt > 0) return "synced";
-  return "noted";
-}
-
-function formatEngagementCount(value: number | undefined): string | null {
-  if (value === undefined) return null;
-  return value.toLocaleString();
-}
-
-function getLikeLabel(item: FeedItemType, state: ReturnType<typeof likeState>): string {
-  if (state === "synced") return `Liked on ${PLATFORM_LABELS[item.platform] ?? item.platform}`;
-  if (state === "noted") return `Liked, syncing to ${PLATFORM_LABELS[item.platform] ?? item.platform}...`;
-  if (state === "failed") return `Could not sync to ${PLATFORM_LABELS[item.platform] ?? item.platform}`;
-  return "Like";
-}
-
 function cardPreviewText(text: string | undefined, limit: number): string | null {
   const trimmed = text?.trim();
   if (!trimmed) return null;
@@ -222,16 +160,14 @@ function cardPreviewText(text: string | undefined, limit: number): string | null
 export const FeedItem = memo(function FeedItem({
   item,
   onClick,
-  showEngagement = false,
   showReadInGrayscale = true,
   focused = false,
   compact = false,
+  summary = false,
   narrow = false,
   selected = false,
   onMouseEnter,
-  onSave,
   onArchive,
-  onLike,
   density = "comfortable",
   storyHeight = 288,
   fixedHeight,
@@ -250,11 +186,11 @@ export const FeedItem = memo(function FeedItem({
   const platformIcon = platformIcons[item.platform] ?? <span className="text-xs">📄</span>;
   const isRead = Boolean(item.userState.readAt);
   const readVisualClass = isRead && showReadInGrayscale ? "grayscale opacity-60 hover:grayscale-0 hover:opacity-100 !transition-[filter,opacity] duration-300 motion-reduce:transition-none" : "";
-  const reactions = PLATFORM_REACTIONS[item.platform] ?? [];
-  const hasReactionPalette = reactions.length > 1;
-  const likeCount = formatEngagementCount(item.engagement?.likes);
   const semanticLabel = semanticChip(item);
   const firstMediaUrl = item.content.mediaUrls[0];
+  // Layout is a presentation option, never a separate card implementation.
+  const photoLayout = !summary && (compact || item.contentType === "story");
+  const cardHeight = compact ? undefined : photoLayout ? storyHeight : fixedHeight ?? DESKTOP_FEED_CARD_HEIGHT_BY_DENSITY[density];
   const photoCardRef = useRef<HTMLElement>(null);
   const [showPhotoTime, setShowPhotoTime] = useState(false);
   const [photoSizing, setPhotoSizing] = useState({ padding: 8, avatar: 16 });
@@ -283,7 +219,7 @@ export const FeedItem = memo(function FeedItem({
   const [compactTextLines, setCompactTextLines] = useState(0);
   useLayoutEffect(() => {
     const area = compactTextAreaRef.current;
-    if ((!compact && item.contentType !== "story") || !area) return;
+    if (!photoLayout || !area) return;
     let disposed = false;
     const measure = () => {
       if (disposed) return;
@@ -313,68 +249,19 @@ export const FeedItem = memo(function FeedItem({
       observer.disconnect();
       document.fonts.removeEventListener("loadingdone", measure);
     };
-  }, [compact, narrow, item.globalId, item.contentType, compactPreviewText, item.content.linkPreview?.title]);
-  const fixedPreviewText = cardPreviewText(item.content.text, FIXED_CARD_TEXT_LIMIT);
-  const fullPreviewText = cardPreviewText(item.content.text, FULL_CARD_TEXT_LIMIT);
+  }, [photoLayout, narrow, item.globalId, compactPreviewText, item.content.linkPreview?.title]);
+  const previewText = cardPreviewText(summary
+    ? item.content.text?.trim() || item.content.linkPreview?.title || "Open post"
+    : item.content.text, FIXED_CARD_TEXT_LIMIT);
 
   const [swipeX, setSwipeX] = useState(0);
   const [mediaFailed, setMediaFailed] = useState(false);
-  const fullCardDensity = {
+  const cardDensity = {
     compact: {
-      article: "p-3",
-      padding: "12px",
-      headerGap: "gap-2 mb-2",
-      avatarSize: 32,
-      author: "text-sm",
-      meta: "text-[0.6875rem]",
-      title: "mb-1 line-clamp-1 text-base leading-snug",
-      body: "mb-2 line-clamp-2 text-sm leading-relaxed",
-      chipWrap: "mb-2 gap-1.5",
-      chip: "px-2 py-0.5 text-[0.6875rem]",
-      mediaWrap: "mt-2 rounded-lg",
-      media: "h-36 sm:h-40",
-      tagWrap: "mt-2 gap-1.5",
-    },
-    comfortable: {
-      article: "",
-      padding: "20px",
-      headerGap: "gap-3 mb-3",
-      avatarSize: 40,
-      author: "",
-      meta: "text-xs",
-      title: "mb-1.5 line-clamp-2 text-lg leading-snug",
-      body: "mb-3 line-clamp-3 text-sm leading-[1.6]",
-      chipWrap: "mb-3 gap-2",
-      chip: "px-2.5 py-1 text-xs",
-      mediaWrap: "mt-3 rounded-xl",
-      media: "h-48 sm:h-56",
-      tagWrap: "mt-3 gap-2",
-    },
-    expansive: {
-      article: "p-6",
-      padding: "24px",
-      headerGap: "gap-3.5 mb-4",
-      avatarSize: 44,
-      author: "text-[1.0625rem]",
-      meta: "text-sm",
-      title: "mb-2 line-clamp-3 text-xl leading-snug",
-      body: "mb-4 line-clamp-5 text-sm leading-[1.6]",
-      chipWrap: "mb-4 gap-2",
-      chip: "px-3 py-1.5 text-xs",
-      mediaWrap: "mt-4 rounded-xl",
-      media: "h-64 sm:h-72",
-      tagWrap: "mt-4 gap-2",
-    },
-  }[density];
-  const fixedCardDensity = {
-    compact: {
-      article: "!p-0",
-      contentPadding: "p-4",
-      gap: "gap-2.5",
+      padding: "0.75rem",
+      textInset: "0.375rem",
       headerGap: "mb-1.5 gap-2",
-      avatarSize: 28,
       author: "text-[0.8125rem]",
-      handle: "text-xs",
       meta: "text-[0.6875rem]",
       title: "mb-0.5 line-clamp-1 text-sm leading-snug",
       bodyWithMedia: "line-clamp-1 text-xs leading-relaxed",
@@ -385,13 +272,10 @@ export const FeedItem = memo(function FeedItem({
       tagLimitWithoutMedia: 1,
     },
     comfortable: {
-      article: "!p-0",
-      contentPadding: "p-5",
-      gap: "gap-4",
+      padding: "1.25rem",
+      textInset: "0.5rem",
       headerGap: "mb-3 gap-3",
-      avatarSize: 40,
       author: "",
-      handle: "text-sm",
       meta: "text-xs",
       title: "mb-1.5 line-clamp-2 text-lg leading-snug",
       bodyWithMedia: "line-clamp-3 text-sm leading-[1.6]",
@@ -402,13 +286,10 @@ export const FeedItem = memo(function FeedItem({
       tagLimitWithoutMedia: 4,
     },
     expansive: {
-      article: "!p-0",
-      contentPadding: "p-6",
-      gap: "gap-5",
+      padding: "1.75rem",
+      textInset: "0.75rem",
       headerGap: "mb-4 gap-3.5",
-      avatarSize: 44,
       author: "text-[1.0625rem]",
-      handle: "text-sm",
       meta: "text-sm",
       title: "mb-2 line-clamp-3 text-xl leading-snug",
       bodyWithMedia: "line-clamp-5 text-sm leading-[1.6]",
@@ -419,7 +300,7 @@ export const FeedItem = memo(function FeedItem({
       tagLimitWithoutMedia: 6,
     },
   }[density];
-  const showFixedMedia = showInlineMedia && firstMediaUrl && !mediaFailed;
+  const showMedia = !summary && showInlineMedia && firstMediaUrl && !mediaFailed;
   const touchStartX = useRef(0);
   const touchStartY = useRef(0);
   const swipeLocked = useRef<"horizontal" | "vertical" | null>(null);
@@ -467,355 +348,21 @@ export const FeedItem = memo(function FeedItem({
     onClick?.();
   };
   const handleActivateKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.target !== event.currentTarget) return;
     if (event.key !== "Enter" && event.key !== " ") return;
     event.preventDefault();
     onClick?.();
   };
 
-  if (compact || item.contentType === "story") {
-    const showCompactMedia = showInlineMedia && firstMediaUrl && !mediaFailed;
-    const thumbnailTitle = item.content.linkPreview?.title || "";
-
-    return (
-      <div className="relative overflow-hidden rounded-[var(--feed-card-radius)]" style={sharedTransitionStyle}>
-        <article
-          ref={photoCardRef}
-          data-feed-item-id={item.globalId}
-          data-focused={focused ? "true" : "false"}
-          data-selected={selected ? "true" : "false"}
-          className={`feed-card group relative min-w-0 cursor-pointer ${compact ? "aspect-square" : ""} overflow-hidden flex flex-col transition-colors ${
-            selected
-              ? "border-l-2 border-l-[var(--theme-accent-secondary)] bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)]"
-              : quickActionsEnabled
-                ? "hover:bg-[var(--theme-bg-muted)]"
-                : ""
-          } ${readVisualClass}`}
-          style={{ ...FEED_CARD_LAYOUT_CONTAINMENT_STYLE, height: compact ? undefined : storyHeight, padding: photoSizing.padding / 2 }}
-          onClick={handleActivateClick}
-          onMouseEnter={onMouseEnter}
-          role="button"
-          tabIndex={0}
-          onKeyDown={handleActivateKeyDown}
-        >
-          {!showCompactMedia && item.contentType === "story" && (
-            <div className={`absolute inset-0 bg-gradient-to-br ${item.platform === "instagram" ? "from-[var(--theme-media-rss)] via-[var(--theme-media-instagram)] to-[var(--theme-accent-secondary)]" : "from-[var(--theme-media-facebook)] to-[var(--theme-media-linkedin)]"}`} />
-          )}
-          {showCompactMedia && (
-            <>
-              {item.content.mediaTypes[0] === "video" ? (
-                <video
-                  src={firstMediaUrl}
-                  muted
-                  playsInline
-                  controls={!compact}
-                  onClick={(event) => { if (!compact) event.stopPropagation(); }}
-                  preload="metadata"
-                  onError={() => setMediaFailed(true)}
-                  className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-[1.03] motion-reduce:transform-none motion-reduce:transition-none"
-                />
-              ) : (
-              <img
-                src={firstMediaUrl}
-                alt=""
-                loading="lazy"
-                decoding="async"
-                onError={() => setMediaFailed(true)}
-                className="absolute inset-0 h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-[1.03] motion-reduce:transform-none motion-reduce:transition-none"
-              />
-              )}
-              <div className="absolute inset-0 pointer-events-none transition-opacity duration-300 ease-out group-hover:opacity-0 motion-reduce:transition-none" style={{ background: "linear-gradient(to bottom, rgb(var(--theme-thumbnail-tint-rgb) / .3), rgb(var(--theme-thumbnail-tint-rgb) / .05), rgb(var(--theme-thumbnail-tint-rgb) / .7))" }} />
-              <div className="pointer-events-none absolute inset-0 bg-[rgb(var(--theme-thumbnail-tint-rgb)/0.45)] transition-opacity duration-300 ease-out motion-reduce:transition-none group-hover:opacity-0" />
-            </>
-          )}
-
-          {(
-            <div className="relative flex min-w-0 shrink-0 items-center gap-2">
-              <ChannelAvatar
-                name={item.author.displayName}
-                avatarUrl={showAvatarImages ? item.author.avatarUrl : null}
-                size={photoSizing.avatar}
-                className={`text-xs ring-1 ${showCompactMedia ? "ring-white/40" : "ring-white/10"}`}
-              />
-              <div className="flex-1 min-w-0">
-                <div className="flex min-w-0 items-center gap-2">
-                  <span className={`truncate font-medium ${compact ? "text-xs" : fixedCardDensity.author} ${showCompactMedia ? "text-white drop-shadow" : ""}`}>{item.author.displayName}</span>
-                </div>
-                {showPhotoTime && (
-                  <div className={`flex min-w-0 items-center gap-2 text-xs ${showCompactMedia ? "text-white/70" : "text-[var(--theme-text-muted)]"}`}>
-                    <span className="flex shrink-0 items-center">{platformIcon}</span>
-                    <span className="min-w-0 truncate">{timeAgo}</span>
-                  </div>
-                )}
-              </div>
-
-            </div>
-          )}
-
-          <div ref={compactTextAreaRef} className="relative flex min-h-0 min-w-0 flex-1 flex-col justify-end overflow-hidden" style={{ padding: photoSizing.padding / 2 }}>
-          {thumbnailTitle && (
-            <h3 title={thumbnailTitle} className={`relative m-0 min-w-0 shrink-0 truncate font-semibold leading-[1.6] ${showCompactMedia ? "text-white drop-shadow transition-[opacity,transform] duration-300 ease-out group-hover:opacity-0 group-hover:scale-[1.03] motion-reduce:transform-none motion-reduce:transition-none" : ""} ${compact ? (narrow ? "text-xs" : "text-sm") : "text-sm"}`}>
-              {thumbnailTitle}
-            </h3>
-          )}
-
-          {compactPreviewText && compactPreviewText !== thumbnailTitle && (
-            <p style={{ display: compactTextLines ? "-webkit-box" : "none", WebkitBoxOrient: "vertical", WebkitLineClamp: Math.max(1, Math.min(2, compactTextLines)), visibility: compactTextLines ? "visible" : "hidden" }} className={`m-0 min-w-0 shrink-0 overflow-hidden break-words ${showCompactMedia ? "text-white/85 drop-shadow transition-[opacity,transform] duration-300 ease-out group-hover:opacity-0 group-hover:scale-[1.03] motion-reduce:transform-none motion-reduce:transition-none" : "text-[var(--theme-text-secondary)]"} ${compact ? (narrow ? "text-[0.625rem]" : "text-xs") : "text-sm"} leading-[1.6]`}>
-              {compactPreviewText}
-            </p>
-          )}
-          </div>
-
-          <div className={`relative flex min-w-0 shrink-0 items-center gap-3 ${showCompactMedia ? "text-white/85 drop-shadow" : "text-[var(--theme-text-muted)]"}`}>
-            {item.location?.name && (
-              <span title={item.location.name} className={`ml-auto flex min-w-0 whitespace-nowrap items-center gap-1 rounded-full px-2 py-0.5 text-[0.625rem] ${showCompactMedia ? "bg-[rgb(var(--theme-thumbnail-tint-rgb)/0.35)]" : "bg-[var(--theme-bg-muted)]"}`}>
-                <svg className="h-2.5 w-2.5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                  <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
-                </svg>
-                <span className="min-w-0 truncate">{item.location.name}</span>
-              </span>
-            )}
-          </div>
-        </article>
-      </div>
-    );
-  }
-
-  const likeStatus = likeState(item);
-  const likeLabel = getLikeLabel(item, likeStatus);
-  const visibleTags = fixedHeight
+  const photoMedia = photoLayout && showMedia;
+  const visibleTags = !photoLayout
     ? item.userState.tags.slice(
         0,
-        showFixedMedia
-          ? fixedCardDensity.tagLimitWithMedia
-          : fixedCardDensity.tagLimitWithoutMedia,
+        showMedia
+          ? cardDensity.tagLimitWithMedia
+          : cardDensity.tagLimitWithoutMedia,
       )
-    : item.userState.tags;
-
-  if (fixedHeight) {
-    return (
-      <div className="relative overflow-hidden rounded-[var(--feed-card-radius)]" style={sharedTransitionStyle}>
-        {enableSwipe && swipeX < 0 && (
-          <div
-            className="absolute inset-y-0 right-0 flex items-center justify-end pr-5 rounded-[var(--feed-card-radius)] transition-colors"
-            style={{
-              width: `${Math.abs(swipeX) + 16}px`,
-              backgroundColor: pastThreshold
-                ? "rgb(var(--theme-feedback-success-rgb) / 0.25)"
-                : "rgb(var(--theme-feedback-success-rgb) / 0.12)",
-            }}
-            aria-hidden
-          >
-            <TrashIcon
-              className="h-5 w-5 text-[rgb(var(--theme-feedback-success-rgb))] transition-transform"
-              style={{ transform: `scale(${0.7 + swipeProgress * 0.3})`, opacity: swipeProgress } as React.CSSProperties}
-            />
-          </div>
-        )}
-
-        <article
-          ref={photoCardRef}
-          data-feed-item-id={item.globalId}
-          data-focused={focused ? "true" : "false"}
-          data-feed-card-density={density}
-          className={`feed-card group overflow-hidden min-w-0 cursor-pointer active:scale-[0.99] transition-transform ${fixedCardDensity.article} ${readVisualClass}`}
-          style={{
-            ...FEED_CARD_LAYOUT_CONTAINMENT_STYLE,
-            height: fixedHeight,
-            transform: swipeX !== 0 ? `translateX(${swipeX}px)` : undefined,
-            transition: swipeX === 0 ? "transform 0.25s ease" : undefined,
-            willChange: swipeX !== 0 ? "transform" : undefined,
-          }}
-          onClick={handleActivateClick}
-          onMouseEnter={onMouseEnter}
-          onTouchStart={enableSwipe ? handleTouchStart : undefined}
-          onTouchMove={enableSwipe ? handleTouchMove : undefined}
-          onTouchEnd={enableSwipe ? handleTouchEnd : undefined}
-          role="button"
-          tabIndex={0}
-          onKeyDown={handleActivateKeyDown}
-        >
-          <div className={`flex h-full min-h-0 min-w-0 transition-colors group-hover:bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)] ${showFixedMedia ? "items-stretch" : "items-start"}`}>
-            <div className="flex min-w-0 flex-1 flex-col" style={{ padding: photoSizing.padding / 2 }}>
-              <div className={`flex min-w-0 items-center ${fixedCardDensity.headerGap}`}>
-                <ChannelAvatar
-                  name={item.author.displayName}
-                  avatarUrl={showAvatarImages ? item.author.avatarUrl : null}
-                  size={photoSizing.avatar}
-                  className="text-lg ring-1 ring-white/10"
-                />
-                <div className="min-w-0 flex-1 -translate-y-0.5 leading-tight">
-                  <div className="flex min-w-0 items-center gap-2">
-                    <span className={`truncate font-medium ${fixedCardDensity.author}`}>{item.author.displayName}</span>
-                  </div>
-                  <div className={`flex min-w-0 items-center gap-2 ${fixedCardDensity.meta} text-[var(--theme-text-muted)]`}>
-                    <span>{platformIcon}</span>
-                    <span className="min-w-0 truncate">{timeAgo}</span>
-                    {item.preservedContent?.readingTime && (
-                      <>
-                        <span>•</span>
-                        <span>{item.preservedContent.readingTime} min</span>
-                      </>
-                    )}
-                  </div>
-                </div>
-
-                {quickActionsEnabled ? (
-                  <div className="flex shrink-0 items-center gap-1">
-                    {onLike && (
-                      <div className="relative group/reactions">
-                        {hasReactionPalette && (
-                          <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
-                            {reactions.map((reaction) => (
-                              <Tooltip key={reaction.label} label={reaction.label} side="top">
-                                <button
-                                  type="button"
-                                  onClick={(e) => { e.stopPropagation(); onLike(e as unknown as React.MouseEvent); }}
-                                  className="flex h-8 w-8 items-center justify-center rounded-lg text-base transition-transform hover:scale-110 hover:bg-white/10"
-                                  aria-label={reaction.label}
-                                >
-                                  <span aria-hidden="true">{reaction.emoji}</span>
-                                </button>
-                              </Tooltip>
-                            ))}
-                          </div>
-                        )}
-
-                        <Tooltip label={likeLabel} side="top">
-                          <button
-                            onClick={(e) => { e.stopPropagation(); onLike(e); }}
-                            aria-label={likeLabel}
-                            className={`${feedActionButtonClass} ${
-                              likeStatus !== "none" ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                            } ${
-                              likeStatus === "synced"
-                                ? "text-red-400"
-                                : likeStatus === "noted"
-                                ? "text-amber-400"
-                                : likeStatus === "failed"
-                                ? "text-orange-400"
-                              : "text-[var(--theme-text-soft)] hover:text-red-400"
-                            }`}
-                          >
-                            <svg className={feedActionIconClass} viewBox="0 0 24 24" fill={likeStatus !== "none" ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2}>
-                              <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                            </svg>
-                            {showEngagement && likeCount !== null && <span>{likeCount}</span>}
-                            {likeStatus === "noted" && (
-                              <svg className={`${feedActionStatusIconClass} animate-spin opacity-70`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                              </svg>
-                            )}
-                            {likeStatus === "failed" && (
-                              <svg className={`${feedActionStatusIconClass} opacity-70`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                                <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                              </svg>
-                            )}
-                          </button>
-                        </Tooltip>
-                      </div>
-                    )}
-
-                    {onSave && (
-                      <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"} side="top">
-                        <button
-                          onClick={onSave}
-                          aria-label={item.userState.saved ? "Remove bookmark" : "Bookmark"}
-                          className={`${feedIconActionButtonClass} ${
-                            item.userState.saved
-                              ? "text-[var(--theme-accent-secondary)]"
-                              : "text-[var(--theme-text-soft)] hover:text-[var(--theme-accent-secondary)] opacity-0 group-hover:opacity-100"
-                          }`}
-                        >
-                          <svg className={feedActionIconClass} fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-                          </svg>
-                        </button>
-                      </Tooltip>
-                    )}
-
-                    {onArchive && !item.userState.saved && (
-                      <Tooltip label="Archive" side="top">
-                        <button
-                          onClick={onArchive}
-                          aria-label="Archive"
-                          className={`${feedIconActionButtonClass} text-[var(--theme-text-soft)] hover:text-[rgb(var(--theme-feedback-success-rgb))] opacity-0 group-hover:opacity-100`}
-                        >
-                          <TrashIcon className={feedActionIconClass} />
-                        </button>
-                      </Tooltip>
-                    )}
-                  </div>
-                ) : null}
-              </div>
-
-              <div className="flex min-h-0 flex-1 flex-col justify-center" style={{ padding: photoSizing.padding / 2 }}>
-              {item.content.linkPreview?.title && (
-                <h3 className={`min-w-0 break-words font-semibold ${fixedCardDensity.title}`}>
-                  {item.content.linkPreview.title}
-                </h3>
-              )}
-
-              {fixedPreviewText && (
-                <p className={`min-h-0 min-w-0 break-words text-[var(--theme-text-secondary)] ${showFixedMedia ? fixedCardDensity.bodyWithMedia : fixedCardDensity.bodyWithoutMedia}`}>
-                  {fixedPreviewText}
-                </p>
-              )}
-              </div>
-
-              {(semanticLabel || visibleTags.length > 0) && (
-                <div className={`mt-auto flex min-w-0 flex-wrap overflow-hidden ${fixedCardDensity.chipWrap}`}>
-                  {semanticLabel && (
-                    <span className={`theme-accent-tag max-w-full truncate rounded-full ${fixedCardDensity.chip}`}>
-                      {semanticLabel}
-                    </span>
-                  )}
-                  {visibleTags.map((tag) => (
-                    <span
-                      key={tag}
-                      className={`theme-accent-tag max-w-full truncate rounded-full ${fixedCardDensity.chip}`}
-                    >
-                      {tag}
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-
-            {showFixedMedia && (
-              <div
-                className="relative h-full max-w-[50%] shrink-0"
-                style={{
-                  width: fixedHeight * 4 / 3,
-                }}
-              >
-                <div className="absolute inset-y-0 -left-6 right-0 overflow-hidden" style={{
-                  // Fade the media itself so every theme's actual card surface
-                  // shows through, including its hover and read states.
-                  maskImage: "linear-gradient(to right, transparent, black 48%)",
-                  WebkitMaskImage: "linear-gradient(to right, transparent, black 48%)",
-                }}>
-                <img
-                  src={firstMediaUrl}
-                  alt=""
-                  loading="lazy"
-                  decoding="async"
-                  onError={() => setMediaFailed(true)}
-                  className="h-full w-full object-cover transition-transform duration-300 group-hover:scale-[1.03] motion-reduce:transform-none"
-                />
-                <div aria-hidden="true" className="pointer-events-none absolute inset-y-0 left-0 w-[48%] opacity-20 mix-blend-soft-light" style={{
-                  backgroundImage: "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 160 160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E\")",
-                  backgroundSize: "160px 160px",
-                  maskImage: "linear-gradient(to right, black, transparent)",
-                  WebkitMaskImage: "linear-gradient(to right, black, transparent)",
-                }} />
-                </div>
-              </div>
-            )}
-          </div>
-        </article>
-      </div>
-    );
-  }
+    : [];
 
   return (
     <div className="relative overflow-hidden rounded-[var(--feed-card-radius)]" style={sharedTransitionStyle}>
@@ -842,10 +389,12 @@ export const FeedItem = memo(function FeedItem({
         data-feed-item-id={item.globalId}
         data-focused={focused ? "true" : "false"}
         data-feed-card-density={density}
-        className={`feed-card group hover:!bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)] min-w-0 cursor-pointer active:scale-[0.99] transition-transform ${fullCardDensity.article} ${readVisualClass}`}
+        data-feed-card-layout={summary ? "summary" : photoLayout ? "photo" : "split"}
+        data-selected={selected ? "true" : "false"}
+        className={`feed-card group relative overflow-hidden min-w-0 cursor-pointer active:scale-[0.99] transition-transform !p-0 ${summary ? "!rounded-2xl" : ""} ${quickActionsEnabled ? photoLayout ? "hover:!bg-[var(--theme-bg-muted)]" : "hover:!bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)]" : ""} ${compact ? "aspect-square" : ""} ${selected ? "border-l-2 border-l-[var(--theme-accent-secondary)] bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)]" : ""} ${readVisualClass}`}
         style={{
           ...FEED_CARD_LAYOUT_CONTAINMENT_STYLE,
-          padding: photoSizing.padding / 2,
+          height: cardHeight,
           transform: swipeX !== 0 ? `translateX(${swipeX}px)` : undefined,
           transition: swipeX === 0 ? "transform 0.25s ease" : undefined,
           willChange: swipeX !== 0 ? "transform" : undefined,
@@ -856,166 +405,113 @@ export const FeedItem = memo(function FeedItem({
         onTouchMove={enableSwipe ? handleTouchMove : undefined}
         onTouchEnd={enableSwipe ? handleTouchEnd : undefined}
         role="button"
+        aria-label={summary ? `Read post: ${previewText}` : undefined}
         tabIndex={0}
         onKeyDown={handleActivateKeyDown}
       >
-        <div className={`flex min-w-0 items-center ${fullCardDensity.headerGap}`}>
-          <ChannelAvatar
-            name={item.author.displayName}
-            avatarUrl={showAvatarImages ? item.author.avatarUrl : null}
-            size={fullCardDensity.avatarSize}
-            className="text-lg ring-1 ring-white/10"
-          />
-          <div className="flex-1 min-w-0">
-            <div className="flex min-w-0 flex-wrap items-center gap-2">
-              <span className={`font-medium truncate ${fullCardDensity.author}`}>{item.author.displayName}</span>
-            </div>
-            <div className={`flex min-w-0 items-center gap-2 ${fullCardDensity.meta} text-[var(--theme-text-muted)]`}>
-              <span>{platformIcon}</span>
-              <span className="min-w-0 truncate">{timeAgo}</span>
-              {item.preservedContent?.readingTime && (
-                <>
-                  <span>•</span>
-                  <span>{item.preservedContent.readingTime} min</span>
-                </>
-              )}
-            </div>
-          </div>
 
-          {quickActionsEnabled ? (
-            <div className="flex items-center gap-1 shrink-0">
-              {onLike && (
-                <div className="relative group/reactions">
-                  {hasReactionPalette && (
-                    <div className="pointer-events-none absolute right-0 bottom-full mb-2 flex translate-y-1 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-elevated)] p-1 opacity-0 shadow-lg shadow-black/30 transition-all group-hover/reactions:pointer-events-auto group-hover/reactions:translate-y-0 group-hover/reactions:opacity-100 group-focus-within/reactions:pointer-events-auto group-focus-within/reactions:translate-y-0 group-focus-within/reactions:opacity-100">
-                      {reactions.map((reaction) => (
-                        <Tooltip key={reaction.label} label={reaction.label} side="top">
-                          <button
-                            type="button"
-                            onClick={(e) => { e.stopPropagation(); onLike(e as unknown as React.MouseEvent); }}
-                            className="flex h-8 w-8 items-center justify-center rounded-lg text-base transition-transform hover:scale-110 hover:bg-white/10"
-                            aria-label={reaction.label}
-                          >
-                            <span aria-hidden="true">{reaction.emoji}</span>
-                          </button>
-                        </Tooltip>
-                      ))}
-                    </div>
+        {showMedia && (
+          <div aria-hidden={item.content.mediaTypes[0] === "video" ? undefined : true} className="absolute inset-y-0 right-0 overflow-hidden" style={{
+            width: photoLayout ? "100%" : `calc(50% + 1.5rem)`,
+            maskImage: photoLayout ? undefined : "linear-gradient(to right, transparent, black 65%)",
+            WebkitMaskImage: photoLayout ? undefined : "linear-gradient(to right, transparent, black 65%)",
+          }}>
+            {photoLayout && item.content.mediaTypes[0] === "video" ? (
+              <video src={firstMediaUrl} muted playsInline controls={!compact} preload="metadata"
+                onClick={(event) => { if (!compact) event.stopPropagation(); }}
+                onError={() => setMediaFailed(true)} className="h-full w-full object-cover" />
+            ) : (
+              <img src={firstMediaUrl} alt="" loading="lazy" decoding="async"
+                onError={() => setMediaFailed(true)}
+                className="h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-[1.03] motion-reduce:transform-none motion-reduce:transition-none" />
+            )}
+            <div aria-hidden="true" className={`pointer-events-none absolute mix-blend-soft-light ${photoLayout ? "inset-0 opacity-15" : "inset-y-0 left-0 w-[65%] opacity-30"}`} style={{
+                backgroundImage: "url(\"data:image/svg+xml,%3Csvg viewBox='0 0 160 160' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='.82' numOctaves='4' stitchTiles='stitch'/%3E%3CfeColorMatrix type='saturate' values='0'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E\")",
+                backgroundSize: "160px 160px",
+                maskImage: photoLayout ? "linear-gradient(to bottom, black, transparent 40%, black)" : "linear-gradient(to right, black, transparent)",
+                WebkitMaskImage: photoLayout ? "linear-gradient(to bottom, black, transparent 40%, black)" : "linear-gradient(to right, black, transparent)",
+              }} />
+            {photoLayout && <>
+              <div className="absolute inset-0 pointer-events-none transition-opacity duration-300 ease-out group-hover:opacity-0 motion-reduce:transition-none" style={{ background: "linear-gradient(to bottom, rgb(var(--theme-thumbnail-tint-rgb) / .3), rgb(var(--theme-thumbnail-tint-rgb) / .05), rgb(var(--theme-thumbnail-tint-rgb) / .7))" }} />
+              <div className="pointer-events-none absolute inset-0 bg-[rgb(var(--theme-thumbnail-tint-rgb)/0.45)] transition-opacity duration-300 ease-out motion-reduce:transition-none group-hover:opacity-0" />
+            </>}
+          </div>
+        )}
+        {!showMedia && photoLayout && item.contentType === "story" && (
+          <div className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${item.platform === "instagram" ? "from-[var(--theme-media-rss)] via-[var(--theme-media-instagram)] to-[var(--theme-accent-secondary)]" : "from-[var(--theme-media-facebook)] to-[var(--theme-media-linkedin)]"}`} />
+        )}
+        <div className="relative flex h-full min-h-0 min-w-0 pointer-events-none">
+          <div className="flex min-w-0 flex-col pointer-events-auto" style={{ padding: summary ? 12 : compact ? photoSizing.padding / 2 : cardDensity.padding, width: !photoLayout && showMedia ? "55%" : "100%" }}>
+
+            <div className={`flex min-w-0 items-center ${photoLayout ? "gap-2" : cardDensity.headerGap}`} style={compact ? { padding: photoSizing.padding / 2 } : undefined}>
+              {!summary && <ChannelAvatar
+                name={item.author.displayName}
+                avatarUrl={showAvatarImages ? item.author.avatarUrl : null}
+                size={photoSizing.avatar}
+                className={`text-xs ring-1 ${photoMedia ? "ring-white/40" : "ring-white/10"}`}
+              />}
+              <div className="min-w-0 flex-1 leading-tight" style={{ columnGap: "inherit" }}>
+                {!summary && <div className="flex min-w-0 items-center" style={{ columnGap: "inherit" }}>
+                  <span className={`truncate font-medium ${compact ? "text-xs" : cardDensity.author} ${photoMedia ? "text-white drop-shadow" : ""}`}>{item.author.displayName}</span>
+                  <span className={`flex shrink-0 items-center ${photoLayout ? "ml-auto" : ""} ${photoMedia ? "text-white/70" : "text-[var(--theme-text-muted)]"}`}>{platformIcon}</span>
+                </div>}
+                {(!photoLayout || showPhotoTime) && <div className={`flex min-w-0 items-center gap-2 ${summary ? "justify-end" : "mt-0.5"} ${cardDensity.meta} ${photoMedia ? "text-white/70" : "text-[var(--theme-text-muted)]"}`}>
+                  <span className="min-w-0 truncate">{timeAgo}</span>
+                  {item.preservedContent?.readingTime && (
+                    <>
+                      <span>•</span>
+                      <span>{item.preservedContent.readingTime} min</span>
+                    </>
                   )}
+                </div>}
+              </div>
 
-                  <Tooltip label={likeLabel} side="top">
-                    <button
-                      onClick={(e) => { e.stopPropagation(); onLike(e); }}
-                      aria-label={likeLabel}
-                      className={`${feedActionButtonClass} ${
-                        likeStatus !== "none" ? "opacity-100" : "opacity-0 group-hover:opacity-100 group-focus-within:opacity-100"
-                      } ${
-                        likeStatus === "synced"
-                          ? "text-red-400"
-                          : likeStatus === "noted"
-                          ? "text-amber-400"
-                          : likeStatus === "failed"
-                          ? "text-orange-400"
-                        : "text-[var(--theme-text-soft)] hover:text-red-400"
-                      }`}
-                    >
-                      <svg className={feedActionIconClass} viewBox="0 0 24 24" fill={likeStatus !== "none" ? "currentColor" : "none"} stroke="currentColor" strokeWidth={2}>
-                        <path strokeLinecap="round" strokeLinejoin="round" d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z" />
-                      </svg>
-                      {showEngagement && likeCount !== null && <span>{likeCount}</span>}
-                      {likeStatus === "noted" && (
-                        <svg className={`${feedActionStatusIconClass} animate-spin opacity-70`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M4 4v5h.582m15.356 2A8.001 8.001 0 004.582 9m0 0H9m11 11v-5h-.581m0 0a8.003 8.003 0 01-15.357-2m15.357 2H15" />
-                        </svg>
-                      )}
-                      {likeStatus === "failed" && (
-                        <svg className={`${feedActionStatusIconClass} opacity-70`} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2.5}>
-                          <path strokeLinecap="round" strokeLinejoin="round" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                        </svg>
-                      )}
-                    </button>
-                  </Tooltip>
-                </div>
+            </div>
+
+            <div ref={compactTextAreaRef} className={`relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden ${photoMedia ? "feed-card-photo-copy" : ""} ${photoLayout ? "justify-end" : "justify-center"}`} style={{ padding: summary ? 0 : compact ? photoSizing.padding / 2 : cardDensity.textInset }}>
+              {!summary && item.content.linkPreview?.title && (
+                <h3 className={`min-w-0 shrink-0 break-words font-semibold ${photoLayout ? "m-0 truncate leading-[1.6] " + (compact && narrow ? "text-xs" : "text-sm") : cardDensity.title} ${photoMedia ? "text-white drop-shadow" : ""}`}>
+                  {item.content.linkPreview.title}
+                </h3>
               )}
 
-              {onSave && (
-                <Tooltip label={item.userState.saved ? "Remove bookmark" : "Bookmark"} side="top">
-                  <button
-                    onClick={onSave}
-                    aria-label={item.userState.saved ? "Remove bookmark" : "Bookmark"}
-                    className={`${feedIconActionButtonClass} ${
-                      item.userState.saved
-                        ? "text-[var(--theme-accent-secondary)]"
-                        : "text-[var(--theme-text-soft)] hover:text-[var(--theme-accent-secondary)] opacity-0 group-hover:opacity-100"
-                    }`}
-                  >
-                    <svg className={feedActionIconClass} fill={item.userState.saved ? "currentColor" : "none"} viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 5a2 2 0 012-2h10a2 2 0 012 2v16l-7-3.5L5 21V5z" />
-                    </svg>
-                  </button>
-                </Tooltip>
-              )}
-
-              {onArchive && !item.userState.saved && (
-                <Tooltip label="Archive" side="top">
-                  <button
-                    onClick={onArchive}
-                    aria-label="Archive"
-                    className={`${feedIconActionButtonClass} text-[var(--theme-text-soft)] hover:text-[rgb(var(--theme-feedback-success-rgb))] opacity-0 group-hover:opacity-100`}
-                  >
-                    <TrashIcon className={feedActionIconClass} />
-                  </button>
-                </Tooltip>
+              {(photoLayout ? compactPreviewText : previewText) && (
+                <p style={photoLayout ? { display: compactTextLines ? "-webkit-box" : "none", WebkitBoxOrient: "vertical", WebkitLineClamp: Math.max(1, Math.min(2, compactTextLines)) } : undefined} className={`min-h-0 min-w-0 overflow-hidden break-words ${photoMedia ? "text-white/85 drop-shadow" : summary ? "text-[var(--theme-text-primary)]" : "text-[var(--theme-text-secondary)]"} ${photoLayout ? "m-0 shrink-0 leading-[1.6] " + (compact ? narrow ? "text-[0.625rem]" : "text-xs" : "text-sm") : summary ? "line-clamp-3 text-sm" : showMedia ? cardDensity.bodyWithMedia : cardDensity.bodyWithoutMedia}`}>
+                  {photoLayout ? compactPreviewText : previewText}
+                </p>
               )}
             </div>
-          ) : null}
+
+            <div className={`relative flex min-w-0 shrink-0 items-center gap-3 ${photoMedia ? "text-white/85 drop-shadow" : "text-[var(--theme-text-muted)]"}`}>
+              {!summary && item.location?.name && (
+                <span title={item.location.name} className={`${photoLayout ? "ml-auto" : "mr-auto"} flex min-w-0 whitespace-nowrap items-center gap-1 rounded-full px-2 py-0.5 text-[0.625rem] ${photoMedia ? "bg-[rgb(var(--theme-thumbnail-tint-rgb)/0.35)]" : "bg-[var(--theme-bg-muted)]"}`}>
+                  <svg className="h-2.5 w-2.5 shrink-0" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 2C8.13 2 5 5.13 5 9c0 5.25 7 13 7 13s7-7.75 7-13c0-3.87-3.13-7-7-7zm0 9.5c-1.38 0-2.5-1.12-2.5-2.5s1.12-2.5 2.5-2.5 2.5 1.12 2.5 2.5-1.12 2.5-2.5 2.5z" />
+                  </svg>
+                  <span className="min-w-0 truncate">{item.location.name}</span>
+                </span>
+              )}
+            </div>
+
+            {(!compact && !summary && (semanticLabel || visibleTags.length > 0)) && (
+              <div className={`mt-auto flex min-w-0 flex-wrap overflow-hidden ${cardDensity.chipWrap}`}>
+                {semanticLabel && (
+                  <span className={`theme-accent-tag max-w-full truncate rounded-full ${cardDensity.chip}`}>
+                    {semanticLabel}
+                  </span>
+                )}
+                {visibleTags.map((tag) => (
+                  <span
+                    key={tag}
+                    className={`theme-accent-tag max-w-full truncate rounded-full ${cardDensity.chip}`}
+                  >
+                    {tag}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
         </div>
-
-        {item.content.linkPreview?.title && (
-          <h3 style={{ paddingInline: photoSizing.padding / 2 }} className={`min-w-0 break-words font-semibold ${fullCardDensity.title}`}>
-            {item.content.linkPreview.title}
-          </h3>
-        )}
-
-        {fullPreviewText && (
-          <p style={{ paddingInline: photoSizing.padding / 2 }} className={`min-w-0 break-words ${fullCardDensity.body} text-[var(--theme-text-secondary)]`}>
-            {fullPreviewText}
-          </p>
-        )}
-
-        {semanticLabel && (
-          <div className={`flex min-w-0 flex-wrap ${fullCardDensity.chipWrap}`}>
-            <span className={`theme-accent-tag max-w-full truncate rounded-full ${fullCardDensity.chip}`}>
-              {semanticLabel}
-            </span>
-          </div>
-        )}
-
-        {showInlineMedia && firstMediaUrl && !mediaFailed && (
-          <div className={`${fullCardDensity.mediaWrap} overflow-hidden ring-1 ring-white/5`}>
-            <img
-              src={firstMediaUrl}
-              alt=""
-              loading="lazy"
-              decoding="async"
-              onError={() => setMediaFailed(true)}
-              className={`w-full ${fullCardDensity.media} object-cover bg-white/5`}
-            />
-          </div>
-        )}
-
-        {visibleTags.length > 0 && (
-          <div className={`flex min-w-0 flex-wrap ${fullCardDensity.tagWrap}`}>
-            {visibleTags.map((tag) => (
-              <span
-                key={tag}
-                className={`theme-accent-tag max-w-full truncate rounded-full ${fullCardDensity.chip}`}
-              >
-                {tag}
-              </span>
-            ))}
-          </div>
-        )}
       </article>
     </div>
   );

--- a/packages/ui/src/components/feed/FeedList.tsx
+++ b/packages/ui/src/components/feed/FeedList.tsx
@@ -33,14 +33,9 @@ const TILE_GAP = FEED_CARD_GAP;
 const MIN_TILE_W = 80; // minimum tile width before a column wraps
 // Tailwind max-w-2xl = 42rem = 672px.
 const MAX_CONTENT_W = 672;
-const ITEM_ROW_ESTIMATE_BY_DENSITY: Record<FeedCardDensity, number> = {
-  compact: 172,
-  comfortable: 220,
-  expansive: 300,
-};
 const MAX_TILE_H_BY_DENSITY: Record<FeedCardDensity, number> = {
-  compact: 220,
-  comfortable: 288,
+  compact: 252,
+  comfortable: 316,
   expansive: 340,
 };
 
@@ -415,7 +410,7 @@ export function FeedList({
       if (!isMobile) return estimateDesktopRowSize(index);
       const row = rows[index];
       if (!row || row.type !== "stories")
-        return ITEM_ROW_ESTIMATE_BY_DENSITY[cardDensity];
+        return desktopFeedCardHeight + FEED_CARD_GAP + (index === 0 ? FEED_CARD_GAP : 0);
       const inner = Math.max(
         Math.min(containerWidth, MAX_CONTENT_W) - feedCardHorizontalGutter * 2,
         0,
@@ -432,6 +427,7 @@ export function FeedList({
     },
     [
       cardDensity,
+      desktopFeedCardHeight,
       estimateDesktopRowSize,
       isMobile,
       rows,
@@ -935,6 +931,7 @@ export function FeedList({
                       onItemSave={onItemSave}
                       onItemLike={onItemLike}
                       onOpenCommentUrl={onOpenCommentUrl}
+                      fixedHeight={desktopFeedCardHeight}
                     />
                   )}
                 </div>

--- a/packages/ui/src/components/friends/CareRating.tsx
+++ b/packages/ui/src/components/friends/CareRating.tsx
@@ -1,4 +1,5 @@
 import { useLayoutEffect, useRef, useState, type CSSProperties } from "react";
+import { Tooltip } from "../Tooltip.js";
 
 export type CareLevel = 1 | 2 | 3 | 4 | 5;
 
@@ -37,6 +38,7 @@ export function CareRating({ level, onChange }: {
   };
   return (
     <div className="w-full min-w-0" onClick={event => event.stopPropagation()} onKeyDown={event => event.stopPropagation()}>
+      <Tooltip label="Importance in My Life" side="top" className="block w-full">
       <div className="friend-closeness-control" style={{
         "--care-handle-width": handleWidth ? `${handleWidth}px` : "7rem",
         "--care-position": ((preview ?? level) - 1) / 4,
@@ -58,6 +60,7 @@ export function CareRating({ level, onChange }: {
         onBlur={event => void commit(Number(event.currentTarget.value) as CareLevel)}
       />
       </div>
+      </Tooltip>
       {error && <p role="alert" className="text-xs theme-feedback-text-warning">Could not save the relationship setting. Please try again.</p>}
     </div>
   );

--- a/packages/ui/src/components/friends/FriendDetailPanel.tsx
+++ b/packages/ui/src/components/friends/FriendDetailPanel.tsx
@@ -166,7 +166,7 @@ export function FriendDetailPanel({
             </p>
           </div>
         </div>
-        <div className="mt-3">
+        <div className="mt-1">
           <CareRating level={friend.careLevel} onChange={onCareLevelChange} />
         </div>
         {friend.bio && (

--- a/packages/ui/src/components/friends/FriendOverview.tsx
+++ b/packages/ui/src/components/friends/FriendOverview.tsx
@@ -1,4 +1,5 @@
 import { formatDistanceToNow } from "date-fns";
+import type { ReactNode } from "react";
 import { FriendAvatar } from "./FriendAvatar.js";
 import { MapPinIcon } from "../icons.js";
 import { CareRating, type CareLevel } from "./CareRating.js";
@@ -15,6 +16,7 @@ export function FriendOverview({
   careLevel,
   latestActivityAt,
   onCareLevelChange,
+  headerActions,
 }: {
   name: string;
   id?: string;
@@ -27,6 +29,7 @@ export function FriendOverview({
   hasLocation?: boolean;
   needsOutreach?: boolean;
   onCareLevelChange?: (level: CareLevel) => void | Promise<void>;
+  headerActions?: ReactNode;
 }) {
   const sourceVersion = useAppStore(state => state.searchCorpusVersion);
   const candidates = useLibraryMapCandidates(sourceVersion);
@@ -35,21 +38,25 @@ export function FriendOverview({
     .sort((a, b) => b.item.publishedAt - a.item.publishedAt)
     .find(candidate => candidate.item.location?.name)?.item.location?.name;
   return (
-    <div className="flex items-start gap-3">
+    <div>
+      <div className="flex items-start gap-3">
       <FriendAvatar name={name} avatarUrl={avatarUrl} size={40} />
       <div className="min-w-0 flex-1">
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className="text-sm font-medium text-[color:var(--theme-text-primary)]">
+        <div className="flex items-start justify-between gap-2">
+          <p className="min-w-0 text-sm leading-tight font-medium text-[color:var(--theme-text-primary)]">
             {name}
           </p>
+          {headerActions}
+        </div>
           {careLevel !== undefined && (
-            <div className="w-full">
+            <div className="mt-1 w-full">
               <CareRating level={careLevel as CareLevel} onChange={onCareLevelChange} />
             </div>
           )}
-        </div>
+      </div>
+      </div>
         {bio && (
-          <p className="mt-1 line-clamp-2 text-xs text-[color:var(--theme-text-muted)]">
+          <p className="mt-2 line-clamp-2 text-xs text-[color:var(--theme-text-muted)]">
             {bio}
           </p>
         )}
@@ -62,13 +69,12 @@ export function FriendOverview({
             </span>
           )}
           {locationName && (
-            <span title={locationName} className="inline-flex w-full min-w-0 items-center gap-1 whitespace-nowrap text-[color:var(--theme-accent-secondary)]">
+            <span title={locationName} className="inline-flex w-full min-w-0 items-center justify-end gap-1 whitespace-nowrap text-right text-[color:var(--theme-accent-secondary)]">
               <MapPinIcon className="h-3 w-3 shrink-0" />
               <span className="truncate">{locationName}</span>
             </span>
           )}
         </div>
-      </div>
     </div>
   );
 }

--- a/packages/ui/src/components/friends/FriendsView.tsx
+++ b/packages/ui/src/components/friends/FriendsView.tsx
@@ -385,19 +385,23 @@ function FriendCandidateRow({
           name={safeText(suggestion.displayName, "Unnamed friend")}
           avatarUrl={overview?.latestAvatarUrl ?? overview?.avatarUrl ?? person?.avatarUrl ?? account?.avatarUrl}
           latestActivityAt={suggestion.lastActivityAt}
+          headerActions={
+            <div className="-mt-1 -mr-1 flex shrink-0 items-center gap-3">
+              <div className="flex items-center gap-1">{suggestion.accountIds.map(id => <SuggestedProviderIcon key={id} accountId={id} />)}</div>
+              <button
+                type="button"
+                onClick={event => { event.stopPropagation(); onDismiss(suggestion.id); }}
+                aria-label={`Dismiss suggestion for ${suggestion.displayName}`}
+                className="rounded-lg p-1 text-[color:var(--theme-text-muted)] hover:text-[color:var(--theme-text-primary)]"
+              >
+                <svg viewBox="0 0 20 20" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
+                  <path d="M5 5l10 10M15 5L5 15" strokeLinecap="round" />
+                </svg>
+              </button>
+            </div>
+          }
         />
       </div>
-      <div className="absolute right-8 top-3 flex gap-1">{suggestion.accountIds.map(id => <SuggestedProviderIcon key={id} accountId={id} />)}</div>
-        <button
-          type="button"
-          onClick={() => onDismiss(suggestion.id)}
-          aria-label={`Dismiss suggestion for ${suggestion.displayName}`}
-          className="absolute right-2 top-2 rounded-lg p-1 text-[color:var(--theme-text-muted)] hover:text-[color:var(--theme-text-primary)]"
-        >
-          <svg viewBox="0 0 20 20" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth="1.75" aria-hidden="true">
-            <path d="M5 5l10 10M15 5L5 15" strokeLinecap="round" />
-          </svg>
-        </button>
     </div>
   );
 }

--- a/packages/ui/src/components/friends/RecentActivityCard.test.tsx
+++ b/packages/ui/src/components/friends/RecentActivityCard.test.tsx
@@ -15,12 +15,14 @@ vi.mock("../../context/PlatformContext.js", () => ({ usePlatform: () => ({
 
 // Tier 1: catches inert activity rows, crossed hit targets, and lost reader scope.
 it("opens the same post in unified or account-scoped reader without nested buttons", async () => {
+  vi.stubGlobal("ResizeObserver", class { observe() {} disconnect() {} });
   const item = { globalId: "post-1", platform: "rss", author: { id: "author-1", displayName: "Romy" },
-    publishedAt: Date.now(), content: { text: "Field notes" }, rssSource: { feedUrl: "https://example.test/feed" } } as FeedItem;
+    publishedAt: Date.now(), content: { text: "Field notes", mediaUrls: [], mediaTypes: [] },
+    userState: { tags: [] }, rssSource: { feedUrl: "https://example.test/feed" } } as FeedItem;
   const host = document.createElement("div");
   const root = createRoot(host);
   await act(async () => root.render(<RecentActivityCard item={item} />));
-  const buttons = host.querySelectorAll("button");
+  const buttons = host.querySelectorAll<HTMLElement>('button, [role="button"]');
   expect(buttons).toHaveLength(2);
   expect(host.querySelector("button button")).toBeNull();
   await act(async () => buttons[0]!.click());
@@ -35,4 +37,5 @@ it("opens the same post in unified or account-scoped reader without nested butto
   expect(opened).toHaveBeenCalledWith(item);
   expect(actions.markAsRead).not.toHaveBeenCalled();
   await act(async () => root.unmount());
+  vi.unstubAllGlobals();
 });

--- a/packages/ui/src/components/friends/RecentActivityCard.tsx
+++ b/packages/ui/src/components/friends/RecentActivityCard.tsx
@@ -1,5 +1,5 @@
-import { formatDistanceToNow } from "date-fns";
 import type { FeedItem } from "@freed/shared";
+import { FeedItem as FeedItemCard } from "../feed/FeedItem.js";
 import { usePlatform } from "../../context/PlatformContext.js";
 import { providerLabel } from "../../lib/account-labels.js";
 import { PlatformIcon } from "../icons.js";
@@ -23,17 +23,9 @@ export function RecentActivityCard({ item }: { item: FeedItem }) {
       void actions.markAsRead(item.globalId);
     }
   };
-  const text = item.content.text?.trim() || item.content.linkPreview?.title || "Open post";
   return (
     <div className="theme-card-soft relative isolate rounded-2xl">
-      <button type="button" onClick={() => open(false)}
-        aria-label={`Read post: ${text}`}
-        className="group w-full rounded-2xl px-3 py-3 text-left transition-colors hover:bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)] focus-visible:outline focus-visible:outline-2 focus-visible:outline-[color:var(--theme-accent-primary)]">
-        <span className="flex justify-end text-[0.6875rem] text-[color:var(--theme-text-muted)]">
-          {formatDistanceToNow(item.publishedAt, { addSuffix: true })}
-        </span>
-        <p className="mt-2 line-clamp-3 text-sm text-[color:var(--theme-text-primary)]">{text}</p>
-      </button>
+      <FeedItemCard item={item} summary fixedHeight={128} showReadInGrayscale={false} onClick={() => open(false)} />
       <button type="button" onClick={() => open(true)}
         title={`Read this post in ${item.author.displayName || "this account"}'s ${providerLabel(item.platform)} feed`}
         className="absolute left-2 top-2 inline-flex items-center gap-1.5 rounded-md px-1 py-1 text-[0.6875rem] font-semibold uppercase tracking-[0.12em] text-[color:var(--theme-accent-primary)] transition-colors hover:bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.18)] hover:underline focus-visible:outline focus-visible:outline-2 focus-visible:outline-current">

--- a/packages/ui/src/components/map/MiniFriendMapCard.tsx
+++ b/packages/ui/src/components/map/MiniFriendMapCard.tsx
@@ -64,11 +64,11 @@ export function MiniFriendMapCard({
         <LoadingState message="Locating profile" className="h-32" />
       ) : null}
       <div className="flex items-center justify-between gap-2 px-3 py-2 transition-colors group-hover:bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)] group-focus-visible:bg-[color:rgb(var(--theme-accent-secondary-rgb)/0.12)]">
-        <div>
+        <div className="min-w-0 w-full">
           <p className="text-[0.6875rem] font-medium uppercase tracking-[0.18em] text-[color:var(--theme-accent-secondary)]">
             Last seen
           </p>
-          <p className="mt-1 text-xs font-medium text-[color:var(--theme-text-primary)]">
+          <p className="mt-1 text-right text-xs font-medium text-[color:var(--theme-text-primary)]">
             {lastSeen?.label ?? namedLocation ?? "Resolving location..."}
           </p>
           <p className="mt-1 text-xs text-[color:var(--theme-text-muted)]">

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1794,8 +1794,36 @@ html[data-theme="scriptorium"] .feed-card {
   box-shadow: 0 8px 18px rgb(84 58 35 / 0.03);
 }
 
+@media (hover: hover) and (pointer: fine) {
+  html[data-theme="scriptorium"] .feed-card:hover {
+    background-color: color-mix(in oklab, var(--theme-bg-surface) 94%, var(--theme-accent-secondary) 6%) !important;
+  }
+}
+
 .feed-card[data-focused="true"] {
   border-color: rgb(var(--theme-accent-secondary-rgb) / 0.6);
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .feed-card-photo-copy {
+    transform-origin: center bottom;
+    transition: opacity 300ms ease-out, transform 300ms ease-out;
+  }
+
+  .feed-card:hover .feed-card-photo-copy {
+    opacity: 0;
+    transform: scale(1.03);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .feed-card-photo-copy {
+    transition: none;
+  }
+
+  .feed-card:hover .feed-card-photo-copy {
+    transform: none;
+  }
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -2209,12 +2237,12 @@ html:is([data-theme="midas"], [data-theme="scriptorium"], [data-theme="starship"
   accent-color: var(--theme-accent-secondary);
 }
 
-.friend-closeness-control { position: relative; height: 2rem; width: 100%; }
+.friend-closeness-control { position: relative; height: 1.75rem; width: 100%; }
 .friend-closeness-handle {
   box-sizing: border-box;
   border: 1px solid var(--theme-accent-secondary);
   border-radius: 0.6rem;
-  padding: 0.25rem 0.75rem;
+  padding: 0.125rem 0.75rem;
   font-size: 0.6875rem;
   line-height: 1rem;
   white-space: nowrap;
@@ -2256,10 +2284,10 @@ html:is([data-theme="midas"], [data-theme="scriptorium"], [data-theme="starship"
 }
 .friend-closeness-slider:active { cursor: grabbing; }
 .friend-closeness-slider:focus-visible { outline: 2px solid var(--theme-accent-secondary); outline-offset: 2px; border-radius: 0.6rem; }
-.friend-closeness-slider::-webkit-slider-runnable-track { height: 2rem; background: transparent; }
-.friend-closeness-slider::-moz-range-track { height: 2rem; background: transparent; }
-.friend-closeness-slider::-webkit-slider-thumb { appearance: none; width: var(--care-handle-width); height: 2rem; border: 0; background: transparent; }
-.friend-closeness-slider::-moz-range-thumb { width: var(--care-handle-width); height: 2rem; border: 0; background: transparent; }
+.friend-closeness-slider::-webkit-slider-runnable-track { height: 1.75rem; background: transparent; }
+.friend-closeness-slider::-moz-range-track { height: 1.75rem; background: transparent; }
+.friend-closeness-slider::-webkit-slider-thumb { appearance: none; width: var(--care-handle-width); height: 1.75rem; border: 0; background: transparent; }
+.friend-closeness-slider::-moz-range-thumb { width: var(--care-handle-width); height: 1.75rem; border: 0; background: transparent; }
 
 .theme-toolbar-density-slider:focus-visible {
   outline: 2px solid rgb(var(--theme-accent-secondary-rgb) / 0.65);

--- a/packages/ui/src/lib/feed-card-density.ts
+++ b/packages/ui/src/lib/feed-card-density.ts
@@ -19,8 +19,8 @@ export const FEED_CARD_DENSITY_LABELS: Record<FeedCardDensity, string> = {
 };
 
 export const DESKTOP_FEED_CARD_HEIGHT_BY_DENSITY: Record<FeedCardDensity, number> = {
-  compact: 136,
-  comfortable: 204,
+  compact: 160,
+  comfortable: 236,
   expansive: 300,
 };
 

--- a/packages/ui/src/lib/friends-galaxy-palette.ts
+++ b/packages/ui/src/lib/friends-galaxy-palette.ts
@@ -104,7 +104,7 @@ export function writeFriendsGalaxyStarPaletteUniforms(
     target[offset + 1] = green;
     target[offset + 2] = blue;
     target[offset + 3] = role === FriendsGalaxyStarColorRole.Background
-      ? lightSurface ? 0.2 : 0.5
+      ? lightSurface ? 0.55 : 0.5
       : role === FriendsGalaxyStarColorRole.Selection
         ? 1
         : lightSurface ? 0.88 : 0.97;

--- a/packages/ui/src/lib/friends-galaxy-provider-fields.ts
+++ b/packages/ui/src/lib/friends-galaxy-provider-fields.ts
@@ -165,12 +165,13 @@ export function writeFriendsGalaxyProviderFieldPresentation(
     throw new Error("Friends Galaxy provider field storage is malformed.");
   }
   const light = friendsGalaxyColorIsLight(palette.background);
+  const fieldContrast = palette.background.toLowerCase() === "#f2e5cc" ? 2 : 1;
   const styleCode = fieldStyleCode(style);
   writeFieldPresentation(
     fields.instanceData,
     0,
     palette.friend,
-    light ? 0.26 : 0.64,
+    light ? 0.62 * fieldContrast : 0.64,
     styleCode,
   );
 
@@ -182,7 +183,7 @@ export function writeFriendsGalaxyProviderFieldPresentation(
       fields.instanceData,
       index + 1,
       providerColor ?? palette.account,
-      light ? 0.13 : 0.34,
+      light ? 0.32 * fieldContrast : 0.34,
       styleCode,
     );
   });

--- a/packages/ui/src/lib/friends-galaxy-three-webgpu-backend.ts
+++ b/packages/ui/src/lib/friends-galaxy-three-webgpu-backend.ts
@@ -1020,6 +1020,6 @@ export class ThreeWebGpuBackend implements FriendsGalaxyRendererBackend {
   private applyMaterialOpacity(palette: FriendsGalaxyRendererPalette): void {
     const lightSurface = paletteLuminance(palette) > 0.58;
     if (this.semanticBatch) this.semanticBatch.material.opacity = lightSurface ? 0.86 : 0.96;
-    if (this.backgroundBatch) this.backgroundBatch.material.opacity = lightSurface ? 0.2 : 0.48;
+    if (this.backgroundBatch) this.backgroundBatch.material.opacity = lightSurface ? 0.55 : 0.48;
   }
 }


### PR DESCRIPTION
(AI Generated).

## Summary
- Unify posts, stories, thumbnails and recent activity on the shared card renderer; correct responsive sizing, padding, author alignment and hover presentation.
- Polish friend rating controls and locations, strengthen light-theme galaxies and remove browser toolbar window-control spacing.

## Testing
- npm run validate:feature passed; focused shared card tests and rendered desktop/mobile preview checks passed.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `6d533640ca4074751ba6f2b70796e39cf461fbc0`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `friend-card-spacing-20260908`
- Provider review decision: `diff_authorized`
- Provider review artifact: `5f0c946e41d3e1c48117ebe32391042e79bea36131fe546ba409b8465923a522`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: The classified App.tsx change only reserves header window-control space inside Tauri, removing the gap in browser previews. Provider requests, navigation, cookies, headers, extraction and cadence are semantically unchanged. Shared feed cards preserve existing inline media policy.
- Fingerprinting risk: No additional provider contact or fingerprint change.
- Lowest profile alternative: Use the existing local preview and offline fixtures without provider navigation.

Files bound into this provider review:
- `packages/desktop/src/App.tsx`