### PR TITLE
fix: clear window controls in compact desktop headers

### DIFF
--- a/packages/ui/src/components/SettingsDialog.tsx
+++ b/packages/ui/src/components/SettingsDialog.tsx
@@ -71,6 +71,7 @@ import { StoryWallView } from "./story-wall/StoryWallView.js";
 import { SettingsToggle } from "./SettingsToggle.js";
 import { ReportComposer } from "./report/ReportComposer.js";
 import { SearchField } from "./SearchField.js";
+import { COMPACT_MACOS_TRAFFIC_LIGHT_INSET_PX } from "./layout/layoutConstants.js";
 import { ThemePreviewButton } from "./ThemePreviewButton.js";
 import {
   FeedCardDensitySlider,
@@ -2114,7 +2115,10 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
 
           <div
             className="flex shrink-0 items-center justify-between px-4 pb-1.5 pt-2 sm:hidden"
-            style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+            style={{
+              paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)",
+              paddingLeft: headerDragRegion ? COMPACT_MACOS_TRAFFIC_LIGHT_INSET_PX : undefined,
+            }}
           >
             <h2 className="text-base font-semibold text-text-primary">Freed Settings</h2>
             <CloseButton
@@ -2172,12 +2176,16 @@ export function SettingsDialog({ open, onClose }: SettingsDialogProps) {
         >
           <div
             className="theme-dialog-divider sm:hidden flex shrink-0 items-center justify-between gap-3 border-b px-4 pb-2 pt-2"
-            style={{ paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)" }}
+            style={{
+              paddingTop: "calc(env(safe-area-inset-top, 0px) + 0.5rem)",
+              paddingLeft: headerDragRegion ? COMPACT_MACOS_TRAFFIC_LIGHT_INSET_PX : undefined,
+            }}
           >
             <button
               onClick={() => setMobileView("nav")}
               className="-ml-1 flex min-w-0 items-center gap-1.5 rounded-lg px-1.5 py-1.5 text-text-secondary transition-colors hover:bg-[color:color-mix(in_srgb,var(--theme-bg-surface)_72%,transparent)] hover:text-text-primary"
               aria-label="Back to settings"
+              style={{ marginLeft: headerDragRegion ? 0 : undefined }}
             >
               <svg className="w-4 h-4 shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 19l-7-7 7-7" />

--- a/packages/ui/src/components/layout/Header.tsx
+++ b/packages/ui/src/components/layout/Header.tsx
@@ -76,6 +76,7 @@ import {
   noDragRegionStyle as noDrag,
 } from "../../lib/native-drag-region.js";
 import {
+  COMPACT_MACOS_TRAFFIC_LIGHT_INSET_PX,
   PRIMARY_SIDEBAR_GAP_WIDTH_PX,
   TOP_TOOLBAR_HEIGHT_PX,
   TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX,
@@ -1100,7 +1101,7 @@ export function Header({
     handleIdentityModeChange,
   ]);
   const macosTrafficLightInsetStyle = headerDragRegion
-    ? ({ paddingLeft: `${MACOS_TRAFFIC_LIGHT_INSET}px` } as CSSProperties)
+    ? ({ paddingLeft: `${COMPACT_MACOS_TRAFFIC_LIGHT_INSET_PX}px` } as CSSProperties)
     : undefined;
   const sidebarHandleCenterline = "var(--freed-sidebar-handle-centerline, 264px)";
   const toolbarBoundaryWidth = `calc(${sidebarHandleCenterline} + ${px(toolbarGapHalfPx)})`;
@@ -1484,7 +1485,7 @@ export function Header({
           style={toolbarContainerStyle}
         >
           <div
-            className={`theme-toolbar-cluster theme-toolbar-cluster-tight flex h-full shrink-0 items-center ${isMobile ? "pl-2" : ""}`}
+            className={`theme-toolbar-cluster theme-toolbar-cluster-tight flex h-full shrink-0 items-center ${isMobile && !headerDragRegion ? "pl-2" : ""}`}
           >
             <div
               ref={layoutControlHostRef}

--- a/packages/ui/src/components/layout/layoutConstants.ts
+++ b/packages/ui/src/components/layout/layoutConstants.ts
@@ -8,6 +8,8 @@ export const AUXILIARY_DRAWER_GAP_WIDTH_PX = 12;
 export const FRIENDS_SIDEBAR_GAP_WIDTH_PX = 12;
 export const TOOLBAR_SIDEBAR_SLOT_PADDING_RIGHT_PX = 8;
 export const TOOLBAR_ICON_BUTTON_SIZE_PX = 40;
+// Native stoplights end at 80 px. Compact headers need only a small gutter.
+export const COMPACT_MACOS_TRAFFIC_LIGHT_INSET_PX = 84;
 export const TOOLBAR_BOUNDARY_BUTTON_GAP_PX = 8;
 export const CANVAS_CONTROL_BUTTON_CLASS =
   "btn-secondary inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg !p-0 text-xs shadow-sm theme-canvas-control";


### PR DESCRIPTION
(AI Generated).

Compact Freed Desktop settings headers now clear the native window controls, including the section back button at enlarged interface text sizes. The compact toolbar hamburger moves 24 pixels left by sharing an 84-pixel inset and dropping redundant mobile padding. Wide desktop spacing and browser safe areas are preserved.

Validation: Desktop frontend production build, three existing headless layout/settings smoke tests, and browser geometry checks for compact native headers, 150 percent interface zoom, browser spacing, and the wide toolbar. The required local feature validation also passed.

Provider behavior is unchanged. The settings diff only adjusts header spacing.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `bca86086c31ea61cb198c2dbd3866dfbb27ea03a`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `compact-window-spacing`
- Provider review decision: `diff_authorized`
- Provider review artifact: `4ea2567c33d263395db1f90ae5cd4b882511fee19eb22a2b0a85eb77b7622771`
- Providers: facebook, instagram, linkedin, medium, other, substack, x, youtube
- Observable behavior: Unchanged. Only local settings header padding and back-button margin change.
- Fingerprinting risk: No additional risk. Provider requests, navigation, timing, cookies, headers, and extraction remain unchanged.
- Lowest profile alternative: Local mocked layout validation without provider contact.

Files bound into this provider review:
- `packages/ui/src/components/SettingsDialog.tsx`