### PR TITLE
fix: anchor PWA preview build paths to repository root

### DIFF
--- a/scripts/pwa-vercel-ignore-build.mjs
+++ b/scripts/pwa-vercel-ignore-build.mjs
@@ -9,6 +9,7 @@ export const PWA_BUILD_PATHS = Object.freeze([
   "packages/shared",
   "packages/sync",
   "packages/ui",
+  "scripts/pwa-vercel-ignore-build.mjs",
   ".nvmrc",
   "package.json",
   "package-lock.json",
@@ -55,7 +56,8 @@ export function planPwaVercelBuild({
     return Object.freeze({ ignore: false, reason: "deployment baseline is not an ancestor" });
   }
   const diff = git(
-    ["diff", "--quiet", previous, current, "--", ...PWA_BUILD_PATHS],
+    ["diff", "--quiet", previous, current, "--",
+      ...PWA_BUILD_PATHS.map((buildPath) => `:(top)${buildPath}`)],
     cwd,
   );
   if (diff.status === 0) {

--- a/scripts/pwa-vercel-ignore-build.test.mjs
+++ b/scripts/pwa-vercel-ignore-build.test.mjs
@@ -26,53 +26,67 @@ function commit(cwd, message) {
   return git(cwd, "rev-parse", "HEAD");
 }
 
-test("PWA Vercel filtering compares the last successful deployment", (t) => {
-  const cwd = mkdtempSync(path.join(os.tmpdir(), "freed-pwa-ignore-"));
-  t.after(() => rmSync(cwd, { recursive: true, force: true }));
-  git(cwd, "init", "-q");
-  mkdirSync(path.join(cwd, "packages", "pwa"), { recursive: true });
-  mkdirSync(path.join(cwd, "docs"), { recursive: true });
-  writeFileSync(path.join(cwd, "packages", "pwa", "app.ts"), "first\n");
-  const deployed = commit(cwd, "initial PWA");
+for (const invocationDirectory of [".", "packages/pwa"]) {
+  test(`PWA Vercel filtering compares the last successful deployment from ${invocationDirectory}`, (t) => {
+    const cwd = mkdtempSync(path.join(os.tmpdir(), "freed-pwa-ignore-"));
+    t.after(() => rmSync(cwd, { recursive: true, force: true }));
+    git(cwd, "init", "-q");
+    mkdirSync(path.join(cwd, "packages", "pwa"), { recursive: true });
+    mkdirSync(path.join(cwd, "docs"), { recursive: true });
+    writeFileSync(path.join(cwd, "packages", "pwa", "app.ts"), "first\n");
+    const deployed = commit(cwd, "initial PWA");
+    const planFromInvocationDirectory = (options) => planPwaVercelBuild({
+      ...options,
+      cwd: path.join(cwd, invocationDirectory),
+    });
 
-  writeFileSync(path.join(cwd, "docs", "notes.md"), "docs only\n");
-  const docsOnly = commit(cwd, "docs only");
-  assert.deepEqual(
-    planPwaVercelBuild({ cwd, previousSha: deployed, currentSha: docsOnly }),
-    { ignore: true, reason: "no PWA-relevant changes" },
-  );
+    writeFileSync(path.join(cwd, "docs", "notes.md"), "docs only\n");
+    const docsOnly = commit(cwd, "docs only");
+    assert.deepEqual(
+      planFromInvocationDirectory({ previousSha: deployed, currentSha: docsOnly }),
+      { ignore: true, reason: "no PWA-relevant changes" },
+    );
 
-  writeFileSync(path.join(cwd, "packages", "pwa", "app.ts"), "functional\n");
-  commit(cwd, "functional change");
-  writeFileSync(path.join(cwd, "docs", "notes.md"), "trailing docs\n");
-  const functionalThenDocs = commit(cwd, "trailing docs");
-  assert.deepEqual(
-    planPwaVercelBuild({
-      cwd,
-      previousSha: docsOnly,
-      currentSha: functionalThenDocs,
-    }),
-    { ignore: false, reason: "PWA-relevant changes detected" },
-  );
+    writeFileSync(path.join(cwd, "packages", "pwa", "app.ts"), "functional\n");
+    commit(cwd, "functional change");
+    writeFileSync(path.join(cwd, "docs", "notes.md"), "trailing docs\n");
+    const functionalThenDocs = commit(cwd, "trailing docs");
+    assert.deepEqual(
+      planFromInvocationDirectory({
+        cwd,
+        previousSha: docsOnly,
+        currentSha: functionalThenDocs,
+      }),
+      { ignore: false, reason: "PWA-relevant changes detected" },
+    );
 
-  assert.equal(
-    planPwaVercelBuild({ cwd, previousSha: "", currentSha: docsOnly }).ignore,
-    false,
-  );
-  assert.equal(
-    planPwaVercelBuild({
-      cwd,
-      previousSha: "f".repeat(40),
-      currentSha: docsOnly,
-    }).ignore,
-    false,
-  );
+    assert.equal(
+      planFromInvocationDirectory({ previousSha: "", currentSha: docsOnly }).ignore,
+      false,
+    );
+    assert.equal(
+      planFromInvocationDirectory({
+        cwd,
+        previousSha: "f".repeat(40),
+        currentSha: docsOnly,
+      }).ignore,
+      false,
+    );
 
-  git(cwd, "checkout", "-q", "--orphan", "unrelated");
-  writeFileSync(path.join(cwd, "docs", "notes.md"), "unrelated root\n");
-  const unrelated = commit(cwd, "unrelated root");
-  assert.deepEqual(
-    planPwaVercelBuild({ cwd, previousSha: deployed, currentSha: unrelated }),
-    { ignore: false, reason: "deployment baseline is not an ancestor" },
-  );
-});
+    mkdirSync(path.join(cwd, "scripts"), { recursive: true });
+    writeFileSync(path.join(cwd, "scripts", "pwa-vercel-ignore-build.mjs"), "// filter repair\n");
+    const filterChange = commit(cwd, "filter repair");
+    assert.deepEqual(
+      planFromInvocationDirectory({ previousSha: functionalThenDocs, currentSha: filterChange }),
+      { ignore: false, reason: "PWA-relevant changes detected" },
+    );
+
+    git(cwd, "checkout", "-q", "--orphan", "unrelated");
+    writeFileSync(path.join(cwd, "docs", "notes.md"), "unrelated root\n");
+    const unrelated = commit(cwd, "unrelated root");
+    assert.deepEqual(
+      planFromInvocationDirectory({ previousSha: deployed, currentSha: unrelated }),
+      { ignore: false, reason: "deployment baseline is not an ancestor" },
+    );
+  });
+}


### PR DESCRIPTION
(AI Generated).

Fixes #1968. Git now anchors PWA build inputs at the repository root, so invocation from `packages/pwa` cannot cancel a relevant preview. The filter itself is also a build input.

The extended Git fixtures cover root and package-directory invocations, documentation-only, PWA and filter-only changes, unavailable history and unrelated baselines. Both tests pass, as does `npm run validate:feature`. The original issue comparison now selects a build from both directories. Existing tooling routing selects the general suite.

Hosted acceptance passed on candidate `17b66db2cc861c93507ac936e7c9e91dc696c5fc`: [preview](https://freed-2sa630nom-aubreyfs-projects.vercel.app/?freed-demo=1), [Ready deployment](https://vercel.com/aubreyfs-projects/freed-pwa/3DP3yohXEXEg3nAhDEozbkzKiZdA). Project access is verified in `aubreyfs-projects`. The build log identifies the candidate and completed deployment, and the served application embeds its full SHA. This new branch had no previous successful deployment; available-baseline filtering is proved by the Git fixtures and original reproduction.

Browser checks used the actual hosted application:

- Search promotion updated Friends without a SQLite alert. A galaxy pin retained identical coordinates after another care change. Reload cleared pins and restored initial care.
- Navigation and reload retained demo mode. Empty Archived returned to feed at desktop and 390 by 844 sizes.
- Forced map failure showed 129 simplified-map markers, zero live MapLibre canvases and zero alerts.
- StoryWall rendered real remote images and accepted layout/palette changes, without import or publishing controls.
- The YouTube reader decoded its thumbnail and retained credits, with no player iframe or API script.
- A remote reader photograph decoded, then showed the graceful fallback with readable text after an injected load failure.
- Newsletter field validation and blocked human-check failure retained safe messages and synthetic input. No subscription was submitted; production HTTP error handling is not exercised by preview-only mode.
- Unsupported commands, maintenance controls, account linking and diagnostics shortcuts remained unavailable.

Continues #1970, which remains draft and unchanged. #1966 is already in the base. No application, map, photo, dependency or durable-data changes. Main receives this repair through normal promotion; www has no PWA filter. Existing www instruction-lane authorization drift is separate. Required GitHub CI is still queued. No production deployment.