### PR TITLE
chore: stage v26.9.901 release notes

### DIFF
--- a/release-notes/daily/production/26.9.9.json
+++ b/release-notes/daily/production/26.9.9.json
@@ -10,5 +10,5 @@
   ],
   "pinnedHighlights": [],
   "editorialNotes": [],
-  "updatedAt": "2026-09-09T16:42:02.333Z"
+  "updatedAt": "2026-09-09T19:33:51.856Z"
 }

--- a/release-notes/releases/v26.9.901.json
+++ b/release-notes/releases/v26.9.901.json
@@ -1,0 +1,82 @@
+{
+  "tag": "v26.9.901",
+  "version": "26.9.901",
+  "channel": "production",
+  "dayKey": "26.9.9",
+  "approved": true,
+  "editorialNotes": [],
+  "generatedAt": "2026-09-09T19:33:51.855Z",
+  "model": "heuristic",
+  "source": {
+    "channel": "production",
+    "previousPublishedTag": "v26.9.900",
+    "previousPublishedDayTag": "v26.9.803",
+    "compareRef": "HEAD",
+    "productCommitSha": "1eee19543a53c3069c19e56a5f1724f6b9844767",
+    "promotedDevCommitSha": "f885b24bf92e22ecc110d7fe0bfdec355ad63781",
+    "libraryCoreActivation": {
+      "schemaVersion": 1,
+      "range": {
+        "channel": "production",
+        "previousPublishedTag": "v26.9.900",
+        "startMode": "previous_product_commit",
+        "fromExclusiveCommitSha": "9c9fa771778abba36a7c46c289caf0f3998ca31c",
+        "toInclusiveProductCommitSha": "1eee19543a53c3069c19e56a5f1724f6b9844767"
+      },
+      "manifest": {
+        "path": "docs/library-core-activation-manifest.json",
+        "previousPresent": true,
+        "previousDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb",
+        "currentDigest": "sha256:709197038cc687ff0889d7e28497c08704b0a1f7096f4348479ea36bf5896ccb"
+      },
+      "transitions": [],
+      "inspectionDigest": "sha256:57c6db801da144ed6d9442399b82be167e5e978419486e340890a1b27716b04d",
+      "decision": {
+        "state": "no_activation_declared",
+        "ownerApprovalReference": null,
+        "approvedInspectionDigest": null,
+        "approvedReleaseArtifactDigest": null
+      }
+    },
+    "isLatestOfDay": true,
+    "sameDayTagsIncluded": [
+      "v26.9.900",
+      "v26.9.901"
+    ],
+    "relatedBuildTags": [
+      "v26.9.900",
+      "v26.9.901"
+    ],
+    "prNumbers": [
+      1941,
+      1947,
+      1961
+    ],
+    "commitSubjects": [
+      "chore: promote dev into main for production release (#1961)",
+      "chore: prepare v26.9.900",
+      "chore: promote dev into main for production release (#1947)",
+      "chore: promote dev into main for production release",
+      "chore: promote dev into main for production release (#1941)",
+      "chore: promote dev into main for production release"
+    ]
+  },
+  "release": {
+    "deck": "More reliable Google Drive enrollment and PWA recovery, with clearer sync status and mobile navigation fixes.",
+    "features": [],
+    "fixes": [
+      "Allow valid device enrollment requests to complete after the Primary Library has advanced, while continuing to reject unknown history and invalid signatures",
+      "Combine overlapping PWA Drive sync requests into one operation",
+      "Show the time of the last successful Drive sync in Settings",
+      "Keep provider Advanced settings available, label Focus mode clearly, and make background activity status less distracting",
+      "Improve mobile welcome and Settings scrolling, stabilize menu panes, and correct Scriptorium icon contrast",
+      "Preserve the previous accepted PWA database after interrupted checkpoint imports and distinguish progressing large imports from stalled workers",
+      "Close participating PWA storage workers before device reset, recover rejected local sample startup results, and offer an explicit choice when Drive contains multiple Libraries",
+      "Report bounded SQLite integrity and worker-timeout diagnostics while retaining failed databases for investigation",
+      "Resume identical PWA checkpoint stages across later retry attempts while retaining the original staging timestamp",
+      "Keep compact headers and view transitions consistent when navigating between pages"
+    ],
+    "followUps": []
+  },
+  "releaseBody": "(AI Generated).\n\n## Freed v26.9.901\n\nMore reliable Google Drive enrollment and PWA recovery, with clearer sync status and mobile navigation fixes\n\n### Fixes\n\n- Allow valid device enrollment requests to complete after the Primary Library has advanced, while continuing to reject unknown history and invalid signatures\n- Combine overlapping PWA Drive sync requests into one operation\n- Show the time of the last successful Drive sync in Settings\n- Keep provider Advanced settings available, label Focus mode clearly, and make background activity status less distracting\n- Improve mobile welcome and Settings scrolling, stabilize menu panes, and correct Scriptorium icon contrast\n- Preserve the previous accepted PWA database after interrupted checkpoint imports and distinguish progressing large imports from stalled workers\n- Close participating PWA storage workers before device reset, recover rejected local sample startup results, and offer an explicit choice when Drive contains multiple Libraries\n- Report bounded SQLite integrity and worker-timeout diagnostics while retaining failed databases for investigation\n- Resume identical PWA checkpoint stages across later retry attempts while retaining the original staging timestamp\n- Keep compact headers and view transitions consistent when navigating between pages\n\n### Downloads\n\n**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  \n**Windows:** `.exe` (NSIS installer)  \n**Linux:** `.AppImage`  \n\n> macOS downloads are signed and notarized for normal Gatekeeper installation.\n"
+}

--- a/release-notes/releases/v26.9.901.md
+++ b/release-notes/releases/v26.9.901.md
@@ -1,0 +1,26 @@
+(AI Generated).
+
+## Freed v26.9.901
+
+More reliable Google Drive enrollment and PWA recovery, with clearer sync status and mobile navigation fixes
+
+### Fixes
+
+- Allow valid device enrollment requests to complete after the Primary Library has advanced, while continuing to reject unknown history and invalid signatures
+- Combine overlapping PWA Drive sync requests into one operation
+- Show the time of the last successful Drive sync in Settings
+- Keep provider Advanced settings available, label Focus mode clearly, and make background activity status less distracting
+- Improve mobile welcome and Settings scrolling, stabilize menu panes, and correct Scriptorium icon contrast
+- Preserve the previous accepted PWA database after interrupted checkpoint imports and distinguish progressing large imports from stalled workers
+- Close participating PWA storage workers before device reset, recover rejected local sample startup results, and offer an explicit choice when Drive contains multiple Libraries
+- Report bounded SQLite integrity and worker-timeout diagnostics while retaining failed databases for investigation
+- Resume identical PWA checkpoint stages across later retry attempts while retaining the original staging timestamp
+- Keep compact headers and view transitions consistent when navigating between pages
+
+### Downloads
+
+**macOS:** `.dmg` (Apple Silicon or Intel, signed + notarized)  
+**Windows:** `.exe` (NSIS installer)  
+**Linux:** `.AppImage`  
+
+> macOS downloads are signed and notarized for normal Gatekeeper installation.


### PR DESCRIPTION
(AI Generated).

Stage the approved v26.9.901 release-note artifacts required by the production release workflow before its website deployment job. Source: release preparation PR #1963 at d806ed974b658de5422ef74aecd5d97cf0f6322e, product source 1eee19543a53c3069c19e56a5f1724f6b9844767, immutable promoted dev snapshot f885b24bf92e22ecc110d7fe0bfdec355ad63781.

The changelog generator continues to select only published GitHub releases. This prerequisite does not announce an unpublished release or change the current showcase mapping. Published release identity, the new theme asset mapping, and live byte verification will follow actual release publication.

Validation: website production build. This change transfers only the reviewed release artifacts into www, without merging product branches. Level 7 task authority includes the production website prerequisite.
