### PR TITLE
fix: wait for PWA sample startup in recovery checks

### DIFF
--- a/packages/pwa/tests/sqlite-opfs-durability.spec.ts
+++ b/packages/pwa/tests/sqlite-opfs-durability.spec.ts
@@ -600,6 +600,9 @@ test("iPhone WebKit recovers a rejected v26.9.803 sample result after restart", 
     const page = context.pages()[0] ?? await context.newPage();
     await openLibrary(page);
     await expect.poll(() => readFacetSummary(page), { timeout: 90_000 }).toMatchObject({ sampleItemCount: previewCounts.items });
+    // Item rows become durable before sample startup finishes publishing UI state.
+    await expect(page.getByRole("status").filter({ hasText: /^Loading ·/ }))
+      .toHaveCount(0, { timeout: 90_000 });
     const item = page.locator("[data-feed-item-id]").first();
     await expect(item).toBeVisible();
     const itemId = await item.getAttribute("data-feed-item-id");


### PR DESCRIPTION
(AI Generated).

The production WebKit recovery test sometimes selected a feed item while sample startup still displayed Loading at 70 percent. The item rows were already durable, but the feed UI was not ready, so the default five-second visibility assertion failed before exercising recovery.

Wait for the existing startup status to finish within the same bounded timeout used by the other sample-data test. The injected v26.9.803 rejection, restart, and successful sample-clear assertions are unchanged. No product behavior changes.

Validation: feature gate passed at fb55d9682, including the PWA build, type checks, unit suite, and all nine persistent WebKit storage cases. The hosted failure evidence is in production run 34321384527, job 102368583759, artifact 10092308283. Eight other hosted cases passed.