### PR TITLE
fix: wait for lazy showcase image readiness

### DIFF
--- a/website/tests/e2e/product-showcase.spec.ts
+++ b/website/tests/e2e/product-showcase.spec.ts
@@ -9,6 +9,11 @@ test("showcase follows all theme previews and reduced motion with verified asset
   await page.goto("/");
   const footer = page.locator('footer[aria-label="Site footer"]');
   const image = page.locator(".demo-showcase img");
+  // Reach the lazy image before moving to the footer's theme previews.
+  await image.scrollIntoViewIfNeeded();
+  await expect.poll(() => image.evaluate((img: HTMLImageElement) =>
+    img.complete && img.naturalWidth > 0,
+  )).toBe(true);
   for (const reducedMotion of ["no-preference", "reduce"] as const) {
     await page.emulateMedia({ reducedMotion });
     for (const [theme, asset] of Object.entries(assets.themes)) {
@@ -23,10 +28,16 @@ test("showcase follows all theme previews and reduced motion with verified asset
         await expect(page.locator(".demo-showcase-reduced-motion")).toBeHidden();
       }
       const selected = asset.animation;
-      await expect.poll(() => image.evaluate((img: HTMLImageElement) => new URL(img.currentSrc).pathname)).toBe(selected.url);
-      const response = await request.get(selected.url);
-      expect(response.ok()).toBeTruthy();
-      expect(createHash("sha256").update(await response.body()).digest("hex")).toBe(selected.sha256);
+      await expect(image).toHaveAttribute("src", selected.url);
+      if (reducedMotion === "no-preference") {
+        await expect.poll(() => image.evaluate((img: HTMLImageElement) => ({
+          pathname: img.currentSrc ? new URL(img.currentSrc).pathname : "",
+          loaded: img.complete && img.naturalWidth > 0,
+        }))).toEqual({ pathname: selected.url, loaded: true });
+        const response = await request.get(selected.url);
+        expect(response.ok()).toBeTruthy();
+        expect(createHash("sha256").update(await response.body()).digest("hex")).toBe(selected.sha256);
+      }
       await footer.getByText("Product", { exact: true }).hover();
     }
   }


### PR DESCRIPTION
(AI Generated).

The showcase test failed on production when a lazy image initially had an empty currentSrc. Wait for its decoded image readiness before checking animation identity, and handle the empty loading state without throwing. Reduced-motion checks assert the selected source and hidden animation without requiring hidden lazy media to load. Hash each of the six assets once per viewport.

Validated both desktop and mobile locally (27.1 seconds), against live freed.wtf (19.8 seconds), and with the website production build. Product rendering and showcase source files are unchanged. Starting www source: 6610148747eded6107df6647411caa42f2d48887.

Closes #1919.
