### PR TITLE
fix: resume PWA checkpoint stages across later retry attempts

### DIFF
--- a/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
@@ -5873,6 +5873,11 @@ describe("PWA Library Core SQLite engine", () => {
       }),
     ).toThrow(/replay changed its bytes/);
     expect(engine.beginNormalizedCheckpointStage(stage)).toEqual(complete);
+    expect(engine.beginNormalizedCheckpointStage({ ...stage, createdAt: 2_000 })).toEqual(complete);
+    expect(database.exec({
+      sql: "SELECT created_at FROM library_checkpoint_stages WHERE stage_id = ?1;",
+      bind: [stage.stageId], rowMode: 0, returnValue: "resultRows",
+    })).toEqual([1_000]);
     expect(() =>
       engine.beginNormalizedCheckpointStage({ ...stage, sourceRevision: 8 }),
     ).toThrow(/replay changed its identity/);

--- a/packages/pwa/src/lib/library-core-sqlite-engine.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.ts
@@ -1206,7 +1206,7 @@ export class PwaLibraryCoreSqliteEngine {
     });
     const matches = this.#database.exec({
       sql: `SELECT library_id = ?2 AND authority_epoch = ?3 AND source_revision = ?4
-                   AND expected_record_count = ?5 AND created_at = ?6
+                   AND expected_record_count = ?5
             FROM library_checkpoint_stages WHERE stage_id = ?1;`,
       bind: [
         stage.stageId,
@@ -1214,7 +1214,6 @@ export class PwaLibraryCoreSqliteEngine {
         stage.authorityEpoch,
         stage.sourceRevision,
         stage.expectedRecordCount,
-        stage.createdAt,
       ],
       rowMode: 0,
       returnValue: "resultRows",


### PR DESCRIPTION
(AI Generated).

A retried Drive checkpoint has the same manifest identity but a new local attempt timestamp. Comparing that timestamp with the retained staging row rejected otherwise identical retries after reload. Preserve the original staging timestamp and compare the Library, epoch, revision, and record count for stage identity. Canonical record replay checks remain unchanged.

Validation: all 33 focused SQLite engine tests and the complete feature gate passed, including all nine WebKit durability cases. The regression assertion verifies a later retry keeps the original staging time; changed revision and record bytes still fail. Authenticated production exposed this failure after interrupted-import recovery. This correction has not yet been deployed.