### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.test.ts
@@ -5873,6 +5873,11 @@ describe("PWA Library Core SQLite engine", () => {
       }),
     ).toThrow(/replay changed its bytes/);
     expect(engine.beginNormalizedCheckpointStage(stage)).toEqual(complete);
+    expect(engine.beginNormalizedCheckpointStage({ ...stage, createdAt: 2_000 })).toEqual(complete);
+    expect(database.exec({
+      sql: "SELECT created_at FROM library_checkpoint_stages WHERE stage_id = ?1;",
+      bind: [stage.stageId], rowMode: 0, returnValue: "resultRows",
+    })).toEqual([1_000]);
     expect(() =>
       engine.beginNormalizedCheckpointStage({ ...stage, sourceRevision: 8 }),
     ).toThrow(/replay changed its identity/);

--- a/packages/pwa/src/lib/library-core-sqlite-engine.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-engine.ts
@@ -1206,7 +1206,7 @@ export class PwaLibraryCoreSqliteEngine {
     });
     const matches = this.#database.exec({
       sql: `SELECT library_id = ?2 AND authority_epoch = ?3 AND source_revision = ?4
-                   AND expected_record_count = ?5 AND created_at = ?6
+                   AND expected_record_count = ?5
             FROM library_checkpoint_stages WHERE stage_id = ?1;`,
       bind: [
         stage.stageId,
@@ -1214,7 +1214,6 @@ export class PwaLibraryCoreSqliteEngine {
         stage.authorityEpoch,
         stage.sourceRevision,
         stage.expectedRecordCount,
-        stage.createdAt,
       ],
       rowMode: 0,
       returnValue: "resultRows",


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote one immutable dev product snapshot into `main` before a production release.
- Base main SHA: `f6a445f7b5ebba15388973faa888fdb46be9343e`
- Source dev SHA: `23286ed8c00eb618dea493df3dff5dafaace54de`

## Testing
- `node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-pwa-stage-retry --snapshot-ref=23286ed8c00eb618dea493df3dff5dafaace54de`
- CI