### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -569,7 +569,11 @@ jobs:
         run: |
           npm ci --ignore-scripts
           npx playwright install --with-deps chromium
-          command -v ffmpeg >/dev/null || brew install ffmpeg
+          brew install ffmpeg-full
+          encoder="$(brew --prefix ffmpeg-full)/bin/ffmpeg"
+          "$encoder" -hide_banner -encoders > /tmp/freed-showcase-encoders.txt
+          grep -w libwebp_anim /tmp/freed-showcase-encoders.txt
+          echo "FFMPEG_PATH=$encoder" >> "$GITHUB_ENV"
 
       - name: Build exact release PWA
         working-directory: packages/pwa
@@ -597,6 +601,7 @@ jobs:
 
       - name: Capture release showcase
         env:
+          TMPDIR: ${{ runner.temp }}
           FREED_SHOWCASE_URL: http://127.0.0.1:4173/?freed-demo=1
           FREED_SHOWCASE_OUTPUT: release-showcase
           FREED_SHOWCASE_SQLITE_MEMORY: "1"
@@ -618,7 +623,7 @@ jobs:
           name: release-showcase-source
           path: |
             release-showcase/
-            /tmp/freed-release-showcase-*/
+            ${{ runner.temp }}/freed-release-showcase-*/
           if-no-files-found: warn
 
   # After all platform builds succeed, promote the draft to a published release

--- a/.github/workflows/showcase-capture.yml
+++ b/.github/workflows/showcase-capture.yml
@@ -22,7 +22,7 @@ jobs:
   capture:
     name: Showcase capture smoke
     runs-on: macos-latest
-    timeout-minutes: 15
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
@@ -33,6 +33,11 @@ jobs:
         run: |
           npm ci --ignore-scripts
           npx playwright install --with-deps chromium
+          brew install ffmpeg-full
+          encoder="$(brew --prefix ffmpeg-full)/bin/ffmpeg"
+          "$encoder" -hide_banner -encoders > /tmp/freed-showcase-encoders.txt
+          grep -w libwebp_anim /tmp/freed-showcase-encoders.txt
+          echo "FFMPEG_PATH=$encoder" >> "$GITHUB_ENV"
       - name: Build production demo
         working-directory: packages/pwa
         env:
@@ -52,19 +57,25 @@ jobs:
           done
           cat /tmp/freed-showcase-preview.log
           exit 1
-      - name: Capture all six views in one representative theme
+      - name: Capture and decode all six themes
         env:
-          DEBUG: pw:browser
+          TMPDIR: ${{ runner.temp }}
           FREED_SHOWCASE_URL: http://127.0.0.1:4173/?freed-demo=1
-          FREED_SHOWCASE_OUTPUT: /tmp/freed-showcase-smoke
+          FREED_SHOWCASE_OUTPUT: ${{ runner.temp }}/freed-showcase-smoke
           FREED_SHOWCASE_SQLITE_MEMORY: '1'
-          FREED_SHOWCASE_THEME: ember
-        run: node scripts/capture-showcase-local.mjs
+        # Exercise release formatting with a synthetic tag. This read-only job
+        # preserves the real checkout SHA and never creates or publishes a tag.
+        run: |
+          export GITHUB_REF=refs/tags/v0.1.100 GITHUB_REF_NAME=v0.1.100
+          node scripts/capture-release-showcase.mjs
+          node scripts/lib/release-showcase-assets.mjs finalize --directory "$FREED_SHOWCASE_OUTPUT"
       - name: Retain capture evidence
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: showcase-capture-evidence
-          path: /tmp/freed-showcase-smoke/
+          path: |
+            ${{ runner.temp }}/freed-showcase-smoke/
+            ${{ runner.temp }}/freed-release-showcase-*/
           retention-days: 7
           if-no-files-found: warn

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/desktop",
   "private": true,
-  "version": "26.9.802",
+  "version": "26.9.601",
   "type": "module",
   "scripts": {
     "dev": "node ../../node_modules/vite/bin/vite.js",

--- a/packages/desktop/src-tauri/Cargo.lock
+++ b/packages/desktop/src-tauri/Cargo.lock
@@ -1266,7 +1266,7 @@ dependencies = [
 
 [[package]]
 name = "freed-desktop"
-version = "26.9.802"
+version = "26.9.601"
 dependencies = [
  "base64 0.23.1",
  "dirs",

--- a/packages/desktop/src-tauri/Cargo.toml
+++ b/packages/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "freed-desktop"
-version = "26.9.802"
+version = "26.9.601"
 description = "Freed Desktop - Escape algorithmic manipulation"
 authors = ["Freed"]
 edition = "2021"

--- a/packages/desktop/src-tauri/tauri.conf.json
+++ b/packages/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Freed",
-  "version": "26.9.802",
+  "version": "26.9.601",
   "identifier": "wtf.freed.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/packages/pwa/package.json
+++ b/packages/pwa/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@freed/pwa",
   "private": true,
-  "version": "26.9.802",
+  "version": "26.9.601",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote one immutable dev product snapshot into `main` before a production release.
- Base main SHA: `03ecf2962f6cd11a6d5921f9658b4de1a45c41fe`
- Source dev SHA: `96a5c381263d67eedad3507bab9e4f084b123c5c`

## Testing
- `node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-showcase-encoder --snapshot-ref=96a5c381263d67eedad3507bab9e4f084b123c5c`
- CI