### PR TITLE
fix: align release regression tests with unified cards

### DIFF
--- a/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
+++ b/packages/desktop/src/__mocks__/@tauri-apps/api/core.ts
@@ -670,7 +670,7 @@ tauriInternals.invoke = async <T = unknown>(
 };
 
 export function isTauri(): boolean {
-  return false;
+  return (window as unknown as Record<string, unknown>).__TAURI_MOCK_NATIVE__ === true;
 }
 
 export function convertFileSrc(filePath: string, protocol = "asset"): string {

--- a/packages/desktop/tests/e2e/README.md
+++ b/packages/desktop/tests/e2e/README.md
@@ -35,6 +35,10 @@ test("renders the expected state", async ({ app, ipc }) => {
 });
 ```
 
+Native window-chrome tests explicitly set `window.__TAURI_MOCK_NATIVE__ = true`
+in a pre-navigation init script. The default mock reports a browser preview,
+so native drag-region checks must opt in without changing browser preview spacing.
+
 The shared `app` fixture injects `tauriInitScript()` with
 `page.addInitScript()` before application JavaScript runs. That script installs
 `window.__TAURI_INTERNALS__`, default IPC handlers, and the mock state used at

--- a/packages/desktop/tests/e2e/feed-card-ui.spec.ts
+++ b/packages/desktop/tests/e2e/feed-card-ui.spec.ts
@@ -268,7 +268,7 @@ async function showStoriesFilter(page: import("@playwright/test").Page): Promise
   });
 }
 
-test("feed card overhaul actions and reader open flow work", async ({ app }) => {
+test("unified feed cards open reader actions and preserve media policy", async ({ app }) => {
   await app.goto();
   await app.waitForReady();
   await injectCardUiItems(app.page);
@@ -276,10 +276,10 @@ test("feed card overhaul actions and reader open flow work", async ({ app }) => 
 
   const facebookCard = app.page.locator("article").filter({ hasText: FACEBOOK_TITLE }).first();
   await expect(facebookCard).toBeVisible();
-  await expect(facebookCard).toContainText("1,234");
+  await expect(facebookCard).not.toContainText("1,234");
   await expect(facebookCard.locator('button[aria-label="Comment"]')).toHaveCount(0);
   await expect(facebookCard).toHaveClass(/grayscale/);
-  await expect(facebookCard.locator('button[aria-label="Archive"]').first()).toBeVisible();
+  await expect(facebookCard.getByRole("button", { name: "Archive", exact: true })).toHaveCount(0);
   const facebookImage = facebookCard.locator(`img[src="${FACEBOOK_MEDIA_URL}"]`).first();
   await expect(facebookImage).toHaveCount(0);
 
@@ -300,24 +300,9 @@ test("feed card overhaul actions and reader open flow work", async ({ app }) => 
   await expect(brokenCard).toContainText(BROKEN_TITLE);
 
   await facebookCard.hover();
-  await expect(facebookCard).toHaveCSS("border-width", "1px");
-  const focusedEdge = await facebookCard.evaluate((card) => {
-    const style = window.getComputedStyle(card);
-    return {
-      boxShadow: style.boxShadow,
-      outlineStyle: style.outlineStyle,
-    };
-  });
-  expect(focusedEdge.boxShadow).not.toMatch(/0px 0px 0px [12]px inset/);
-  expect(focusedEdge.outlineStyle).toBe("none");
-  const likeButton = facebookCard.locator('button[aria-label="Like"]').last();
-  await likeButton.hover();
-  await expect(facebookCard.locator('button[aria-label="Love"]')).toBeVisible();
-
+  await expect(facebookCard.getByRole("button", { name: "Like", exact: true })).toHaveCount(0);
   const rssCard = app.page.locator("article").filter({ hasText: RSS_TITLE }).first();
   await expect(rssCard).toBeVisible();
-  await rssCard.hover();
-  await expect(rssCard.locator('button[aria-label="Love"]')).toHaveCount(0);
 
   await expect(facebookCard.locator('button[aria-label="Open"]')).toHaveCount(0);
 
@@ -394,18 +379,20 @@ test("story grid top padding aligns with the sidebar panel", async ({ app, page 
   expect(geometry.storyTop).toBe(geometry.sidebarInnerTop);
 });
 
-test("feed card archive removes the visible card immediately", async ({ app }) => {
+test("reader archive removes its feed card immediately", async ({ app }) => {
   await app.goto();
   await app.waitForReady();
   await injectCardUiItems(app.page);
+  await app.setDeviceDisplayPreferences({ dualColumnMode: true });
 
   const card = app.page.locator('[data-feed-item-id="test-facebook-card-ui-overhaul"]').first();
   await expect(card).toBeVisible();
+  await card.click();
+  await expect(app.page.getByTestId("reader-article")).toBeVisible();
 
   const elapsedMs = await app.page.evaluate(async () => {
     const selector = '[data-feed-item-id="test-facebook-card-ui-overhaul"]';
-    const cardElement = document.querySelector(selector) as HTMLElement | null;
-    const archiveButton = cardElement?.querySelector('button[aria-label="Archive"]') as HTMLButtonElement | null;
+    const archiveButton = document.querySelector('button[aria-label="Archive"]') as HTMLButtonElement | null;
     if (!archiveButton) {
       throw new Error("Archive button was not found");
     }
@@ -425,10 +412,11 @@ test("feed card archive removes the visible card immediately", async ({ app }) =
   await expect(card).toHaveCount(0);
 });
 
-test("feed card archive rollback restores the visible card after a failed mutation", async ({ app }) => {
+test("reader archive rollback restores its feed card after a failed mutation", async ({ app }) => {
   await app.goto();
   await app.waitForReady();
   await injectCardUiItems(app.page);
+  await app.setDeviceDisplayPreferences({ dualColumnMode: true });
 
   await app.page.evaluate(() => {
     (window as Window & {
@@ -439,9 +427,11 @@ test("feed card archive rollback restores the visible card after a failed mutati
 
   const card = app.page.locator('[data-feed-item-id="test-facebook-card-ui-overhaul"]').first();
   await expect(card).toBeVisible();
+  await card.click();
+  await expect(app.page.getByTestId("reader-article")).toBeVisible();
 
-  const archiveButton = card.locator('button[aria-label="Archive"]').first();
-  await archiveButton.click({ force: true });
+  const archiveButton = app.page.getByRole("button", { name: "Archive", exact: true });
+  await archiveButton.click();
 
   await expect.poll(async () =>
     app.page.evaluate(() => {
@@ -492,13 +482,17 @@ test("liking an X post keeps it in the unified feed", async ({ app, ipc }) => {
   const xCard = app.page.locator('[data-feed-item-id="x:2049705418436600244"]');
   await expect(xCard).toBeVisible();
   await expect(xCard).toContainText(X_LIKE_TITLE);
-  await xCard.hover();
-
-  await xCard.getByRole("button", { name: "Like", exact: true }).click();
+  await xCard.click();
+  await expect(app.page.getByTestId("reader-article")).toBeVisible();
+  const search = app.page.getByRole("textbox", { name: "Search or run", exact: true });
+  await search.fill("Like current item");
+  await app.page.getByTestId("search-command-action-item-toggle-liked").click();
+  await search.fill("");
+  await search.press("Escape");
+  await app.page.getByTestId("workspace-toolbar-reader-back").click();
 
   await expect(xCard).toBeVisible();
   await expect(xCard).toContainText(X_LIKE_TITLE);
-  await expect(xCard.getByRole("button", { name: /Liked/ })).toBeVisible();
   await expect.poll(() => app.page.evaluate(() => {
     const state = (window as unknown as {
       __TAURI_MOCK_SQLITE_LIBRARY__: {
@@ -507,9 +501,6 @@ test("liking an X post keeps it in the unified feed", async ({ app, ipc }) => {
     }).__TAURI_MOCK_SQLITE_LIBRARY__;
     return state.items["x:2049705418436600244"]?.userState.likedSyncedAt ?? null;
   }), { timeout: 10_000 }).toEqual(expect.any(Number));
-  await expect(xCard.getByRole("button", { name: "Liked on X" })).toBeVisible({
-    timeout: 8_000,
-  });
   await expect(xCard).toBeVisible();
   await expect(xCard).toContainText(X_LIKE_TITLE);
 

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -1408,6 +1408,9 @@ test("compact sidebar search opens as a floating palette and closes cleanly", as
 });
 
 test("desktop toolbar controls remain clickable no-drag targets", async ({ app, page }) => {
+  await page.addInitScript(() => {
+    (window as unknown as Record<string, unknown>).__TAURI_MOCK_NATIVE__ = true;
+  });
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -1436,6 +1439,9 @@ test("desktop toolbar controls remain clickable no-drag targets", async ({ app, 
 });
 
 test("desktop passive toolbar targets expose direct native drag attributes", async ({ app, page }) => {
+  await page.addInitScript(() => {
+    (window as unknown as Record<string, unknown>).__TAURI_MOCK_NATIVE__ = true;
+  });
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -1474,6 +1480,9 @@ test("desktop passive toolbar targets expose direct native drag attributes", asy
 });
 
 test("reader toolbar keeps back button clickable while title text is a drag target", async ({ app, page }) => {
+  await page.addInitScript(() => {
+    (window as unknown as Record<string, unknown>).__TAURI_MOCK_NATIVE__ = true;
+  });
   await page.setViewportSize({ width: 1440, height: 900 });
   await app.goto();
   await app.waitForReady();
@@ -5011,7 +5020,7 @@ test("AI ranked friend suggestion dismiss hides the candidate without deleting t
 
   const row = page.getByTestId("friend-candidate-suggestion").filter({ hasText: "Ida Wells" });
   await expect(row).toBeVisible({ timeout: 10_000 });
-  const dismissButton = row.getByRole("button", { name: "Dismiss" });
+  const dismissButton = row.getByRole("button", { name: "Dismiss suggestion for Ida Wells", exact: true });
   await expect(dismissButton).toBeVisible({ timeout: 10_000 });
   await dismissButton.evaluate((button) => {
     (button as HTMLButtonElement).click();


### PR DESCRIPTION
(AI Generated).

## Summary
- Use reader archive controls and the existing Like command while retaining mutation and retention assertions.
- Opt native toolbar tests into the native mock and target friend suggestion dismissal exactly.

## Testing
- npm run validate:feature passed; serial full regression passed all 166 cases; previously failing consent case passed three isolated repetitions.