### PR TITLE
fix: tolerate skipped feed view transitions

### DIFF
--- a/packages/ui/src/lib/view-transitions.test.ts
+++ b/packages/ui/src/lib/view-transitions.test.ts
@@ -6,7 +6,7 @@ import { applyAnimationIntensityToDocument } from "./animation-preferences.js";
 import { runFeedLayoutTransition } from "./view-transitions.js";
 
 type ViewTransitionDocument = Document & {
-  startViewTransition?: (update: () => void) => { finished: Promise<void> };
+  startViewTransition?: (update: () => void) => { ready: Promise<void>; finished: Promise<void> };
 };
 
 afterEach(() => {
@@ -21,7 +21,7 @@ describe("runFeedLayoutTransition", () => {
     const update = vi.fn();
     const startViewTransition = vi.fn((callback: () => void) => {
       callback();
-      return { finished: Promise.resolve() };
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
     });
     (document as ViewTransitionDocument).startViewTransition = startViewTransition;
 
@@ -37,7 +37,7 @@ describe("runFeedLayoutTransition", () => {
     const update = vi.fn();
     const startViewTransition = vi.fn((callback: () => void) => {
       callback();
-      return { finished: Promise.resolve() };
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
     });
     (document as ViewTransitionDocument).startViewTransition = startViewTransition;
 
@@ -48,12 +48,32 @@ describe("runFeedLayoutTransition", () => {
     expect(document.documentElement.dataset.animation).toBe("light");
   });
 
+  it("preserves the update and clears transition styling when a resize skips the animation", async () => {
+    applyAnimationIntensityToDocument("detailed");
+    const update = vi.fn();
+    (document as ViewTransitionDocument).startViewTransition = (callback) => {
+      callback();
+      return {
+        ready: Promise.reject(new DOMException(
+          "Transition was aborted because of invalid state", "InvalidStateError",
+        )),
+        finished: Promise.resolve(),
+      };
+    };
+
+    runFeedLayoutTransition(update);
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(update).toHaveBeenCalledTimes(1);
+    expect(document.documentElement.classList.contains("feed-layout-transition")).toBe(false);
+  });
+
   it("bypasses view transitions when animation is none", () => {
     applyAnimationIntensityToDocument("none");
     const update = vi.fn();
     const startViewTransition = vi.fn((callback: () => void) => {
       callback();
-      return { finished: Promise.resolve() };
+      return { ready: Promise.resolve(), finished: Promise.resolve() };
     });
     (document as ViewTransitionDocument).startViewTransition = startViewTransition;
 

--- a/packages/ui/src/lib/view-transitions.ts
+++ b/packages/ui/src/lib/view-transitions.ts
@@ -1,6 +1,7 @@
 import { shouldEliminateMotion } from "./animation-preferences.js";
 
 type ViewTransitionLike = {
+  ready: Promise<void>;
   finished: Promise<void>;
 };
 
@@ -26,6 +27,11 @@ export function runFeedLayoutTransition(update: () => void): void {
     const transition = doc.startViewTransition(() => {
       update();
     });
+
+    // Resizing or replacing a transition can skip its animation while the DOM
+    // update succeeds. Consume that animation-only rejection; update failures
+    // still propagate through finished and the browser's updateCallbackDone.
+    void transition.ready.catch(() => {});
 
     void transition.finished.finally(() => {
       document.documentElement.classList.remove("feed-layout-transition");


### PR DESCRIPTION
(AI Generated).

Returning from a reader after resizing could replace the app with its fatal-error screen. The View Transition API rejects `ready` when the animation cannot start, even when the underlying DOM update succeeds. The feed transition helper now consumes that animation rejection while preserving update failures through `finished` and `updateCallbackDone`.

The existing helper suite covers a rejected `ready` promise, a single update, and styling cleanup. It fails against the previous implementation with the same unhandled InvalidStateError captured by dev integration. The existing Saved reader and viewport regression also passes locally.

Validation: `npm run validate:feature`; focused Saved browser regression. The change repairs the integration failure in run 34378411006 and unblocks the pending dev release. No provider-visible behavior changes.