### PR TITLE
fix: report pending PWA device enrollment accurately

### DIFF
--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -1310,7 +1310,9 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
   readonly accessToken: string;
   readonly libraryId?: string;
   readonly signal?: AbortSignal;
-}): Promise<LibraryCoreRuntimeStateV1> {
+}): Promise<LibraryCoreRuntimeStateV1 & {
+  readonly followerEnrollmentState: Awaited<ReturnType<typeof syncPwaLibraryCoreFollowerV2>>["enrollmentState"];
+}> {
   const selected = await readPwaNormalizedCheckpointReceipt();
   const retainedLibraryId = selected.receipt &&
     !selected.receipt.controlRevision.startsWith("preview:")
@@ -1354,7 +1356,7 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
       writerActorId: pointer.writerId,
     }),
   });
-  await syncPwaLibraryCoreFollowerV2(
+  const followerReceipt = await syncPwaLibraryCoreFollowerV2(
     createGoogleDriveLibraryCoreNormalizedFollowerTransportV2({
       accessToken: input.accessToken,
       controlFileId: discovered.controlFileId,
@@ -1363,7 +1365,10 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
     }),
     { signal: input.signal },
   );
-  return publishSelectedStateAfterLibraryCoreSync();
+  return Object.freeze({
+    ...await publishSelectedStateAfterLibraryCoreSync(),
+    followerEnrollmentState: followerReceipt.enrollmentState,
+  });
 }
 
 registerPwaFactoryResetQuiesceHandler(

--- a/packages/pwa/src/lib/sync.test.ts
+++ b/packages/pwa/src/lib/sync.test.ts
@@ -60,6 +60,7 @@ describe("PWA Library Core sync lifecycle", () => {
   beforeEach(() => {
     vi.useFakeTimers();
     vi.clearAllMocks();
+    mocks.syncLibraryCore.mockResolvedValue({ followerEnrollmentState: "enrolled" });
     localStorage.clear();
     resetFactoryResetStateForTests();
     stopCloudSync();
@@ -70,6 +71,18 @@ describe("PWA Library Core sync lifecycle", () => {
     resetFactoryResetStateForTests();
     vi.unstubAllGlobals();
     vi.useRealTimers();
+  });
+
+  it("reports pending enrollment until the Primary admits this device", async () => {
+    mocks.syncLibraryCore.mockResolvedValueOnce({ followerEnrollmentState: "pending" });
+    await startCloudSync("gdrive", "stored-token");
+    expect(mocks.updateCloudProvider).toHaveBeenLastCalledWith("gdrive", expect.objectContaining({
+      status: "connected",
+      statusMessage: "Library downloaded. Device enrollment pending.",
+    }));
+    expect(mocks.recordCloudProviderEvent).toHaveBeenLastCalledWith("gdrive", expect.objectContaining({ kind: "waiting" }));
+    await syncCloudProviderNow("gdrive");
+    expect(mocks.recordCloudProviderEvent).toHaveBeenLastCalledWith("gdrive", expect.objectContaining({ kind: "success" }));
   });
 
   it.each(["success", "failure"] as const)(

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -201,9 +201,9 @@ function isGoogleAuthenticationFailure(error: unknown): boolean {
 async function syncGoogleDriveWithFreshCredentials(
   accessToken: string,
   signal: AbortSignal,
-): Promise<void> {
+): Promise<Awaited<ReturnType<typeof syncPwaLibraryCoreFromGoogleDrive>>> {
   try {
-    await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal,
+    return await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal,
       libraryId: localStorage.getItem(CLOUD_LIBRARY_KEY) ?? undefined });
   } catch (error) {
     if (!isGoogleAuthenticationFailure(error)) throw error;
@@ -221,7 +221,7 @@ async function syncGoogleDriveWithFreshCredentials(
         "Google Drive authorization expired. Reconnect Google Drive to continue sync.",
       );
     }
-    await syncPwaLibraryCoreFromGoogleDrive({
+    return await syncPwaLibraryCoreFromGoogleDrive({
       accessToken: refreshedAccessToken,
       libraryId: localStorage.getItem(CLOUD_LIBRARY_KEY) ?? undefined,
       signal,
@@ -260,8 +260,9 @@ async function performGoogleDriveSync(
     statusMessage: "Refreshing the SQLite Library checkpoint.",
     error: undefined,
   });
+  let syncResult: Awaited<ReturnType<typeof syncGoogleDriveWithFreshCredentials>>;
   try {
-    await syncGoogleDriveWithFreshCredentials(accessToken, signal);
+    syncResult = await syncGoogleDriveWithFreshCredentials(accessToken, signal);
   } catch (error) {
     if (generation !== cloudGeneration || signal.aborted) throw error;
     if (error instanceof GoogleDriveLibrarySelectionRequiredError) {
@@ -290,6 +291,7 @@ async function performGoogleDriveSync(
   }
   if (generation !== cloudGeneration || signal.aborted) return;
   const now = Date.now();
+  const enrollmentPending = syncResult.followerEnrollmentState !== "enrolled";
   setCloudLibraryChoices(emptyLibraryChoices);
   updateCloudProvider("gdrive", {
     status: "connected",
@@ -298,14 +300,20 @@ async function performGoogleDriveSync(
     lastSyncAt: now,
     lastDownloadAt: now,
     lastMergeAt: now,
-    statusMessage: "SQLite Library synchronized.",
-    pendingReason: "Waiting for the next checkpoint, intent, or result change.",
+    statusMessage: enrollmentPending
+      ? "Library downloaded. Device enrollment pending."
+      : "SQLite Library synchronized.",
+    pendingReason: enrollmentPending
+      ? "Open the Primary Freed Desktop and resolve any Drive sync error so this device can sync edits."
+      : "Waiting for the next checkpoint, intent, or result change.",
     error: undefined,
   });
   recordCloudProviderEvent("gdrive", {
-    kind: "success",
+    kind: enrollmentPending ? "waiting" : "success",
     stage: "idle",
-    message: "Synchronized the SQLite Library and follower state.",
+    message: enrollmentPending
+      ? "Library downloaded; waiting for device enrollment before syncing edits."
+      : "Synchronized the SQLite Library and follower state.",
   });
 }
 


### PR DESCRIPTION
(AI Generated).

A PWA waiting for device enrollment reported that its Library and follower state had synchronized. Preserve the existing follower receipt through the runtime wrapper and report a waiting state until enrollment succeeds. The downloaded Library remains connected and readable, with a clear instruction to resolve Primary Drive sync before edits can synchronize.

Validation: full feature validation passed. The lifecycle regression verifies pending enrollment produces a waiting event and the next enrolled pass produces success. No transport, refresh cadence, storage or authority changes.

Keep this correction separate from the current enrollment release until its selected source integration finishes. Authenticated release verification remains pending.

## Provider Review
- Status: Draft publication was requested. Provider authority is validated, but no ready transition was requested.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `f17b9079cfe83a43d9ca0ddba5d311824d6b0a07`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-enrollment-status-20260909`
- Provider review decision: `diff_authorized`
- Provider review artifact: `e380474ecd7e95c51aecc8f159677cb8351d2ada08377f9c71273d61f1be6cb6`
- Providers: other
- Observable behavior: Propagate the existing follower enrollment receipt to status text and waiting/success events. No transport, cadence, storage, identity or authority change.
- Fingerprinting risk: No provider-observable behavior change.
- Lowest profile alternative: Local component fixture with distinct RSS and Drive timestamps.

Files bound into this provider review:
- `packages/pwa/src/lib/sync.ts`