### PR TITLE
fix: verify showcase animation encoding before release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -693,7 +693,11 @@ jobs:
         run: |
           npm ci --ignore-scripts
           npx playwright install --with-deps chromium
-          command -v ffmpeg >/dev/null || brew install ffmpeg
+          brew install ffmpeg-full
+          encoder="$(brew --prefix ffmpeg-full)/bin/ffmpeg"
+          "$encoder" -hide_banner -encoders > /tmp/freed-showcase-encoders.txt
+          grep -w libwebp_anim /tmp/freed-showcase-encoders.txt
+          echo "FFMPEG_PATH=$encoder" >> "$GITHUB_ENV"
 
       - name: Build exact release PWA
         working-directory: packages/pwa
@@ -721,6 +725,7 @@ jobs:
 
       - name: Capture release showcase
         env:
+          TMPDIR: ${{ runner.temp }}
           FREED_SHOWCASE_URL: http://127.0.0.1:4173/?freed-demo=1
           FREED_SHOWCASE_OUTPUT: release-showcase
           FREED_SHOWCASE_SQLITE_MEMORY: "1"
@@ -742,7 +747,7 @@ jobs:
           name: release-showcase-source
           path: |
             release-showcase/
-            /tmp/freed-release-showcase-*/
+            ${{ runner.temp }}/freed-release-showcase-*/
           if-no-files-found: warn
 
   # After all platform builds succeed, promote the draft to a published release

--- a/.github/workflows/showcase-capture.yml
+++ b/.github/workflows/showcase-capture.yml
@@ -22,7 +22,7 @@ jobs:
   capture:
     name: Showcase capture smoke
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -33,6 +33,11 @@ jobs:
         run: |
           npm ci --ignore-scripts
           npx playwright install --with-deps chromium
+          brew install ffmpeg-full
+          encoder="$(brew --prefix ffmpeg-full)/bin/ffmpeg"
+          "$encoder" -hide_banner -encoders > /tmp/freed-showcase-encoders.txt
+          grep -w libwebp_anim /tmp/freed-showcase-encoders.txt
+          echo "FFMPEG_PATH=$encoder" >> "$GITHUB_ENV"
       - name: Build production demo
         working-directory: packages/pwa
         env:
@@ -52,19 +57,20 @@ jobs:
           done
           cat /tmp/freed-showcase-preview.log
           exit 1
-      - name: Capture all six views in one representative theme
+      - name: Capture and decode all six themes
         env:
-          DEBUG: pw:browser
+          TMPDIR: ${{ runner.temp }}
           FREED_SHOWCASE_URL: http://127.0.0.1:4173/?freed-demo=1
-          FREED_SHOWCASE_OUTPUT: /tmp/freed-showcase-smoke
+          FREED_SHOWCASE_OUTPUT: ${{ runner.temp }}/freed-showcase-smoke
           FREED_SHOWCASE_SQLITE_MEMORY: '1'
-          FREED_SHOWCASE_THEME: ember
-        run: node scripts/capture-showcase-local.mjs
+        run: node scripts/capture-release-showcase.mjs
       - name: Retain capture evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: showcase-capture-evidence
-          path: /tmp/freed-showcase-smoke/
+          path: |
+            ${{ runner.temp }}/freed-showcase-smoke/
+            ${{ runner.temp }}/freed-release-showcase-*/
           retention-days: 7
           if-no-files-found: warn

--- a/.github/workflows/showcase-capture.yml
+++ b/.github/workflows/showcase-capture.yml
@@ -65,7 +65,10 @@ jobs:
           FREED_SHOWCASE_SQLITE_MEMORY: '1'
         # Exercise release formatting with a synthetic tag. This read-only job
         # preserves the real checkout SHA and never creates or publishes a tag.
-        run: GITHUB_REF=refs/tags/v0.1.100 GITHUB_REF_NAME=v0.1.100 node scripts/capture-release-showcase.mjs
+        run: |
+          export GITHUB_REF=refs/tags/v0.1.100 GITHUB_REF_NAME=v0.1.100
+          node scripts/capture-release-showcase.mjs
+          node scripts/lib/release-showcase-assets.mjs finalize --directory "$FREED_SHOWCASE_OUTPUT"
       - name: Retain capture evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a

--- a/.github/workflows/showcase-capture.yml
+++ b/.github/workflows/showcase-capture.yml
@@ -63,7 +63,9 @@ jobs:
           FREED_SHOWCASE_URL: http://127.0.0.1:4173/?freed-demo=1
           FREED_SHOWCASE_OUTPUT: ${{ runner.temp }}/freed-showcase-smoke
           FREED_SHOWCASE_SQLITE_MEMORY: '1'
-        run: node scripts/capture-release-showcase.mjs
+        # Exercise release formatting with a synthetic tag. This read-only job
+        # preserves the real checkout SHA and never creates or publishes a tag.
+        run: GITHUB_REF=refs/tags/v0.1.100 GITHUB_REF_NAME=v0.1.100 node scripts/capture-release-showcase.mjs
       - name: Retain capture evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a


### PR DESCRIPTION
(AI Generated).

Production showcase screenshots succeeded, but encoding failed because the macOS runner's existing FFmpeg did not contain libwebp_anim. Install Homebrew ffmpeg-full, select its keg-only binary explicitly, and verify the required encoder before capture.

Run the complete six-theme production capture, encoding, decode, and manifest-finalization path in the changed-path check. Its synthetic tag fixture preserves the actual checkout SHA and cannot publish from this read-only job. Retain staging files under runner.temp so macOS failures preserve their source evidence.

Validation: full local feature checks passed. The complete local pipeline passed all 36 frames, six animated WebPs, decode/timing/alpha checks, and manifest finalization. The hosted runner already confirmed ffmpeg-full provides the required encoder. Require the complete hosted check on this exact head before merge and the next release tag.