### PR TITLE
chore: prepare v26.9.801

### DIFF
--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.9.601",
+  "version": "26.9.801",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.9.601"
+version = "26.9.801"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.9.601"
+version = "26.9.801"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.9.601",
+  "version": "26.9.801",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.9.601",
+  "version": "26.9.801",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/release-notes/daily/production/26.9.8.json
+++ b/release-notes/daily/production/26.9.8.json
@@ -10,5 +10,5 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [],
-  "updatedAt": "2026-09-08T10:21:37.673Z"
+  "updatedAt": "2026-09-08T21:10:35.524Z"
 }

--- a/release-notes/daily/production/26.9.8.json
+++ b/release-notes/daily/production/26.9.8.json
@@ -2,13 +2,17 @@
   "channel": "production",
   "dayKey": "26.9.8",
   "date": "2026-09-08",
-  "preferredDeck": null,
+  "preferredDeck": "Unified feed cards, clearer Friends views, and a welcoming mobile demo.",
   "editorialGuidance": [
     "Keep the tone concise, professional, and specific.",
     "Lead with user-facing outcomes, shipping milestones, trust wins, and installability improvements.",
     "Demote internal cleanup unless it clearly changes the shipped product."
   ],
-  "pinnedHighlights": [],
+  "pinnedHighlights": [
+    "Explore the 500-post demo with a full-screen mobile welcome, editable session settings, and character-specific feeds.",
+    "Select friends consistently across the galaxy and sidebar, adjust connection strength with a five-stop slider, and open provider-filtered reading lists.",
+    "Read unified story and post cards with consistent spacing, textured image fades, interface zoom, and paused YouTube playback."
+  ],
   "editorialNotes": [],
   "updatedAt": "2026-09-08T21:10:35.524Z"
 }

--- a/release-notes/releases/v26.9.801.json
+++ b/release-notes/releases/v26.9.801.json
@@ -1,0 +1,65 @@
+{
+  "tag": "v26.9.801",
+  "version": "26.9.801",
+  "channel": "production",
+  "dayKey": "26.9.8",
+  "approved": false,
+  "editorialNotes": [],
+  "generatedAt": "2026-09-08T21:10:35.523Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.9.602",
+    "previousPublishedDayTag": "v26.9.602",
+    "compareRef": "HEAD",
+    "productCommitSha": "14813880388c6f10e32ae7fcecf7ec2af3ea417f",
+    "promotedDevCommitSha": "e83e6292167ad1f2f5b1a9805f319253841ad180",
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "production",
+        "previousPublishedTag": "v26.9.602",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "c7b6cc4315df47e202cca3c2ab27feff4d1bddc6",
+        "toInclusiveProductCommitSha": "14813880388c6f10e32ae7fcecf7ec2af3ea417f"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:dd4b758ea3feb3afa56785839e9c5cda3d28eddfa3bc7ef64c4d211682a71854",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.9.801"
+    ],
+    "relatedBuildTags": [
+      "v26.9.801"
+    ],
+    "prNumbers": [
+      1893,
+      1897
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release",
+      "chore: prepare v26.9.800 (#1897)",
+      "chore: promote dev into main for production release (#1893)"
+    ]
+  },
+  "release": {
+    "deck": "Promote dev into main for production release and prepare v26.9.800",
+    "features": [],
+    "fixes": [],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.801\n\nPromote dev into main for production release and prepare v26.9.800\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.9.801.json
+++ b/release-notes/releases/v26.9.801.json
@@ -3,7 +3,7 @@
   "version": "26.9.801",
   "channel": "production",
   "dayKey": "26.9.8",
-  "approved": false,
+  "approved": true,
   "editorialNotes": [],
   "generatedAt": "2026-09-08T21:10:35.523Z",
   "model": "heuristic",
@@ -56,10 +56,25 @@
     ]
   },
   "release": {
-    "deck": "Promote dev into main for production release and prepare v26.9.800",
-    "features": [],
-    "fixes": [],
+    "deck": "Unified feed cards, clearer Friends views, and a welcoming mobile demo.",
+    "features": [
+      "Explore the 500-post demo with a full-screen mobile welcome, editable session settings, and character-specific feeds.",
+      "Select friends consistently across the galaxy and sidebar, adjust connection strength with a five-stop slider, and open provider-filtered reading lists.",
+      "Read unified story and post cards with consistent spacing, textured image fades, interface zoom, and paused YouTube playback."
+    ],
+    "fixes": [
+      "Align author details and card spacing across feeds and recent activity; improve Friends controls and light-theme galaxies.",
+      "Pan and zoom the map with desktop trackpad gestures and momentum.",
+      "Keep galaxy avatars visible at maximum zoom and make selected star systems easier to see.",
+      "Last-seen maps are visible again, and recent activity includes provider icons.",
+      "Reader previews disappear instantly; transitioning demo tabs cannot intercept input.",
+      "Mobile cards retain horizontal margins, and landscape layouts scroll within the viewport.",
+      "Sample thumbnails load correctly, and the PWA starts with the demo corpus.",
+      "Preserve the Google sign-in redirect URI and show PWA installation guidance in Chrome on iOS.",
+      "Exclude Facebook advertisements from captured posts.",
+      "Stop feed reloads from restarting ranking."
+    ],
     "followUps": []
   },
-  "releaseBody": "(AI Generated).\n\n## Freed v26.9.801\n\nPromote dev into main for production release and prepare v26.9.800\n\n### Fixes\n\n- Bug fixes and improvements\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.801\n\nUnified feed cards, clearer Friends views, and a welcoming mobile demo\n\n### Features\n\n- Explore the 500-post demo with a full-screen mobile welcome, editable session settings, and character-specific feeds\n- Select friends consistently across the galaxy and sidebar, adjust connection strength with a five-stop slider, and open provider-filtered reading lists\n- Read unified story and post cards with consistent spacing, textured image fades, interface zoom, and paused YouTube playback\n\n### Fixes\n\n- Align author details and card spacing across feeds and recent activity; improve Friends controls and light-theme galaxies\n- Pan and zoom the map with desktop trackpad gestures and momentum\n- Keep galaxy avatars visible at maximum zoom and make selected star systems easier to see\n- Last-seen maps are visible again, and recent activity includes provider icons\n- Reader previews disappear instantly; transitioning demo tabs cannot intercept input\n- Mobile cards retain horizontal margins, and landscape layouts scroll within the viewport\n- Sample thumbnails load correctly, and the PWA starts with the demo corpus\n- Preserve the Google sign-in redirect URI and show PWA installation guidance in Chrome on iOS\n- Exclude Facebook advertisements from captured posts\n- Stop feed reloads from restarting ranking\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
 }

--- a/release-notes/releases/v26.9.801.md
+++ b/release-notes/releases/v26.9.801.md
@@ -2,11 +2,26 @@
 
 ## Freed v26.9.801
 
-Promote dev into main for production release and prepare v26.9.800
+Unified feed cards, clearer Friends views, and a welcoming mobile demo
+
+### Features
+
+- Explore the 500-post demo with a full-screen mobile welcome, editable session settings, and character-specific feeds
+- Select friends consistently across the galaxy and sidebar, adjust connection strength with a five-stop slider, and open provider-filtered reading lists
+- Read unified story and post cards with consistent spacing, textured image fades, interface zoom, and paused YouTube playback
 
 ### Fixes
 
-- Bug fixes and improvements
+- Align author details and card spacing across feeds and recent activity; improve Friends controls and light-theme galaxies
+- Pan and zoom the map with desktop trackpad gestures and momentum
+- Keep galaxy avatars visible at maximum zoom and make selected star systems easier to see
+- Last-seen maps are visible again, and recent activity includes provider icons
+- Reader previews disappear instantly; transitioning demo tabs cannot intercept input
+- Mobile cards retain horizontal margins, and landscape layouts scroll within the viewport
+- Sample thumbnails load correctly, and the PWA starts with the demo corpus
+- Preserve the Google sign-in redirect URI and show PWA installation guidance in Chrome on iOS
+- Exclude Facebook advertisements from captured posts
+- Stop feed reloads from restarting ranking
 
 ### Downloads
 

--- a/release-notes/releases/v26.9.801.md
+++ b/release-notes/releases/v26.9.801.md
@@ -1,0 +1,17 @@
+(AI Generated).
+
+## Freed v26.9.801
+
+Promote dev into main for production release and prepare v26.9.800
+
+### Fixes
+
+- Bug fixes and improvements
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

Prepare v26.9.801 with unified feed cards and clearer Friends presentation, including PR1899 and the regression-test repair in PR1901. Release notes cover changes since published v26.9.602. The earlier v26.9.800 draft remains untouched.

Frozen dev source: e83e6292167ad1f2f5b1a9805f319253841ad180. Product promotion: 14813880388c6f10e32ae7fcecf7ec2af3ea417f. Generated Library Core activation has an unchanged manifest and no transitions.

Full local release validation passed at d8f68cc275248b09388f56dbb2a0d78c7f73f234, including browser durability, 166 Desktop regression tests, native tests, production build, and release identity. All six local showcase themes passed capture and decode checks. Final tagged assets and installed identity will be verified after publication. Approved website metadata is staged through PR1903.