### PR TITLE
fix: identify stalled Drive sync stages

### DIFF
--- a/packages/desktop/src/lib/library-core-cloud-sync.test.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.test.ts
@@ -1413,6 +1413,17 @@ describe("SQLite Library Google Drive production wiring", () => {
     ).rejects.toThrow(
       "read local SQLite revision failed: SQLite Library could not read its authority key",
     );
+
+    for (const [operation, stage] of [
+      [mocks.setWriterAdmission, "persist verified writer admission"],
+      [mocks.discoverEnrollmentRequests, "discover follower enrollment requests"],
+      [mocks.beginNormalizedExport, "prepare checkpoint snapshot"],
+    ] as const) {
+      operation.mockRejectedValueOnce("diagnostic boundary failure");
+      await expect(
+        publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
+      ).rejects.toThrow(`${stage} failed: diagnostic boundary failure`);
+    }
   });
 
   it("coalesces overlapping publication requests before opening the singleton native export", async () => {

--- a/packages/desktop/src/lib/library-core-cloud-sync.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.ts
@@ -66,7 +66,7 @@ import {
   readNormalizedLibraryFollowerTransportContext,
   reassignNormalizedLibraryWriterEpoch,
   recordNormalizedLibraryFollowerIntentTransportPublication,
-  setSqliteLibraryCloudWriterAdmission,
+  setSqliteLibraryCloudWriterAdmission as setNativeWriterAdmission,
   type NormalizedLibraryCloudIdentity,
   type SqliteLibraryPersistedCloudIdentity,
 } from "./sqlite-library";
@@ -373,6 +373,13 @@ function controlPointersEqual(
   return leftBytes.every((byte, index) => byte === rightBytes[index]);
 }
 
+function setSqliteLibraryCloudWriterAdmission(
+  input: Parameters<typeof setNativeWriterAdmission>[0],
+): ReturnType<typeof setNativeWriterAdmission> {
+  return tracedPublicationStage("persist verified writer admission", () =>
+    setNativeWriterAdmission(input));
+}
+
 async function persistVerifiedWriterAdmission(input: {
   readonly localWriterId: string;
   readonly pointer: LibraryCoreControlPointerV1;
@@ -585,20 +592,23 @@ async function acceptPendingNormalizedFollowerEnrollments(input: {
   readonly signal?: AbortSignal;
 }): Promise<readonly string[]> {
   const requests =
-    await discoverGoogleDriveLibraryCoreActorEnrollmentRequestsV1(input);
+    await tracedPublicationStage("discover follower enrollment requests", () =>
+      discoverGoogleDriveLibraryCoreActorEnrollmentRequestsV1(input));
   for (const request of requests) {
     const canonical = new TextDecoder("utf-8", { fatal: true }).decode(
       request.bytes,
     );
     const enrollment =
-      await countersignNormalizedLibraryFollowerActorRequest(canonical);
-    await publishNormalizedActorEnrollment({
+      await tracedPublicationStage("countersign follower enrollment", () =>
+        countersignNormalizedLibraryFollowerActorRequest(canonical));
+    await tracedPublicationStage("publish follower enrollment", () => publishNormalizedActorEnrollment({
       adapter: input.adapter,
       enrollment,
-    });
+    }));
   }
   const certificates =
-    await discoverGoogleDriveLibraryCoreActorEnrollmentsV1(input);
+    await tracedPublicationStage("discover accepted follower enrollments", () =>
+      discoverGoogleDriveLibraryCoreActorEnrollmentsV1(input));
   const actorIds = new Set<string>();
   for (const certificate of certificates) {
     const identity = normalizedEnrollmentIdentity(certificate.bytes);
@@ -1145,7 +1155,7 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
     libraryId: state.libraryId,
     signal: input.signal,
   });
-  await ingestPendingNormalizedFollowerIntents({
+  await tracedPublicationStage("ingest follower intents", () => ingestPendingNormalizedFollowerIntents({
     accessToken: input.accessToken,
     actorIds,
     controlFileId: provisioned.controlFileId,
@@ -1153,8 +1163,8 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
     googleFetch: input.googleFetch,
     libraryId: state.libraryId,
     signal: input.signal,
-  });
-  await flushNormalizedFollowerResults({
+  }));
+  await tracedPublicationStage("publish follower results", () => flushNormalizedFollowerResults({
     accessToken: input.accessToken,
     actorIds,
     controlFileId: provisioned.controlFileId,
@@ -1162,11 +1172,12 @@ async function publishCurrentSqliteLibraryToGoogleDriveInternal(input: {
     googleFetch: input.googleFetch,
     libraryId: state.libraryId,
     signal: input.signal,
-  });
+  }));
   throwIfPublicationCanceled(input.signal);
   return withCheckpointExport(async () => {
     const normalizedCheckpoint =
-      await beginNormalizedLibraryCheckpointExport();
+      await tracedPublicationStage("prepare checkpoint snapshot", () =>
+        beginNormalizedLibraryCheckpointExport());
     throwIfPublicationCanceled(input.signal);
     if (
       normalizedCheckpoint.libraryId !== state.libraryId ||


### PR DESCRIPTION
(AI Generated).

On installed production 26.9.901, Primary sync logs stop distinguishing progress after reading the Drive control. Device enrollment remains pending, and the current output cannot identify whether admission, enrollment discovery, signing, result publication, or snapshot preparation is taking the time.

Reuse the existing stage timing and error wrapper at those boundaries, including every native writer-admission call. Labels are constant, enrollment work is bounded by the existing discovery limit, and no per-record logs are added. Google Drive calls, retries, credentials, operation ordering and durable authority are unchanged. This is an instrumentation change; it does not claim the pending sync is fixed.

Validation: all 26 focused production-wiring tests passed, including native string failures at admission, enrollment discovery and checkpoint preparation. Full feature validation passed, including Desktop unit tests and all 9 browser smoke tests. Existing AbortError preservation and publication ownership tests continue to pass.

Post-install acceptance requires an attributable stage result during the retained enrollment scenario, then the existing task continues to enrollment and a signed bidirectional edit. No Library reset or signed-request deletion is part of this change.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `c65de202b997d62708622c098867aed28e97cb7b`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `drive-stage-diagnostics-20260909`
- Provider review decision: `diff_authorized`
- Provider review artifact: `766205a94443ec69762a8211864464fd3dfafcfabda10b70a2724c01be12a1c4`
- Providers: other
- Observable behavior: Bounded local stage timing and error attribution only; no change to provider calls, retry cadence, credentials, protocol or durable authority.
- Fingerprinting risk: No provider-observable behavior change.
- Lowest profile alternative: Keep current passive logs, which do not distinguish the stage after control discovery.

Files bound into this provider review:
- `packages/desktop/src/lib/library-core-cloud-sync.ts`