### PR TITLE
perf: cross-compile Intel releases on Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,9 @@ jobs:
             exit 1
           fi
 
-          PRIMARY_RELEASE_MATRIX='{"include":[{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"},{"platform":"macos-15-intel","args":"--target x86_64-apple-darwin","rust_target":"x86_64-apple-darwin"},{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","rust_target":"x86_64-pc-windows-msvc"},{"platform":"ubuntu-22.04","args":"","rust_target":"x86_64-unknown-linux-gnu"}]}'
+          # Cross-compile Intel on the faster Apple Silicon host. The explicit
+          # Rust target still produces a separately signed Intel application.
+          PRIMARY_RELEASE_MATRIX='{"include":[{"platform":"macos-latest","args":"--target aarch64-apple-darwin","rust_target":"aarch64-apple-darwin"},{"platform":"macos-latest","args":"--target x86_64-apple-darwin","rust_target":"x86_64-apple-darwin"},{"platform":"windows-latest","args":"--target x86_64-pc-windows-msvc","rust_target":"x86_64-pc-windows-msvc"},{"platform":"ubuntu-22.04","args":"","rust_target":"x86_64-unknown-linux-gnu"}]}'
 
           # Write to GITHUB_OUTPUT using heredoc to handle multiline
           {

--- a/scripts/release-workflow-matrix.test.mjs
+++ b/scripts/release-workflow-matrix.test.mjs
@@ -36,7 +36,7 @@ test("dev and production releases use the same primary platform matrix", () => {
       rust_target: "aarch64-apple-darwin",
     },
     {
-      platform: "macos-15-intel",
+      platform: "macos-latest",
       args: "--target x86_64-apple-darwin",
       rust_target: "x86_64-apple-darwin",
     },


### PR DESCRIPTION
(AI Generated).

Intel packaging took 27.90 minutes in v26.9.803, including 20m39s compiling on the Intel host. Build the Intel target on the Apple Silicon runner while retaining the explicit x86_64 target, separate artifact, signing, notarization, and updater checks.

A clean-target local Rust 1.98.1 cross-build completed in 3.1 minutes, including frontend compilation and unsigned app bundling. Native release compilation took 2m45s. The generated executable is verified Mach-O x86_64. This local host is not the hosted runner, and signing was unavailable locally, so this is feasibility evidence only. The signed hosted dev release will supply the packaging time and artifact proof before production use.

Validation: validate:feature passed. The existing release matrix contract still requires all four target architectures.
