### PR TITLE
chore: promote PWA reset and Drive repair to production

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -2,6 +2,13 @@
 
 > **Status:** 🚧 In Progress
 
+Drive discovery distinguishes separate Libraries from duplicate controls for the
+same Library. When several Libraries are published, the PWA offers an explicit
+Library ID choice and pins later discovery to the imported checkpoint identity.
+It never chooses by modification time or deletes competing controls. Duplicate
+controls for one identity remain an integrity error. Authenticated production
+acceptance remains open.
+
 Checkpoint publication separates a five-minute no-progress deadline from a
 fixed total budget. After the native snapshot is known, the budget is five
 minutes plus ten seconds per estimated 4,096-record page, capped at two hours

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -2,6 +2,15 @@
 
 > **Status:** 🚧 In Progress (the official SQLite WebAssembly engine, exact schema identity, single-worker OPFS runtime, normalized checkpoint import, product mutation entrypoints, bounded product queries, follower transport, recovery UI, selective content, and IndexedDB Library deletion are implemented; physical iPhone acceptance remains open)
 
+Local sample results include the optimistic care fields required for settlement.
+A specifically rejected, uncommitted sample result from v26.9.803 can be retired
+and rebuilt from its retained intent after restart. Connected Library results
+and accepted result identities are never rewritten. Device reset closes every
+participating tab's storage worker before the initiating tab deletes storage;
+reads cannot reopen the worker during reset. Shared overlay scroll locks retain
+ownership until the last overlay closes, and mobile Settings uses bounded flex
+scroll containers. Physical iPhone touch acceptance remains open.
+
 The mobile demo opens its full-screen welcome on every fresh load and uses only
 welcome and minimized-tab states. Newsletter entry stays inside the welcome.
 Presentation settings remain editable for the current demo session; existing

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -21,7 +21,7 @@
     {
       "id": 4,
       "status": "current",
-      "reviewedAt": "2026-09-05",
+      "reviewedAt": "2026-09-08",
       "source": "docs/PHASE-4-SYNC.md"
     },
     {
@@ -33,7 +33,7 @@
     {
       "id": 6,
       "status": "current",
-      "reviewedAt": "2026-09-07",
+      "reviewedAt": "2026-09-08",
       "source": "docs/PHASE-6-PWA.md"
     },
     {

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -102,6 +102,7 @@ import {
   appendPwaLibraryCorePersonReachOut,
   assignPwaLibraryCoreAccountToPerson,
   ensurePwaLibraryCoreLocalSampleState,
+  clearPwaLibraryCoreLocalDataForFactoryReset,
   executePwaLibraryCoreScopeAction,
   openPwaLibraryCoreFeedReader,
   openPwaLibraryCoreFriendsFeedReader,
@@ -480,7 +481,7 @@ function App() {
               resetInterfaceZoom,
               resetThemePreference,
             ],
-            clearLocalData: [],
+            clearLocalData: [clearPwaLibraryCoreLocalDataForFactoryReset],
             clearProviderDataAndConnections: async () => {
               stopCloudSync();
               await clearStoredCloudDataForFactoryReset(deleteFromCloud);
@@ -514,7 +515,7 @@ function App() {
       reset: async () => {
         beginFactoryResetBoundary();
         stopCloudSync();
-        await runCoordinatedPwaFactoryReset(async () => {});
+        await runCoordinatedPwaFactoryReset(clearPwaLibraryCoreLocalDataForFactoryReset);
       },
       reload: () => {
         preparePwaFactoryResetReload();

--- a/packages/pwa/src/components/DemoWelcomeBanner.tsx
+++ b/packages/pwa/src/components/DemoWelcomeBanner.tsx
@@ -72,6 +72,27 @@ function FirstLookWelcome({
 }) {
   const [newsletterOpen, setNewsletterOpen] = useState(false);
   const [newsletterVisited, setNewsletterVisited] = useState(false);
+  const welcomeRef = useRef<HTMLDivElement>(null);
+  const [mobileTopSpace, setMobileTopSpace] = useState(0);
+  useLayoutEffect(() => {
+    const content = welcomeRef.current;
+    if (!content) return;
+    const fitWelcome = () => {
+      const panel = content.parentElement!;
+      const form = content.querySelector<HTMLElement>("[data-newsletter-form]");
+      // Center the collapsed group independently so expanding the form cannot move its toggle.
+      const collapsedHeight = content.offsetHeight - (form?.offsetHeight ?? 0);
+      const padding = Number.parseFloat(getComputedStyle(panel).paddingTop) * 2;
+      setMobileTopSpace(window.innerWidth <= 640
+        ? Math.max(0, (panel.clientHeight - padding - collapsedHeight) / 2) : 0);
+    };
+    const observer = new ResizeObserver(fitWelcome);
+    observer.observe(content);
+    observer.observe(content.parentElement!);
+    window.addEventListener("resize", fitWelcome);
+    fitWelcome();
+    return () => { observer.disconnect(); window.removeEventListener("resize", fitWelcome); };
+  }, []);
   const newsletterPreviewOnly = import.meta.env.DEV ||
     isFreedNewsletterPreviewHostname(window.location.hostname);
   return (
@@ -91,7 +112,7 @@ function FirstLookWelcome({
           className="absolute inset-0 bg-[radial-gradient(circle_at_top,var(--theme-accent-glow),transparent_58%)] opacity-60"
           aria-hidden="true"
         />
-        <div className="relative flex flex-col items-center">
+        <div ref={welcomeRef} className="relative flex flex-col items-center" style={{ marginTop: mobileTopSpace }}>
           <FreedLogo className="h-20 w-20 sm:h-24 sm:w-24" />
           <p className="mt-7 text-[0.6875rem] font-semibold uppercase tracking-[0.22em] text-[var(--theme-accent-secondary)]">
             {copy.eyebrow}
@@ -111,22 +132,23 @@ function FirstLookWelcome({
             Explore Freed Demo
           </button>
           <div className="mt-3 w-full max-w-sm min-[641px]:hidden">
-            <div inert={!newsletterOpen} aria-hidden={!newsletterOpen}
-              className="grid transition-[grid-template-rows,opacity,transform,padding] duration-300 ease-in-out motion-reduce:transition-none"
-              style={{ gridTemplateRows: newsletterOpen ? "1fr" : "0fr", opacity: newsletterOpen ? 1 : 0,
-                transform: newsletterOpen ? "translateY(0)" : "translateY(-12px)", paddingBlock: newsletterOpen ? "1rem" : "0" }}>
-              <div className="min-h-0 overflow-hidden">
-                {newsletterVisited && <NewsletterSignup compact previewOnly={newsletterPreviewOnly}
-                  {...(newsletterPreviewOnly ? { siteKey: FREED_NEWSLETTER_TURNSTILE_TEST_SITE_KEY } : {})} />
-                }
-              </div>
-            </div>
             <button type="button" aria-expanded={newsletterOpen}
               className="btn-secondary inline-flex !min-h-10 w-full items-center justify-center gap-2 rounded-[2rem] !px-4 !py-2 !text-sm"
               onClick={() => { setNewsletterVisited(true); setNewsletterOpen(value => !value); }}>
               {newsletterOpen && <svg aria-hidden="true" className="h-4 w-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2"><path d="m6 15 6-6 6 6" /></svg>}
-              {newsletterOpen ? "Back to welcome" : "Join the newsletter"}
+              {newsletterOpen ? "Skip the newsletter" : "Join the newsletter"}
             </button>
+            <div data-newsletter-form inert={!newsletterOpen} aria-hidden={!newsletterOpen}
+              className="grid transition-[grid-template-rows,opacity,transform,padding] duration-300 ease-in-out motion-reduce:transition-none"
+              style={{ gridTemplateRows: newsletterOpen ? "1fr" : "0fr", opacity: newsletterOpen ? 1 : 0,
+                transform: newsletterOpen ? "translateY(0)" : "translateY(-12px)", paddingTop: newsletterOpen ? "2rem" : "0" }}>
+              <div className="min-h-0 overflow-hidden">
+                {newsletterVisited && <NewsletterSignup compact previewOnly={newsletterPreviewOnly}
+                  submitLabel="Join the newsletter!" showPrivacyNote={false}
+                  {...(newsletterPreviewOnly ? { siteKey: FREED_NEWSLETTER_TURNSTILE_TEST_SITE_KEY } : {})} />
+                }
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/pwa/src/components/PwaSyncSettings.test.ts
+++ b/packages/pwa/src/components/PwaSyncSettings.test.ts
@@ -7,6 +7,8 @@ import { useAppStore } from "../lib/store";
 import { PwaDemoSyncSettings, PwaSyncSettings } from "./PwaSyncSettings";
 
 const mocks = vi.hoisted(() => ({
+  libraryChoices: Object.freeze([]) as readonly string[],
+  selectCloudLibrary: vi.fn(async () => {}),
   clipboardWrite: vi.fn(async () => {}),
   clearCloudSync: vi.fn(),
   getCloudProvider: vi.fn<() => "gdrive" | null>(() => "gdrive"),
@@ -63,6 +65,9 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock("../lib/sync", () => ({
+  getCloudLibraryChoices: () => mocks.libraryChoices,
+  subscribeCloudLibraryChoices: () => () => {},
+  selectCloudLibrary: mocks.selectCloudLibrary,
   clearCloudSync: mocks.clearCloudSync,
   getCloudProvider: mocks.getCloudProvider,
   stopCloudSync: mocks.stopCloudSync,
@@ -119,6 +124,7 @@ describe("PwaSyncSettings cloud diagnostics", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-06-09T12:00:30Z"));
     vi.clearAllMocks();
+    mocks.libraryChoices = Object.freeze([]);
     Object.defineProperty(navigator, "clipboard", {
       configurable: true,
       value: { writeText: mocks.clipboardWrite },
@@ -170,6 +176,19 @@ describe("PwaSyncSettings cloud diagnostics", () => {
     (
       globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
     ).IS_REACT_ACT_ENVIRONMENT = false;
+  });
+
+  it("requires an explicit Library choice and forwards the exact identity", async () => {
+    mocks.libraryChoices = Object.freeze(["11".repeat(32), "22".repeat(32)]);
+    const { container, root } = renderWithPlatform(createElement(PwaSyncSettings));
+    await act(async () => { await Promise.resolve(); });
+    expect(mocks.selectCloudLibrary).not.toHaveBeenCalled();
+    const choices = container.querySelectorAll<HTMLButtonElement>("[data-testid='pwa-library-choice'] button");
+    expect(choices).toHaveLength(2);
+    expect(choices[1]!.textContent).toContain("...22222222");
+    await act(async () => { choices[1]!.click(); });
+    expect(mocks.selectCloudLibrary).toHaveBeenCalledWith("22".repeat(32));
+    act(() => root.unmount());
   });
 
   it("explains a missing upload and lets the user run sync now", async () => {

--- a/packages/pwa/src/components/PwaSyncSettings.tsx
+++ b/packages/pwa/src/components/PwaSyncSettings.tsx
@@ -9,7 +9,7 @@
  *   last-synced time, and a Disconnect action.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { getWebsiteHostForChannel } from "@freed/shared";
 import { usePlatform } from "@freed/ui/context";
 import { useLibraryFacetSummary } from "@freed/ui/hooks/useLibraryFacetSummary";
@@ -24,6 +24,9 @@ import {
   clearCloudSync,
   stopCloudSync,
   syncCloudProviderNow,
+  getCloudLibraryChoices,
+  subscribeCloudLibraryChoices,
+  selectCloudLibrary,
 } from "../lib/sync";
 import { PwaCloudSyncConnect } from "./PwaCloudSyncConnect";
 import { useCloudSyncActivity } from "./cloudSyncActivity";
@@ -170,6 +173,7 @@ export function PwaDemoSyncSettings() {
 }
 
 export function PwaSyncSettings() {
+  const libraryChoices = useSyncExternalStore(subscribeCloudLibraryChoices, getCloudLibraryChoices);
   const { releaseChannel } = usePlatform();
   const syncConnected = useAppStore((s) => s.syncConnected);
   const isSyncing = useAppStore((s) => s.isSyncing);
@@ -373,6 +377,36 @@ export function PwaSyncSettings() {
 
   return (
     <div className="space-y-4">
+      {libraryChoices.length > 0 && (
+        <div className="theme-card-soft rounded-xl p-4" data-testid="pwa-library-choice">
+          <p className="text-sm font-semibold">Choose your Library</p>
+          <p className="mt-1 text-xs text-text-muted">Google Drive contains several Libraries. Match the Library ID shown in Freed Desktop. Other Libraries remain untouched.</p>
+          <div className="mt-3 space-y-2">
+            {libraryChoices.map((libraryId) => (
+              <button
+                key={libraryId}
+                type="button"
+                disabled={isManualSyncing}
+                className="btn-secondary block w-full rounded-lg px-3 py-2 text-sm"
+                onClick={async () => {
+                  setManualSyncingProvider("gdrive");
+                  setManualSyncError(null);
+                  try {
+                    await selectCloudLibrary(libraryId);
+                    await refreshSelectedCheckpoint();
+                  } catch (error) {
+                    setManualSyncError(error instanceof Error ? error.message : "Library connection failed.");
+                  } finally {
+                    setManualSyncingProvider(null);
+                  }
+                }}
+              >
+                Sync Library {formatIdentityTail(libraryId)}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
       <div className="flex items-center gap-4 rounded-xl border border-[var(--theme-border-subtle)] bg-[var(--theme-bg-card)] px-4 py-4">
         {provider && <ProviderLogo />}
         <div className="min-w-0 flex-1">

--- a/packages/pwa/src/index.css
+++ b/packages/pwa/src/index.css
@@ -151,6 +151,13 @@ html[data-theme="neon"] .demo-freed-logo {
   transform-origin: center bottom;
 }
 
+@media (max-width: 640px) {
+  /* The fullscreen card fades with its overlay; keep its position and size fixed. */
+  .demo-welcome-first-look-card--departing {
+    animation: none;
+  }
+}
+
 .demo-welcome-field-guide--arriving {
   animation: demo-welcome-field-guide-in 900ms linear both;
   transform-origin: center bottom;

--- a/packages/pwa/src/lib/body-scroll-lock.test.ts
+++ b/packages/pwa/src/lib/body-scroll-lock.test.ts
@@ -1,0 +1,27 @@
+import { expect, it } from "vitest";
+import { lockBodyScroll } from "../../../ui/src/lib/body-scroll-lock";
+
+it("keeps nested overlays locked and restores scrolling when closed out of order", () => {
+  document.body.style.overflow = "auto";
+  const closeSettings = lockBodyScroll();
+  const closeReader = lockBodyScroll();
+  closeSettings();
+  expect(document.body.style.overflow).toBe("hidden");
+  closeSettings();
+  expect(document.body.style.overflow).toBe("hidden");
+  closeReader();
+  expect(document.body.style.overflow).toBe("auto");
+  document.body.style.overflow = "";
+});
+
+it("restores stylesheet-owned scrolling after repeated overlay cycles", () => {
+  document.body.style.overflow = "";
+  for (let cycle = 0; cycle < 3; cycle += 1) {
+    const closeSheet = lockBodyScroll();
+    const closeReader = lockBodyScroll();
+    closeReader();
+    expect(document.body.style.overflow).toBe("hidden");
+    closeSheet();
+    expect(document.body.style.overflow).toBe("");
+  }
+});

--- a/packages/pwa/src/lib/library-core-browser-key-vault.test.ts
+++ b/packages/pwa/src/lib/library-core-browser-key-vault.test.ts
@@ -8,6 +8,7 @@ import {
 
 import {
   commitPwaLibraryCoreLocalSampleResult,
+  discardRejectedPwaLibraryCoreLocalSampleResult,
   createPwaLibraryCoreLocalSampleAuthority,
   markPwaLibraryCoreLocalSampleAuthorityReady,
   PwaLibraryCoreLegacyLocalSampleAuthorityError,
@@ -276,6 +277,19 @@ describe("PWA Library Core browser key vault", () => {
       previousResultDigest: resultDigest,
       sourceRevision: 1,
     });
+  });
+
+  it("retires only the rejected prepared result without advancing its cursors", async () => {
+    const created = await createPwaLibraryCoreLocalSampleAuthority();
+    const ready = await markPwaLibraryCoreLocalSampleAuthorityReady(created.libraryId, lowercaseHex64("55".repeat(32)));
+    const resultDigest = lowercaseHex64("66".repeat(32));
+    await preparePwaLibraryCoreLocalSampleResult(created.libraryId, {
+      canonicalResultBytes: Uint8Array.of(4, 5, 6), nextActorCounter: 2,
+      nextResultSequence: 2, previousResultDigest: resultDigest, sourceRevision: 1,
+    });
+    await expect(discardRejectedPwaLibraryCoreLocalSampleResult(created.libraryId, lowercaseHex64("77".repeat(32)))).rejects.toThrow("rejected local sample result changed");
+    await expect(discardRejectedPwaLibraryCoreLocalSampleResult(created.libraryId, resultDigest)).resolves.toEqual(ready);
+    await expect(discardRejectedPwaLibraryCoreLocalSampleResult(created.libraryId, resultDigest)).rejects.toThrow("rejected local sample result changed");
   });
 
   it("identifies the retired WebKit sample authority for bounded recovery", async () => {

--- a/packages/pwa/src/lib/library-core-browser-key-vault.ts
+++ b/packages/pwa/src/lib/library-core-browser-key-vault.ts
@@ -170,7 +170,11 @@ function openKeyDatabase(): Promise<IDBDatabase> {
       },
       { once: true },
     );
-    request.addEventListener("success", () => resolve(request.result), {
+    request.addEventListener("success", () => {
+      const database = request.result;
+      database.addEventListener("versionchange", () => database.close());
+      resolve(database);
+    }, {
       once: true,
     });
     request.addEventListener(
@@ -512,6 +516,24 @@ export async function preparePwaLibraryCoreLocalSampleResult(
       preparedResult: validatePreparedResult(preparedResult),
     });
   });
+}
+
+/** Retire only the exact local result SQLite has rejected before admission. */
+export async function discardRejectedPwaLibraryCoreLocalSampleResult(
+  libraryId: LibraryCoreLowercaseHex64,
+  resultDigest: LibraryCoreLowercaseHex64,
+): Promise<PwaLibraryCoreLocalSampleAuthority> {
+  const stored = await updateStoredLocalSampleAuthority((current) => {
+    if (
+      current.libraryId !== libraryId ||
+      current.status !== "ready" ||
+      current.preparedResult?.previousResultDigest !== resultDigest
+    ) {
+      throw new Error("PWA rejected local sample result changed");
+    }
+    return Object.freeze({ ...current, preparedResult: null });
+  });
+  return publicLocalSampleAuthority(stored);
 }
 
 export async function commitPwaLibraryCoreLocalSampleResult(

--- a/packages/pwa/src/lib/library-core-preview-bootstrap.ts
+++ b/packages/pwa/src/lib/library-core-preview-bootstrap.ts
@@ -9,12 +9,14 @@ import {
   LIBRARY_CORE_OPERATION_TRANSACTION_MAXIMUM_BYTES,
   LIBRARY_CORE_OPERATION_TRANSACTION_MAXIMUM_MEMBERS,
   libraryCoreFollowerResultBodyV1,
+  libraryCoreOptimisticFieldsForEnvelopeV1,
   parseLibraryCoreFollowerResultEnvelopeV1,
   sha256LowerHex,
   type LibraryCoreCanonicalValue,
   type LibraryCoreDigestDomain,
   type LibraryCoreEd25519SignatureHex,
   type LibraryCoreLowercaseHex64,
+  type LibraryCoreOperationEnvelopeV1,
 } from "@freed/shared/library-core";
 import {
   installPwaLibraryCoreFollowerEnrollment,
@@ -34,6 +36,7 @@ import {
   commitPwaLibraryCoreLocalSampleResult,
   createPwaLibraryCoreLocalSampleAuthority,
   deletePwaLibraryCoreLocalSampleAuthority,
+  discardRejectedPwaLibraryCoreLocalSampleResult,
   markPwaLibraryCoreLocalSampleAuthorityReady,
   preparePwaLibraryCoreLocalSampleResult,
   PwaLibraryCoreLegacyLocalSampleAuthorityError,
@@ -120,16 +123,35 @@ async function createPreviewLibrary(): Promise<void> {
     }
     if (authority?.status === "ready") {
       if (authority.preparedResult) {
-        const receipt = await applyPwaFollowerResult({
-          canonicalResultBytes: authority.preparedResult.canonicalResultBytes,
-        });
-        if (!isLibraryCoreLowercaseHex64(receipt.resultDigest)) {
-          throw new Error("PWA local sample result digest is invalid");
+        try {
+          const receipt = await applyPwaFollowerResult({
+            canonicalResultBytes: authority.preparedResult.canonicalResultBytes,
+          });
+          if (!isLibraryCoreLowercaseHex64(receipt.resultDigest)) {
+            throw new Error("PWA local sample result digest is invalid");
+          }
+          authority = await commitPwaLibraryCoreLocalSampleResult(
+            authority.libraryId,
+            receipt.resultDigest,
+          );
+        } catch (error) {
+          if (
+            !(error instanceof Error) ||
+            error.message !== "follower result replacement projection is incomplete" ||
+            !selected.receipt.controlRevision.startsWith("preview:")
+          ) {
+            throw error;
+          }
+          // v26.9.803 could prepare a local result without its care projections.
+          // This exact SQLite rejection rolls back before result admission.
+          // Keep the intent and all cursors so settlement can rebuild the result
+          // from the original envelopes. Admitted results return a retry receipt
+          // above and never enter this recovery path.
+          authority = await discardRejectedPwaLibraryCoreLocalSampleResult(
+            authority.libraryId,
+            authority.preparedResult!.previousResultDigest,
+          );
         }
-        authority = await commitPwaLibraryCoreLocalSampleResult(
-          authority.libraryId,
-          receipt.resultDigest,
-        );
       }
       localSampleAuthority = authority;
       previewActorId = authority.actorId;
@@ -422,7 +444,20 @@ async function settlePwaLibraryCorePreviewIntentsExclusive(): Promise<void> {
         previous_result_digest: previewPreviousResultDigest,
         receipt_ids: envelopeDigests,
         rejection_reason: null,
-        replacement_fields: [],
+        replacement_fields: members.flatMap((member) =>
+          libraryCoreOptimisticFieldsForEnvelopeV1(
+            member as unknown as LibraryCoreOperationEnvelopeV1,
+          ).map((field) => ({
+            entity_type: field.entityType,
+            entity_id: field.entityId,
+            field_path: field.fieldPath,
+            value_type: field.valueType,
+            boolean_value: field.valueType === "boolean" ? field.value : null,
+            integer_value: field.valueType === "integer" ? field.value : null,
+            real_value: null,
+            text_value: null,
+          })),
+        ),
         resolved_at_ms: resolvedAt,
         result_body_digest: "0".repeat(64),
         result_sequence: previewNextResultSequence,

--- a/packages/pwa/src/lib/library-core-runtime.test.ts
+++ b/packages/pwa/src/lib/library-core-runtime.test.ts
@@ -105,6 +105,7 @@ vi.mock("./library-core-sqlite-runtime", () => ({
   readPwaNormalizedCheckpointExportPage:
     mocks.readNormalizedCheckpointExportPage,
   resetPwaNormalizedLibrary: mocks.resetNormalizedLibrary,
+  closePwaNormalizedLibrary: vi.fn(async () => {}),
 }));
 
 import {
@@ -569,6 +570,15 @@ describe("PWA Library Core bounded scanner", () => {
       signal: undefined,
     });
     expect(mocks.syncFollower).toHaveBeenCalledWith({}, { signal: undefined });
+    expect(mocks.discoverControl).toHaveBeenCalledWith(expect.objectContaining({ libraryId }));
+  });
+
+  it("refuses to replace a retained Library through a different connection choice", async () => {
+    mocks.readNormalizedCheckpointReceipt.mockResolvedValue({ receipt: SELECTED_RECEIPT });
+    await expect(syncPwaLibraryCoreFromGoogleDrive({ accessToken: "test-token", libraryId: "another-library" }))
+      .rejects.toThrow("Reset this device before connecting a different Library");
+    expect(mocks.discoverControl).not.toHaveBeenCalled();
+    expect(mocks.importCheckpoint).not.toHaveBeenCalled();
   });
 
   it("binds search identity to the selected checkpoint instead of stale shell state", async () => {

--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -92,6 +92,7 @@ import {
   readPwaFollowerTransportContext,
   readPwaNormalizedCheckpointReceipt,
   resetPwaNormalizedLibrary,
+  closePwaNormalizedLibrary,
 } from "./library-core-sqlite-runtime";
 import { createPwaNormalizedCheckpointWriter } from "./library-core-pwa-normalized-checkpoint-writer";
 import { PWA_LIBRARY_CORE_KEY_DATABASE_NAME } from "./library-core-browser-key-vault";
@@ -1307,10 +1308,19 @@ async function publishSelectedStateAfterLibraryCoreSync(): Promise<LibraryCoreRu
 /** Import the published normalized Desktop checkpoint into OPFS SQLite. */
 export async function syncPwaLibraryCoreFromGoogleDrive(input: {
   readonly accessToken: string;
+  readonly libraryId?: string;
   readonly signal?: AbortSignal;
 }): Promise<LibraryCoreRuntimeStateV1> {
+  const selected = await readPwaNormalizedCheckpointReceipt();
+  const retainedLibraryId = selected.receipt &&
+    !selected.receipt.controlRevision.startsWith("preview:")
+      ? selected.receipt.libraryId : undefined;
+  if (retainedLibraryId && input.libraryId && retainedLibraryId !== input.libraryId) {
+    throw new Error("Reset this device before connecting a different Library");
+  }
   const discovered = await discoverPublishedGoogleDriveLibraryCoreControlV1({
     accessToken: input.accessToken,
+    libraryId: retainedLibraryId ?? input.libraryId,
     signal: input.signal,
   });
   if (!discovered) {
@@ -1359,29 +1369,36 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
 registerPwaFactoryResetQuiesceHandler(
   "library-core-storage",
   async () => {
-    await resetPwaNormalizedLibrary();
+    await closePwaNormalizedLibrary();
     lastState = null;
     lastLocalChangeSequence = 0;
-    const deleteDatabase = (databaseName: string) =>
-      new Promise<void>((resolve, reject) => {
-        const request = globalThis.indexedDB.deleteDatabase(databaseName);
-        request.addEventListener("success", () => resolve(), { once: true });
-        request.addEventListener(
-          "error",
-          () =>
-            reject(request.error ?? new Error("SQLite Library reset failed")),
-          { once: true },
-        );
-        request.addEventListener(
-          "blocked",
-          () =>
-            reject(
-              new Error("SQLite Library reset was blocked by another tab"),
-            ),
-          { once: true },
-        );
-      });
-    await deleteDatabase(PWA_LIBRARY_CORE_KEY_DATABASE_NAME);
   },
   25,
 );
+
+/** Delete storage only after every peer has released its worker and handles. */
+export async function clearPwaLibraryCoreLocalDataForFactoryReset(): Promise<void> {
+  await resetPwaNormalizedLibrary();
+  const deleteDatabase = (databaseName: string) =>
+    new Promise<void>((resolve, reject) => {
+      const request = globalThis.indexedDB.deleteDatabase(databaseName);
+      const timeout = setTimeout(() => reject(
+        new Error("SQLite Library reset was blocked by another tab"),
+      ), 10_000);
+      request.addEventListener("success", () => {
+        clearTimeout(timeout);
+        resolve();
+      }, { once: true });
+      request.addEventListener(
+        "error",
+        () => {
+          clearTimeout(timeout);
+          reject(request.error ?? new Error("SQLite Library reset failed"));
+        },
+        { once: true },
+      );
+      // A blocked notification can precede success while a peer processes its
+      // versionchange event. Bound that wait instead of aborting on notification.
+    });
+  await deleteDatabase(PWA_LIBRARY_CORE_KEY_DATABASE_NAME);
+}

--- a/packages/pwa/src/lib/library-core-sqlite-runtime.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-runtime.test.ts
@@ -126,6 +126,37 @@ describe("PWA SQLite runtime worker recovery", () => {
     vi.unstubAllGlobals();
   });
 
+  it("fences background reads throughout device reset without reopening OPFS", async () => {
+    const { beginFactoryResetBoundary } = await import("@freed/ui/lib/factory-reset");
+    const { queryPwaNormalizedLibrary } = await import("./library-core-sqlite-runtime");
+    beginFactoryResetBoundary();
+    await expect(queryPwaNormalizedLibrary({
+      queryId: "library_facet_summary_v1",
+      schemaVersion: 1,
+    })).rejects.toThrow("unavailable while this device resets");
+    expect(RecoveringWorker.instances).toHaveLength(0);
+  });
+
+  it("coalesces storage deletion and refuses a new worker during local reset", async () => {
+    let finish!: () => void;
+    const removal = new Promise<void>((resolve) => { finish = resolve; });
+    const removeEntry = vi.fn(() => removal);
+    vi.stubGlobal("navigator", {
+      storage: { getDirectory: vi.fn(async () => ({ removeEntry })) },
+    });
+    const { queryPwaNormalizedLibrary, resetPwaNormalizedLibrary } = await import("./library-core-sqlite-runtime");
+    const first = resetPwaNormalizedLibrary();
+    const second = resetPwaNormalizedLibrary();
+    await expect(queryPwaNormalizedLibrary({
+      queryId: "library_facet_summary_v1",
+      schemaVersion: 1,
+    })).rejects.toThrow("unavailable while this device resets");
+    expect(RecoveringWorker.instances).toHaveLength(0);
+    finish();
+    await Promise.all([first, second]);
+    expect(removeEntry).toHaveBeenCalledTimes(2);
+  });
+
   it("reopens the accepted OPFS Library and retries one read after worker loss", async () => {
     const { queryPwaNormalizedLibrary } = await import(
       "./library-core-sqlite-runtime"

--- a/packages/pwa/src/lib/library-core-sqlite-runtime.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-runtime.ts
@@ -47,6 +47,7 @@ import {
   PwaLibraryCoreSqliteClient,
 } from "./library-core-sqlite-client";
 import { deletePwaLibraryCoreSqliteStorage } from "./library-core-sqlite-storage";
+import { isFactoryResetInProgress } from "@freed/ui/lib/factory-reset";
 
 interface ClientGeneration {
   readonly client: PwaLibraryCoreSqliteClient;
@@ -54,6 +55,13 @@ interface ClientGeneration {
 }
 
 let clientGeneration: ClientGeneration | null = null;
+let resetTask: Promise<void> | null = null;
+
+function assertLibraryAvailable(): void {
+  if (resetTask || isFactoryResetInProgress()) {
+    throw new Error("PWA Library SQLite is unavailable while this device resets");
+  }
+}
 
 function clearClientGeneration(active: PwaLibraryCoreSqliteClient): void {
   if (clientGeneration?.client === active) clientGeneration = null;
@@ -81,8 +89,10 @@ function createClientGeneration(): ClientGeneration {
 }
 
 async function openClient(): Promise<PwaLibraryCoreSqliteClient> {
+  assertLibraryAvailable();
   const generation = clientGeneration ?? createClientGeneration();
   await generation.openTask;
+  assertLibraryAvailable();
   return generation.client;
 }
 
@@ -286,7 +296,7 @@ export async function installPwaFollowerActorEnrollment(
   return active.installFollowerActorEnrollment(install);
 }
 
-async function closePwaNormalizedLibrary(): Promise<void> {
+export async function closePwaNormalizedLibrary(): Promise<void> {
   const active = clientGeneration?.client ?? null;
   clientGeneration = null;
   if (!active) return;
@@ -303,6 +313,14 @@ async function closePwaNormalizedLibrary(): Promise<void> {
 }
 
 export async function resetPwaNormalizedLibrary(): Promise<void> {
-  await closePwaNormalizedLibrary();
-  await deletePwaLibraryCoreSqliteStorage();
+  if (resetTask) return resetTask;
+  resetTask = (async () => {
+    await closePwaNormalizedLibrary();
+    await deletePwaLibraryCoreSqliteStorage();
+  })();
+  try {
+    await resetTask;
+  } finally {
+    resetTask = null;
+  }
 }

--- a/packages/pwa/src/lib/library-core-sqlite-worker.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-worker.ts
@@ -34,6 +34,7 @@ const useDemoMemoryStorage = scope.name === "freed-library-core-sqlite-demo" &&
 const useMemoryStorage = useMemoryE2eStorage || useDemoMemoryStorage;
 let engine: PwaLibraryCoreSqliteEngine | null = null;
 let contentVault: PwaLibraryCoreOpfsContentVault | null = null;
+let opfsPool: { pauseVfs(): unknown } | null = null;
 let releaseOwnership: (() => void) | null = null;
 let ownershipTask: Promise<unknown> | null = null;
 
@@ -107,13 +108,13 @@ async function open(): Promise<PwaLibraryCoreSqliteEngine> {
     openingStage = useMemoryStorage
       ? "open the isolated memory database"
       : "install the OPFS SAH pool VFS";
-    const database = useMemoryStorage
-      ? new sqlite3.oo1.DB(":memory:", "c")
-      : new (
-          await installPwaLibraryCoreOpfsSahPool((options) =>
-            sqlite3.installOpfsSAHPoolVfs(options),
-          )
-        ).OpfsSAHPoolDb(PWA_LIBRARY_CORE_SQLITE_DATABASE_FILENAME);
+    const pool = useMemoryStorage ? null : await installPwaLibraryCoreOpfsSahPool(
+      (options) => sqlite3.installOpfsSAHPoolVfs(options),
+    );
+    opfsPool = pool;
+    const database = pool
+      ? new pool.OpfsSAHPoolDb(PWA_LIBRARY_CORE_SQLITE_DATABASE_FILENAME)
+      : new sqlite3.oo1.DB(":memory:", "c");
     openingStage = "initialize the normalized schema";
     const next = new PwaLibraryCoreSqliteEngine(
       database,
@@ -133,6 +134,8 @@ async function open(): Promise<PwaLibraryCoreSqliteEngine> {
     return next;
   } catch (error) {
     openingEngine?.close();
+    opfsPool?.pauseVfs();
+    opfsPool = null;
     releaseOwnership?.();
     releaseOwnership = null;
     await ownershipTask?.catch(() => undefined);
@@ -239,6 +242,11 @@ async function executeClose(
   contentVault = null;
   active.close();
   engine = null;
+  // Closing the DB retains the pool's SyncAccessHandles. Explicitly release
+  // them before acknowledging quiescence or allowing another tab to open.
+  // Worker termination alone does not synchronously release handles in WebKit.
+  opfsPool?.pauseVfs();
+  opfsPool = null;
   releaseOwnership?.();
   releaseOwnership = null;
   await ownershipTask?.catch(() => undefined);

--- a/packages/pwa/src/lib/sync.test.ts
+++ b/packages/pwa/src/lib/sync.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { GoogleDriveLibrarySelectionRequiredError } from "@freed/sync/cloud/library-core";
 import {
   beginFactoryResetBoundary,
   resetFactoryResetStateForTests,
@@ -27,6 +28,8 @@ import {
   stopCloudSync,
   storeCloudToken,
   syncCloudProviderNow,
+  getCloudLibraryChoices,
+  selectCloudLibrary,
 } from "./sync";
 
 function deferred<T>(): {
@@ -64,6 +67,20 @@ describe("PWA Library Core sync lifecycle", () => {
     resetFactoryResetStateForTests();
     vi.unstubAllGlobals();
     vi.useRealTimers();
+  });
+
+  it("retains an explicit discovered Library choice across sync passes", async () => {
+    mocks.syncLibraryCore.mockRejectedValueOnce(new GoogleDriveLibrarySelectionRequiredError(["library-a", "library-b"]));
+    await expect(startCloudSync("gdrive", "stored-token")).rejects.toThrow("Choose which Library");
+    expect(getCloudLibraryChoices()).toEqual(["library-a", "library-b"]);
+    await expect(selectCloudLibrary("unknown")).rejects.toThrow("Refresh Google Drive");
+    await selectCloudLibrary("library-b");
+    expect(mocks.syncLibraryCore).toHaveBeenLastCalledWith(expect.objectContaining({ libraryId: "library-b" }));
+    await syncCloudProviderNow("gdrive");
+    expect(mocks.syncLibraryCore).toHaveBeenLastCalledWith(expect.objectContaining({ libraryId: "library-b" }));
+    expect(getCloudLibraryChoices()).toEqual([]);
+    clearCloudSync("gdrive");
+    expect(localStorage.getItem("freed_cloud_library_gdrive")).toBeNull();
   });
 
   it("surfaces an initial failure and lets Sync now restore the live session", async () => {

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -1,6 +1,7 @@
 /** PWA Library Core synchronization and OAuth credential lifecycle. */
 
 import type { CloudProvider } from "@freed/sync/cloud/library-core";
+import { GoogleDriveLibrarySelectionRequiredError } from "@freed/sync/cloud/library-core";
 import {
   recordCloudProviderEvent,
   updateCloudProvider,
@@ -19,6 +20,31 @@ import { syncPwaLibraryCoreFromGoogleDrive } from "./library-core-runtime";
 export type { CloudProvider };
 
 const CLOUD_PROVIDER_KEY = "freed_cloud_provider";
+const CLOUD_LIBRARY_KEY = "freed_cloud_library_gdrive";
+const emptyLibraryChoices: readonly string[] = Object.freeze([]);
+let libraryChoices = emptyLibraryChoices;
+const libraryChoiceListeners = new Set<() => void>();
+
+export function getCloudLibraryChoices(): readonly string[] { return libraryChoices; }
+export function subscribeCloudLibraryChoices(listener: () => void): () => void {
+  libraryChoiceListeners.add(listener);
+  return () => { libraryChoiceListeners.delete(listener); };
+}
+function setCloudLibraryChoices(choices: readonly string[]): void {
+  libraryChoices = Object.freeze([...choices]);
+  for (const listener of libraryChoiceListeners) listener();
+}
+
+/** Persist an explicit first-import choice; SQLite still verifies its authority. */
+export async function selectCloudLibrary(libraryId: string): Promise<void> {
+  if (!libraryChoices.includes(libraryId)) {
+    throw new Error("Refresh Google Drive before choosing this Library");
+  }
+  stopCloudSync();
+  localStorage.setItem(CLOUD_LIBRARY_KEY, libraryId);
+  setCloudLibraryChoices(emptyLibraryChoices);
+  await syncCloudProviderNow("gdrive");
+}
 const CLOUD_TOKEN_KEY = (provider: CloudProvider) =>
   `freed_cloud_token_${provider}`;
 const CLOUD_TOKEN_META_KEY = (provider: CloudProvider) =>
@@ -172,7 +198,8 @@ async function syncGoogleDriveWithFreshCredentials(
   signal: AbortSignal,
 ): Promise<void> {
   try {
-    await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal });
+    await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal,
+      libraryId: localStorage.getItem(CLOUD_LIBRARY_KEY) ?? undefined });
   } catch (error) {
     if (!isGoogleAuthenticationFailure(error)) throw error;
 
@@ -191,6 +218,7 @@ async function syncGoogleDriveWithFreshCredentials(
     }
     await syncPwaLibraryCoreFromGoogleDrive({
       accessToken: refreshedAccessToken,
+      libraryId: localStorage.getItem(CLOUD_LIBRARY_KEY) ?? undefined,
       signal,
     });
   }
@@ -213,6 +241,9 @@ async function syncGoogleDriveOnce(
     await syncGoogleDriveWithFreshCredentials(accessToken, signal);
   } catch (error) {
     if (generation !== cloudGeneration || signal.aborted) throw error;
+    if (error instanceof GoogleDriveLibrarySelectionRequiredError) {
+      setCloudLibraryChoices(error.libraryIds);
+    }
     const message = error instanceof Error ? error.message : String(error);
     const isWaitingForPrimary = message === MISSING_PUBLISHED_LIBRARY_ERROR;
     updateCloudProvider("gdrive", {
@@ -236,6 +267,7 @@ async function syncGoogleDriveOnce(
   }
   if (generation !== cloudGeneration || signal.aborted) return;
   const now = Date.now();
+  setCloudLibraryChoices(emptyLibraryChoices);
   updateCloudProvider("gdrive", {
     status: "connected",
     stage: "idle",
@@ -317,6 +349,8 @@ export function getCloudProvider(): CloudProvider | null {
 
 export function clearCloudSync(provider: CloudProvider): void {
   stopCloudSync();
+  localStorage.removeItem(CLOUD_LIBRARY_KEY);
+  setCloudLibraryChoices(emptyLibraryChoices);
   localStorage.removeItem(CLOUD_TOKEN_KEY(provider));
   localStorage.removeItem(CLOUD_TOKEN_META_KEY(provider));
   if (getCloudProvider() === provider) localStorage.removeItem(CLOUD_PROVIDER_KEY);

--- a/packages/pwa/tests/safari-viewport.spec.ts
+++ b/packages/pwa/tests/safari-viewport.spec.ts
@@ -265,8 +265,8 @@ test.describe("Safari viewport layout — iPhone 14 / WebKit", () => {
       });
       expect(geometry.left).toBe(0);
       expect(geometry.right).toBe(viewport.width);
-      expect(geometry.contentPadding).toBe(viewport.width > 767 ? 47 : 0);
-      expect(geometry.toolbarPadding).toBe(viewport.width > 767 ? 47 : 12);
+      expect(geometry.contentPadding).toBe(viewport.width > 767 ? 47 : 8);
+      expect(geometry.toolbarPadding).toBe(viewport.width > 767 ? 47 : 6);
       expect(geometry.smooth).toBe("auto");
       expect(geometry.overflow).toBe(false);
       await page.evaluate(() => window.scrollTo({ top: 600, behavior: "instant" }));
@@ -565,5 +565,19 @@ test.describe("BottomSheet / drawer viewport", () => {
     expect(box!.y).toBeGreaterThanOrEqual(0);
     // Panel top must be below the header (not covering it entirely).
     expect(box!.y).toBeLessThan(viewportHeight * 0.5);
+
+    await page.getByRole("button", { name: "Appearance", exact: true }).click();
+    const scrollport = page.locator(".theme-settings-scrollport");
+    await expect(scrollport).toBeVisible();
+    const scrollHeight = await scrollport.evaluate((element) => {
+      element.scrollTop = element.scrollHeight;
+      return element.clientHeight;
+    });
+    expect(scrollHeight).toBeGreaterThan(0);
+    expect(scrollHeight).toBeLessThan(viewportHeight);
+    await expect.poll(() => scrollport.evaluate(element => element.scrollTop)).toBeGreaterThan(0);
+    await page.getByRole("button", { name: "Close settings", exact: true }).click();
+    await expect(panel).toHaveCount(0);
+    await expect.poll(() => page.evaluate(() => document.body.style.overflow)).toBe("");
   });
 });

--- a/packages/pwa/tests/sqlite-opfs-durability.spec.ts
+++ b/packages/pwa/tests/sqlite-opfs-durability.spec.ts
@@ -528,6 +528,18 @@ test("iPhone WebKit persists, clears, and rebuilds the local sample Library", as
     context = opened.context;
     const reopened = opened.page;
     await expectShowcaseSampleData(reopened, baseline);
+    // Scrolling the feed queues read assignments before Settings clears the
+    // samples. Those signed results must include their sparse replacements.
+    const item = reopened.locator("[data-feed-item-id]").first();
+    await expect(item).toBeVisible();
+    const itemId = await item.getAttribute("data-feed-item-id");
+    expect(itemId).toBeTruthy();
+    await reopened.evaluate(async (itemId) => {
+      const store = (window as unknown as {
+        __FREED_STORE__: { getState(): { markAsRead(id: string): Promise<void> } };
+      }).__FREED_STORE__;
+      await store.getState().markAsRead(itemId!);
+    }, itemId);
     await openDangerZone(reopened);
     await expect(
       reopened.getByRole("button", { name: /Sample data populated/ }),
@@ -566,6 +578,110 @@ test("iPhone WebKit persists, clears, and rebuilds the local sample Library", as
     await context.close();
     context = null;
     await verifyDurableOpfsLibrary(profileRoot);
+  } finally {
+    await context?.close();
+    await rm(profileRoot, { force: true, recursive: true });
+  }
+});
+
+test("iPhone WebKit recovers a rejected v26.9.803 sample result after restart", async () => {
+  test.setTimeout(180_000);
+  const profileRoot = await mkdtemp(join(tmpdir(), "freed-pwa-rejected-sample-webkit-"));
+  let context: BrowserContext | null = null;
+  try {
+    context = await launchPersistentLibraryContext(profileRoot);
+    await context.route("**/src/lib/library-core-preview-bootstrap.ts*", async (route) => {
+      const response = await route.fetch();
+      const body = await response.text();
+      const projection = /replacement_fields: members\.flatMap\([\s\S]*?resolved_at_ms:/;
+      expect(body).toMatch(projection);
+      await route.fulfill({ response, body: body.replace(projection, "replacement_fields: [], resolved_at_ms:") });
+    });
+    const page = context.pages()[0] ?? await context.newPage();
+    await openLibrary(page);
+    await expect.poll(() => readFacetSummary(page), { timeout: 90_000 }).toMatchObject({ sampleItemCount: previewCounts.items });
+    const item = page.locator("[data-feed-item-id]").first();
+    await expect(item).toBeVisible();
+    const itemId = await item.getAttribute("data-feed-item-id");
+    expect(await page.evaluate(async (id) => {
+      const store = (window as unknown as { __FREED_STORE__: { getState(): {
+        markAsRead(id: string): Promise<void>;
+        clearSampleData(): Promise<void>;
+      } } }).__FREED_STORE__.getState();
+      await store.markAsRead(id!);
+      try { await store.clearSampleData(); return null; }
+      catch (error) { return String(error); }
+    }, itemId)).toContain("follower result replacement projection is incomplete");
+    await context.close();
+    context = null;
+    const opened = await openPersistentLibrary(profileRoot);
+    context = opened.context;
+    await expect.poll(() => readFacetSummary(opened.page), { timeout: 90_000 }).toMatchObject({ sampleItemCount: previewCounts.items });
+    await opened.page.evaluate(async () => {
+      await (window as unknown as { __FREED_STORE__: { getState(): {
+        clearSampleData(): Promise<void>;
+      } } }).__FREED_STORE__.getState().clearSampleData();
+    });
+    await expect.poll(() => readFacetSummary(opened.page)).toMatchObject({ sampleItemCount: 0, sampleFeedCount: 0, samplePersonCount: 0 });
+  } finally {
+    await context?.close();
+    await rm(profileRoot, { force: true, recursive: true });
+  }
+});
+
+test("iPhone WebKit resets populated storage after every open tab quiesces", async () => {
+  test.setTimeout(180_000);
+  const profileRoot = await mkdtemp(join(tmpdir(), "freed-pwa-reset-webkit-"));
+  let context: BrowserContext | null = null;
+  try {
+    context = await launchPersistentLibraryContext(profileRoot);
+    const resetErrors: string[] = [];
+    context.on("console", message => { if (message.text().startsWith("RESET_TEST_FAILURE")) resetErrors.push(message.text()); });
+    // Exercise ordinary startup. The feature-preview server must not silently
+    // repopulate the emptied Library on the reset navigation.
+    await context.route("**/src/App.tsx*", async (route) => {
+      const response = await route.fetch();
+      const body = await response.text();
+      expect(body).toMatch(/const IS_FEATURE_PREVIEW = [^;]+;/);
+      await route.fulfill({ response, body: body.replace(/const IS_FEATURE_PREVIEW = [^;]+;/, "const IS_FEATURE_PREVIEW = false;").replace("onFailure: (error) => {", 'onFailure: (error) => { console.error("RESET_TEST_FAILURE", error);') });
+    });
+    const page = context.pages()[0] ?? await context.newPage();
+    await page.goto("/");
+    await expect(page.getByTestId("legal-gate-accept")).toBeVisible();
+    await acceptLegalGate(page);
+    await waitForLibrary(page);
+    await openDangerZone(page);
+    await page.getByRole("button", { name: /Populate sample data Adds/ }).click();
+    await expect(page.getByRole("button", { name: /Sample data populated/ })).toBeDisabled({ timeout: 90_000 });
+    const peer = await context.newPage();
+    await peer.goto("/");
+    await expect(peer.getByText(/another app window|another Freed window|another tab/).first()).toBeVisible({ timeout: 30_000 });
+    await page.getByRole("button", { name: /Reset this device Wipes/ }).click();
+    await Promise.all([
+      page.waitForEvent("domcontentloaded"),
+      page.getByRole("button", { name: "Reset Device", exact: true }).click(),
+    ]);
+    await expect(page.getByRole("button", { name: "Reset Device", exact: true })).toHaveCount(0, { timeout: 30_000 });
+    expect(resetErrors).toEqual([]);
+    await peer.close();
+    const retry = page.getByRole("button", { name: "Retry here", exact: true });
+    await expect(retry.or(page.getByRole("button", { name: "Open menu" }))).toBeVisible();
+    if (await retry.isVisible()) {
+      await Promise.all([page.waitForEvent("domcontentloaded"), retry.click()]);
+    }
+    await waitForLibrary(page);
+    await expect.poll(() => page.evaluate(async () => {
+      const modulePath = "/src/lib/library-core-sqlite-runtime.ts";
+      const runtime = await import(modulePath);
+      return runtime.readPwaNormalizedCheckpointReceipt();
+    }), { timeout: 30_000 }).toEqual({ receipt: null });
+    await page.reload();
+    await waitForLibrary(page);
+    expect(await page.evaluate(async () => {
+      const modulePath = "/src/lib/library-core-sqlite-runtime.ts";
+      const runtime = await import(modulePath);
+      return runtime.readPwaNormalizedCheckpointReceipt();
+    })).toEqual({ receipt: null });
   } finally {
     await context?.close();
     await rm(profileRoot, { force: true, recursive: true });

--- a/packages/sync/src/cloud/library-core-google-drive-adapter.test.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-adapter.test.ts
@@ -24,6 +24,7 @@ import {
   discoverGoogleDriveLibraryCoreIntentHeadV1,
   discoverGoogleDriveLibraryCoreIntentSegmentsV1,
   discoverPublishedGoogleDriveLibraryCoreControlV1,
+  GoogleDriveLibrarySelectionRequiredError,
   provisionGoogleDriveLibraryCoreControlV1,
   provisionGoogleDriveLibraryCoreIntentHeadV1,
   provisionGoogleDriveLibraryCoreNormalizedIntentHeadV2,
@@ -583,6 +584,32 @@ describe("Google Drive Library Core immutable adapter", () => {
         googleFetch: fake.fetch,
       }),
     ).rejects.toThrow("more than one published Library Core control");
+  });
+
+  it("offers distinct Libraries and isolates later discovery to the chosen identity", async () => {
+    const fake = new FakeGoogleDrive();
+    fake.addControl("control-1", publishedControlBytes());
+    const second = fake.addControl("control-2", publishedControlBytes("library-2"));
+    second.appProperties.freedLibraryDigest = libraryDigest("library-2");
+    const discovery = { accessToken: "test-token", googleFetch: fake.fetch };
+    await expect(discoverPublishedGoogleDriveLibraryCoreControlV1(discovery))
+      .rejects.toMatchObject({
+        name: GoogleDriveLibrarySelectionRequiredError.name,
+        libraryIds: ["library-1", "library-2"],
+      });
+    await expect(discoverPublishedGoogleDriveLibraryCoreControlV1({
+      ...discovery, libraryId: "library-2",
+    })).resolves.toMatchObject({ libraryId: "library-2", controlFileId: "control-2" });
+    const lastQuery = fake.requests.filter((request) => new URL(request.url).searchParams.has("q")).at(-1);
+    expect(lastQuery?.url).toContain("freedLibraryDigest");
+  });
+
+  it("rejects selected controls whose body changes Library identity", async () => {
+    const fake = new FakeGoogleDrive();
+    fake.addControl("control-1", publishedControlBytes("library-2"));
+    await expect(discoverPublishedGoogleDriveLibraryCoreControlV1({
+      accessToken: "test-token", googleFetch: fake.fetch, libraryId: "library-1",
+    })).rejects.toThrow("does not match the selected Library");
   });
 
   it("fails closed when a control body is malformed", async () => {

--- a/packages/sync/src/cloud/library-core-google-drive-adapter.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-adapter.ts
@@ -796,13 +796,25 @@ export async function discoverGoogleDriveLibraryCoreControlV1(input: {
   return Object.freeze({ controlFileId: file.id });
 }
 
+/** Distinct published Libraries require an explicit first-import choice. */
+export class GoogleDriveLibrarySelectionRequiredError extends Error {
+  readonly libraryIds: readonly string[];
+
+  constructor(libraryIds: readonly string[]) {
+    super("Choose which Library to sync from Google Drive");
+    this.name = "GoogleDriveLibrarySelectionRequiredError";
+    this.libraryIds = Object.freeze([...libraryIds].sort());
+  }
+}
+
 /**
- * Discover the sole published Library Core control available to a fresh PWA.
- * The control body supplies the library identity. App properties only narrow
- * discovery to the protocol and object kind, and never establish authority.
+ * Discover one published control, optionally narrowed to a selected Library.
+ * The control body supplies the Library identity. App properties only narrow
+ * discovery and never establish authority.
  */
 export async function discoverPublishedGoogleDriveLibraryCoreControlV1(input: {
   readonly accessToken: string;
+  readonly libraryId?: string;
   readonly googleFetch?: GoogleDriveFetch;
   readonly signal?: AbortSignal;
 }): Promise<PublishedGoogleDriveLibraryCoreControlV1 | null> {
@@ -812,9 +824,13 @@ export async function discoverPublishedGoogleDriveLibraryCoreControlV1(input: {
     MAX_ACCESS_TOKEN_BYTES,
   );
   const googleFetch = input.googleFetch ?? defaultGoogleDriveFetch();
+  if (input.libraryId !== undefined) assertLibraryId(input.libraryId);
   const expectedProperties = Object.freeze({
     freedProtocol: PROTOCOL_PROPERTY,
     freedObjectKind: "control",
+    ...(input.libraryId === undefined ? {} : {
+      freedLibraryDigest: await libraryIdentityDigest(input.libraryId),
+    }),
   });
   const files = await listDriveFilesByProperties({
     accessToken: input.accessToken,
@@ -823,7 +839,7 @@ export async function discoverPublishedGoogleDriveLibraryCoreControlV1(input: {
     signal: input.signal,
     maxFiles: MAX_CONTROL_DISCOVERY_CANDIDATES,
   });
-  let discovered: PublishedGoogleDriveLibraryCoreControlV1 | null = null;
+  const discovered = new Map<string, PublishedGoogleDriveLibraryCoreControlV1>();
   for (const file of files) {
     assertExpectedProperties(
       file.appProperties,
@@ -847,18 +863,24 @@ export async function discoverPublishedGoogleDriveLibraryCoreControlV1(input: {
       new TextDecoder("utf-8", { fatal: true }).decode(controlBytes),
     );
     const pointer = parseLibraryCoreControlPointerV1(decoded);
-    if (discovered !== null) {
+    if (input.libraryId !== undefined && pointer.libraryId !== input.libraryId) {
+      throw new Error("Published Drive control does not match the selected Library");
+    }
+    if (discovered.has(pointer.libraryId)) {
       throw new Error(
-        "Drive contains more than one published Library Core control",
+        "Drive contains more than one published Library Core control for the same Library",
       );
     }
-    discovered = Object.freeze({
+    discovered.set(pointer.libraryId, Object.freeze({
       controlFileId: file.id,
       control: Object.freeze({ bytes: controlBytes }),
       libraryId: pointer.libraryId,
-    });
+    }));
   }
-  return discovered;
+  if (discovered.size > 1) {
+    throw new GoogleDriveLibrarySelectionRequiredError([...discovered.keys()]);
+  }
+  return discovered.values().next().value ?? null;
 }
 
 /**

--- a/packages/ui/src/components/BottomSheet.tsx
+++ b/packages/ui/src/components/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import { useRef, useCallback, useEffect, type ReactNode } from "react";
 import { createPortal } from "react-dom";
+import { lockBodyScroll } from "../lib/body-scroll-lock.js";
 
 interface BottomSheetProps {
   open: boolean;
@@ -34,12 +35,7 @@ export function BottomSheet({
 
   // Lock body scroll while open
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
+    if (open) return lockBodyScroll();
   }, [open]);
 
   useEffect(() => {

--- a/packages/ui/src/components/NewsletterSignup.tsx
+++ b/packages/ui/src/components/NewsletterSignup.tsx
@@ -59,6 +59,8 @@ export interface NewsletterSignupProps {
   siteKey?: string;
   compact?: boolean;
   previewOnly?: boolean;
+  submitLabel?: string;
+  showPrivacyNote?: boolean;
   onSubscribed?: () => void;
 }
 
@@ -115,6 +117,8 @@ export function NewsletterSignup({
   siteKey = FREED_NEWSLETTER_TURNSTILE_SITE_KEY,
   compact = false,
   previewOnly = false,
+  submitLabel = "Join the newsletter",
+  showPrivacyNote = true,
   onSubscribed,
 }: NewsletterSignupProps = {}) {
   const [verificationStarted, setVerificationStarted] = useState(false);
@@ -410,7 +414,7 @@ export function NewsletterSignup({
           className="btn-primary inline-flex min-h-11 w-full items-center justify-center px-5 py-2.5 text-sm font-semibold disabled:cursor-not-allowed disabled:opacity-60"
           disabled={status === "submitting"}
         >
-          {status === "submitting" ? "Joining…" : "Join the newsletter"}
+          {status === "submitting" ? "Joining…" : submitLabel}
         </button>
 
         {message ? (
@@ -423,10 +427,10 @@ export function NewsletterSignup({
         ) : null}
       </form>
 
-      <p className={`text-[0.6875rem] leading-relaxed text-[var(--theme-text-soft)] ${compact ? "text-center" : ""}`}>
+      {showPrivacyNote && <p className={`text-[0.6875rem] leading-relaxed text-[var(--theme-text-soft)] ${compact ? "text-center" : ""}`}>
         Unsubscribe anytime. Your email goes to our newsletter provider and
         nowhere else.
-      </p>
+      </p>}
     </section>
   );
 }

--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -20,6 +20,7 @@ import {
 } from "@freed/shared";
 import { THEME_DEFINITIONS, type ThemeId } from "@freed/shared/themes";
 import { createPortal } from "react-dom";
+import { lockBodyScroll } from "../lib/body-scroll-lock.js";
 import {
   useAppStore,
   usePlatform,
@@ -1398,12 +1399,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
   // Body scroll lock
   useEffect(() => {
-    if (open) {
-      document.body.style.overflow = "hidden";
-    }
-    return () => {
-      document.body.style.overflow = "";
-    };
+    if (open) return lockBodyScroll();
   }, [open]);
 
   if (!open) return null;
@@ -2170,7 +2166,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         {/* ── Right column ────────────────────────────────────────────────── */}
         <div
           className={`
-            flex-1 flex flex-col overflow-hidden
+            min-h-0 flex-1 flex flex-col overflow-hidden
             ${mobileView === "nav" ? "hidden sm:flex" : "flex"}
           `}
         >
@@ -2223,7 +2219,7 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
           <div
             ref={scrollRef}
             data-testid="settings-scroll-container"
-            className="theme-settings-scrollport flex-1 overflow-y-auto px-4 pt-2 text-base sm:px-6 sm:pt-6 sm:text-sm sm:[&>section+section]:mt-24 [&>section+section]:mt-6"
+            className="theme-settings-scrollport min-h-0 flex-1 overflow-y-auto px-4 pt-2 text-base sm:px-6 sm:pt-6 sm:text-sm sm:[&>section+section]:mt-24 [&>section+section]:mt-6"
             style={{
               paddingBottom: scrollContainerBottomPadding,
             }}

--- a/packages/ui/src/components/feed/ReaderView.tsx
+++ b/packages/ui/src/components/feed/ReaderView.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import { lockBodyScroll } from "../../lib/body-scroll-lock.js";
 import { formatDistanceToNow } from "date-fns";
 import { AuthorIdentityLink } from "../AuthorIdentityLink.js";
 import { LoadingState } from "../LoadingState.js";
@@ -788,11 +789,7 @@ export function ReaderView({
 
   useEffect(() => {
     if (inline) return;
-    const previousOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = previousOverflow;
-    };
+    return lockBodyScroll();
   }, [inline]);
 
   return (

--- a/packages/ui/src/components/layout/AppShell.tsx
+++ b/packages/ui/src/components/layout/AppShell.tsx
@@ -559,7 +559,7 @@ export function AppShell({ children }: AppShellProps) {
           <main
             ref={mainRef}
             className={`relative min-w-0 flex-1 ${activeView === "friends" ? "z-0" : "z-10"} ${activeView === "map" ? "pointer-events-none" : ""} ${
-              isMobileViewport ? "" : activeView === "friends" ? "min-h-0 overflow-visible" : "min-h-0 overflow-hidden"
+              usesDocumentScroll ? "" : activeView === "friends" ? "min-h-0 overflow-visible" : "min-h-0 overflow-hidden"
             }`}
           >
             {activeView === "friends"

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -45,6 +45,7 @@ import { useLibraryFilterScopeSummary } from "../../hooks/useLibraryFilterScopeS
 import { useLibraryItemDetail } from "../../hooks/useLibraryItemDetail.js";
 import { useLibraryCommandPaletteReader } from "../../hooks/useLibraryCommandPaletteReader.js";
 import { useIsMobile } from "../../hooks/useIsMobile.js";
+import { useIsMobileDevice } from "../../hooks/useIsMobileDevice.js";
 import { useBackgroundActivityStore } from "../../lib/background-activity-store.js";
 import { useCommandSurfaceStore } from "../../lib/command-surface-store.js";
 import {
@@ -335,6 +336,7 @@ export function Header({
   } = usePlatform();
   const readOnly = interactionMode === "read-only";
   const isMobile = useIsMobile();
+  const isMobileDevice = useIsMobileDevice();
   const visibleDesktopSidebarMode = desktopSidebarDisplayMode ?? desktopSidebarMode;
   const desktopSidebarToggleLabel = visibleDesktopSidebarMode === "closed"
     ? "Show sidebar"
@@ -1146,7 +1148,7 @@ export function Header({
   const toolbarContainerStyle = {
     ...(headerDragRegion ? dragStyle : {}),
     // Keep narrow-screen controls clear of rounded device edges and safe areas.
-    ...(isMobile && !headerDragRegion ? {
+    ...((isMobile || isMobileDevice) && !headerDragRegion ? {
       paddingLeft: "max(6px, var(--safe-area-left, env(safe-area-inset-left, 0px)))",
       paddingRight: "max(6px, var(--safe-area-right, env(safe-area-inset-right, 0px)))",
     } : {}),

--- a/packages/ui/src/lib/body-scroll-lock.ts
+++ b/packages/ui/src/lib/body-scroll-lock.ts
@@ -1,0 +1,20 @@
+const locks = new WeakMap<HTMLElement, { count: number; overflow: string }>();
+
+/** Keep overlapping dialogs from restoring each other's temporary scroll lock. */
+export function lockBodyScroll(): () => void {
+  const body = document.body;
+  const lock = locks.get(body) ?? { count: 0, overflow: body.style.overflow };
+  lock.count += 1;
+  locks.set(body, lock);
+  body.style.overflow = "hidden";
+  let released = false;
+  return () => {
+    if (released) return;
+    released = true;
+    lock.count -= 1;
+    if (lock.count === 0) {
+      body.style.overflow = lock.overflow;
+      locks.delete(body);
+    }
+  };
+}


### PR DESCRIPTION
(AI Generated).

Promote the PWA repair for rejected sample-data clearing, device reset that retained OPFS handles, mobile scrolling locked by overlapping overlays, and Google Drive discovery with multiple published Libraries. Distinct Libraries receive an explicit selection; duplicate controls for one identity remain an integrity error rather than being chosen or deleted automatically.

This is a production PWA snapshot. It does not create a Desktop version, tag, or release card.

Source dev snapshot: 162e6be938573a3fd1ca2700ba6e1dc53cc816e1.
Base main: 2d1c8e49a213d9b856d3e437e3c65a203f3a0081.
Promotion head: d8d6aeb2b97d3faf7a590225713748ef0cae4fd2.

Validation: the repair passed local feature and full dev integration gates, and the exact promotion passed hosted Production validation. Both Chromium and WebKit passed the 100,000-item bounded-query probe. All nine WebKit durability cases passed locally. The first hosted storage attempt passed eight cases and failed before the recovery operation because startup was still at 70 percent; one targeted job rerun is pending. The permanent test setup correction is tracked in #1937.

After all required checks pass, deploy with the PWA snapshot helper and verify the authenticated PWA Library identity, checkpoint receipt, and follower round trip. Physical iPhone touch acceptance remains open.
