### PR TITLE
fix: preserve map tooltip themes and isolate dev releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -738,6 +738,7 @@ jobs:
   publish-website:
     name: Deploy Website
     needs: [publish, notes]
+    if: needs.notes.outputs.release_channel == 'production'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/packages/desktop/tests/e2e/smoke.spec.ts
+++ b/packages/desktop/tests/e2e/smoke.spec.ts
@@ -10,6 +10,7 @@
  */
 
 import type { Locator, Page } from "@playwright/test";
+import { createRequire } from "node:module";
 import {
   test,
   expect,
@@ -3284,6 +3285,32 @@ test("Map view popup exposes friend actions and supports post navigation", async
   const popup = page.locator("[data-map-floating-panel]");
   const marker = page.locator('.freed-map-marker[aria-label="Ada Lovelace"]:visible').first();
   const popupArrow = popup.locator("[data-map-popup-arrow]");
+  // MapLibre loads its stylesheet lazily in the online renderer. Exercise that
+  // cascade even when this smoke fixture uses the offline map fallback.
+  await page.addStyleTag({
+    path: createRequire(import.meta.url).resolve("maplibre-gl/dist/maplibre-gl.css"),
+  });
+  const originalTheme = await page.locator("html").getAttribute("data-theme");
+  for (const theme of ["ember", "midas", "scriptorium", "starship", "dark-star", "neon"]) {
+    await page.locator("html").evaluate((element, value) => { element.dataset.theme = value; }, theme);
+    const surface = await popup.evaluate((element) => {
+      const panel = element.querySelector(".theme-tooltip-panel")!;
+      const arrow = element.querySelector("[data-map-popup-arrow]")!;
+      return {
+        panel: getComputedStyle(panel).backgroundColor,
+        arrow: getComputedStyle(arrow).backgroundColor,
+      };
+    });
+    expect(surface.panel, `${theme} popup must retain its themed surface after MapLibre CSS loads`).toBe(surface.arrow);
+    expect(surface.panel).not.toBe("rgba(0, 0, 0, 0)");
+  }
+  await page.emulateMedia({ reducedMotion: "reduce" });
+  await expect(popup.locator(".theme-tooltip-panel")).toHaveCSS("animation-name", "none");
+  await page.emulateMedia({ reducedMotion: "no-preference" });
+  await page.locator("html").evaluate((element, value) => {
+    if (value === null) delete element.dataset.theme;
+    else element.dataset.theme = value;
+  }, originalTheme);
   const popupBox = await popup.boundingBox();
   const markerBox = await marker.boundingBox();
   const popupArrowBox = await popupArrow.boundingBox();

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1377,7 +1377,9 @@ html[data-theme="scriptorium"] .phase-card-complete {
   box-shadow: 0 8px 18px rgb(84 58 35 / 0.045);
 }
 
-.theme-tooltip-panel {
+/* Keep map cards themed when MapLibre's lazy stylesheet loads after this file. */
+.theme-tooltip-panel,
+.freed-map-popup .theme-tooltip-panel {
   position: fixed;
   z-index: 400;
   pointer-events: none;
@@ -1770,7 +1772,8 @@ html[data-theme="scriptorium"] .theme-tooltip-arrow {
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .theme-tooltip-panel {
+  .theme-tooltip-panel,
+  .freed-map-popup .theme-tooltip-panel {
     animation: none;
   }
 }

--- a/scripts/release-governance.test.mjs
+++ b/scripts/release-governance.test.mjs
@@ -447,6 +447,11 @@ test("dev releases publish a signed isolated Apple Silicon verifier without upda
 });
 
 test("production releases publish an exact-tag PWA showcase with reviewed media", () => {
+  const websiteJobHeader = releaseWorkflow.slice(
+    releaseWorkflow.indexOf("\n  publish-website:"),
+    releaseWorkflow.indexOf("\n  publish-pwa:"),
+  ).split("    steps:")[0];
+  assert.match(websiteJobHeader, /if: needs\.notes\.outputs\.release_channel == 'production'/);
   const showcaseJob = releaseWorkflow.slice(
     releaseWorkflow.indexOf("\n  showcase-assets:"),
     releaseWorkflow.indexOf("\n  # After all platform builds succeed"),


### PR DESCRIPTION
(AI Generated).

MapLibre loads its stylesheet after Freed's theme styles, turning dark map tooltips white while retaining pale text. Keep the shared tooltip surface and shadow themed, including reduced-motion behavior. The current production screenshot contains this product defect; the capture script does not override the card colors.

Restrict the release workflow's production website deployment job to production releases. Dev tags previously scheduled that job too, which could deploy the marketing site if Vercel credentials were available.

Validation: reproduced both failures before their fixes. The existing map interaction test now covers all six themes, reduced motion, and friend/post navigation. A fresh PWA map screenshot was visually inspected. Full feature validation covers typechecks, the PWA build, UI/PWA/Desktop tests, smoke workflows, and release tooling contracts. Native release compilation and app bundling succeeded; updater signing is reserved for the GitHub release workflow.