### PR TITLE
fix: preserve demo maps through recoverable resource errors

### DIFF
--- a/packages/ui/src/components/map/MapSurface.lifecycle.test.tsx
+++ b/packages/ui/src/components/map/MapSurface.lifecycle.test.tsx
@@ -1,0 +1,167 @@
+/** @vitest-environment jsdom */
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { LocationMarkerSummary } from "@freed/shared";
+
+const lifecycle = vi.hoisted(() => ({ construct: vi.fn(), style: vi.fn() }));
+vi.mock("maplibre-gl", () => ({
+  Map: class { constructor(options: unknown) { return lifecycle.construct(options); } },
+  Marker: class {
+    setLngLat() { return this; }
+    addTo() { return this; }
+    remove = vi.fn();
+  },
+  GPUInitializationError: class GPUInitializationError extends Error {},
+  setWorkerUrl: vi.fn(), setWorkerCount: vi.fn(),
+}));
+vi.mock("../../lib/map-style.js", () => ({ buildThemedMapStyle: () => lifecycle.style() }));
+vi.mock("../../context/PlatformContext.js", () => ({
+  usePlatform: () => ({ geographicMapMode: "online", interactionMode: "read-only" }),
+}));
+import { MapSurface } from "./MapSurface";
+
+const markers: LocationMarkerSummary[] = [{
+  key: "location:paris", authorKey: "author:ada", lat: 48.85, lng: 2.35,
+  label: "Paris", groupCount: 1, seenAt: 1,
+  item: {
+    globalId: "rss:1", platform: "rss", contentType: "post", capturedAt: 1,
+    author: { id: "ada", handle: "ada", displayName: "Ada" },
+    content: { text: "At the observatory.", mediaUrls: [], mediaTypes: [] },
+    userState: { hidden: false, saved: false, archived: false, tags: [] }, topics: [],
+  },
+}];
+
+function liveMap(container: HTMLElement) {
+  const canvasContainer = document.createElement("div");
+  const canvas = document.createElement("canvas");
+  canvas.className = "maplibregl-canvas";
+  canvasContainer.append(canvas);
+  container.append(canvasContainer);
+  const loseContext = vi.fn();
+  vi.spyOn(canvas, "getContext").mockReturnValue({
+    getExtension: () => ({ loseContext }),
+  } as unknown as WebGL2RenderingContext);
+  const listeners = new Map<string, Set<(event?: unknown) => void>>();
+  return {
+    painter: {},
+    on: vi.fn((event: string, listener: (event?: unknown) => void) => {
+      if (!listeners.has(event)) listeners.set(event, new Set());
+      listeners.get(event)!.add(listener);
+    }),
+    off: vi.fn((event: string, listener: (event?: unknown) => void) => { listeners.get(event)?.delete(listener); }),
+    emit: (event: string, value?: unknown) => {
+      for (const listener of [...(listeners.get(event) ?? [])]) listener(value);
+    },
+    listenerCount: () => [...listeners.values()].reduce((sum, entries) => sum + entries.size, 0),
+    getCanvas: () => canvas, getCanvasContainer: () => canvasContainer,
+    stop: vi.fn(), remove: vi.fn(() => canvasContainer.remove()),
+    resize: vi.fn(), panBy: vi.fn(), flyTo: vi.fn(), loaded: () => true, loseContext,
+  };
+}
+
+describe("MapSurface initialization ownership", () => {
+  let container: HTMLDivElement;
+  let root: Root | null;
+  let map: ReturnType<typeof liveMap>;
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+    vi.useFakeTimers();
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    lifecycle.style.mockReset().mockResolvedValue({ version: 8, sources: {}, layers: [] });
+    lifecycle.construct.mockReset().mockImplementation(({ container }) => {
+      map = liveMap(container); return map;
+    });
+    container = document.createElement("div");
+    document.body.append(container);
+    root = createRoot(container);
+  });
+  afterEach(async () => {
+    await act(async () => root?.unmount());
+    container.remove(); vi.useRealTimers(); vi.restoreAllMocks();
+  });
+  async function mount() {
+    await act(async () => { root!.render(<MapSurface markers={markers} />); });
+    await act(async () => { await vi.dynamicImportSettled(); });
+  }
+  async function unmount() { await act(async () => root!.unmount()); root = null; }
+
+  it("preserves the map through recoverable errors and removes its handlers on unmount", async () => {
+    await mount();
+    await act(async () => { vi.runOnlyPendingTimers(); map.emit("idle"); });
+    const canvas = map.getCanvas();
+    await act(async () => {
+      map.emit("error", { error: new Error("tile unavailable"), sourceId: "openmaptiles" });
+      map.emit("error", { error: new Error("glyph unavailable") });
+      map.emit("webglcontextlost"); map.emit("webglcontextrestored");
+    });
+    expect(container.querySelector("canvas")).toBe(canvas);
+    expect(container.querySelector(".freed-map-fallback-scan")).toBeNull();
+    expect(map.remove).not.toHaveBeenCalled();
+    map.getCanvasContainer().dispatchEvent(new WheelEvent("wheel", { deltaX: 4, deltaY: 2 }));
+    expect(map.panBy).toHaveBeenCalledOnce();
+    await unmount();
+    expect(map.remove).toHaveBeenCalledOnce();
+    expect(map.loseContext).toHaveBeenCalledOnce();
+    expect(map.listenerCount()).toBe(0);
+    map.getCanvasContainer().dispatchEvent(new WheelEvent("wheel", { deltaY: 3 }));
+    expect(map.panBy).toHaveBeenCalledOnce();
+  });
+  it("activates the location grid when style preparation rejects", async () => {
+    lifecycle.style.mockRejectedValue(new Error("style unavailable"));
+    await mount();
+    expect(lifecycle.construct).not.toHaveBeenCalled();
+    expect(container.querySelector(".freed-map-fallback-scan button")).not.toBeNull();
+    expect(container.querySelector("canvas")).toBeNull();
+  });
+  it("activates fallback on a constructor exception", async () => {
+    lifecycle.construct.mockImplementation(({ container }) => {
+      container.append(document.createElement("canvas"));
+      throw new Error("renderer construction failed");
+    });
+    await mount();
+    expect(container.querySelector(".freed-map-fallback-scan button")).not.toBeNull();
+    expect(container.querySelector("canvas")).toBeNull();
+  });
+  it("clears a partial renderer even when its teardown throws", async () => {
+    lifecycle.construct.mockImplementation(({ container }) => {
+      map = liveMap(container);
+      map.remove.mockImplementation(() => { throw new Error("partial teardown"); });
+      return { ...map, painter: undefined };
+    });
+    await mount();
+    expect(container.querySelector(".freed-map-fallback-scan button")).not.toBeNull();
+    expect(container.querySelector("canvas")).toBeNull();
+    await unmount();
+    expect(map.remove).toHaveBeenCalledOnce();
+  });
+  it("cancels resize and listeners after explicit GPU initialization failure", async () => {
+    const { GPUInitializationError } = await import("maplibre-gl");
+    await mount();
+    await act(async () => {
+      map.emit("error", { error: new GPUInitializationError({}, null) });
+      vi.runOnlyPendingTimers();
+    });
+    expect(container.querySelector(".freed-map-fallback-scan button")).not.toBeNull();
+    expect(map.resize).not.toHaveBeenCalled();
+    expect(map.listenerCount()).toBe(0);
+    await unmount();
+    expect(map.remove).toHaveBeenCalledOnce();
+  });
+  it("cancels the queued initial resize on ordinary unmount", async () => {
+    await mount(); await unmount();
+    await act(async () => { vi.runOnlyPendingTimers(); });
+    expect(map.resize).not.toHaveBeenCalled();
+    expect(map.remove).toHaveBeenCalledOnce();
+  });
+  it("ignores obsolete preparation failures after a new lifecycle mounts", async () => {
+    let reject!: (reason: Error) => void;
+    lifecycle.style.mockImplementationOnce(() => new Promise((_resolve, rejectPromise) => { reject = rejectPromise; }));
+    await mount();
+    await act(async () => { root!.render(<MapSurface markers={markers} interactive={false} />); });
+    await act(async () => { reject(new Error("obsolete style request")); });
+    expect(container.querySelector("canvas")).toBe(map.getCanvas());
+    expect(container.querySelector(".freed-map-fallback-scan")).toBeNull();
+    expect(map.remove).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui/src/components/map/MapSurface.tsx
+++ b/packages/ui/src/components/map/MapSurface.tsx
@@ -1319,7 +1319,45 @@ export function MapSurface({
     const lifecycleId = mapLifecycleRef.current + 1;
     mapLifecycleRef.current = lifecycleId;
     let cancelled = false;
+    let ownedMap: MapInstance | null = null;
+    let resizeTimeout: ReturnType<typeof setTimeout> | undefined;
     let removeTrackpadPan: (() => void) | undefined;
+    let removeMapListeners: (() => void) | undefined;
+    const releaseMap = () => {
+      clearTimeout(resizeTimeout);
+      resizeTimeout = undefined;
+      removeMapListeners?.();
+      removeMapListeners = undefined;
+      removeTrackpadPan?.();
+      removeTrackpadPan = undefined;
+      closeActivePopup();
+      clearNativeMarkerRestoreTimeout();
+      for (const { marker } of markersRef.current) marker.remove();
+      markersRef.current = [];
+      const map = ownedMap;
+      ownedMap = null;
+      if (mapRef.current === map) mapRef.current = null;
+      if (map) {
+        try {
+          disposeMapInstance(map);
+        } catch (error) {
+          // MapLibre can return a partially initialized instance without a
+          // painter. Its remove() can then throw; still release our DOM owner.
+          console.error("[MapSurface] Failed to dispose MapLibre", error);
+        }
+      }
+      // A constructor can append DOM before throwing without returning a map.
+      containerRef.current?.replaceChildren();
+      setShellMoving(false);
+    };
+    const failInitialization = (error: unknown) => {
+      if (cancelled) return;
+      console.error("[MapSurface] Map renderer unavailable", error);
+      releaseMap();
+      setMapReady(false);
+      setMapTilesReady(false);
+      setLoadFailed(true);
+    };
     setShellMoving(false);
     setMapReady(false);
     setMapTilesReady(false);
@@ -1329,12 +1367,7 @@ export function MapSurface({
       setLoadFailed(true);
       return () => {
         cancelled = true;
-        closeActivePopup();
-        clearNativeMarkerRestoreTimeout();
-        for (const { marker } of markersRef.current) marker.remove();
-        markersRef.current = [];
-        if (mapRef.current) disposeMapInstance(mapRef.current);
-        mapRef.current = null;
+        releaseMap();
       };
     }
 
@@ -1363,7 +1396,11 @@ export function MapSurface({
           interactive,
           attributionControl: false,
         });
+        ownedMap = map;
         mapRef.current = map;
+        // MapLibre 6 can report GPU creation failure during its constructor,
+        // before listeners can attach, and return without a renderer.
+        if (!map.painter) throw new Error("MapLibre did not initialize a renderer");
         if (interactive) {
           const canvasContainer = map.getCanvasContainer();
           const panWithTrackpad = (event: globalThis.WheelEvent) => {
@@ -1396,52 +1433,61 @@ export function MapSurface({
         map.on("zoomend", clearMoving);
         // Construction readiness permits marker placement, but does not prove
         // the basemap has rendered. Capture callers need the settled tile state.
-        map.on("error", () => {
-          if (cancelled || interactionMode !== "read-only") return;
-          // Keep the sample locations usable when WebGL, styles, or tiles fail.
-          setLoadFailed(true);
-          setMapReady(false);
-          disposeMapInstance(map);
-          if (mapRef.current === map) mapRef.current = null;
-        });
-        map.on("dataloading", () => {
-          if (!cancelled) setMapTilesReady(false);
-        });
-        map.on("idle", () => {
-          if (!cancelled) setMapTilesReady(map.loaded());
-        });
+        const onError = (event: { error: Error }) => {
+          if (cancelled || ownedMap !== map) return;
+          // Tile, glyph and sprite errors do not imply an unusable map. Only
+          // explicit GPU initialization failure defeats context restoration.
+          if (interactionMode === "read-only" && event.error instanceof maplibre.GPUInitializationError) {
+            failInitialization(event.error);
+          }
+        };
+        const onDataLoading = () => {
+          if (!cancelled && ownedMap === map) setMapTilesReady(false);
+        };
+        const onIdle = () => {
+          if (!cancelled && ownedMap === map) setMapTilesReady(map.loaded());
+        };
+        removeMapListeners = () => {
+          map.off("movestart", setMoving);
+          map.off("zoomstart", setMoving);
+          map.off("moveend", clearMoving);
+          map.off("zoomend", clearMoving);
+          map.off("error", onError);
+          map.off("dataloading", onDataLoading);
+          map.off("idle", onIdle);
+        };
+        map.on("error", onError);
+        map.on("dataloading", onDataLoading);
+        map.on("idle", onIdle);
         setMapGeneration(lifecycleId);
         setMapReady(true);
-        setTimeout(() => map.resize(), 0);
+        resizeTimeout = setTimeout(() => {
+          resizeTimeout = undefined;
+          if (cancelled || ownedMap !== map) return;
+          try {
+            map.resize();
+          } catch (error) {
+            failInitialization(error);
+          }
+        }, 0);
         if (desiredMapThemeRef.current !== initialThemeId) {
           applyMapThemeStyle(desiredMapThemeRef.current);
         }
       } catch (error) {
-        console.error("[MapSurface] Failed to initialize MapLibre", error);
-        if (mapRef.current) disposeMapInstance(mapRef.current);
-        mapRef.current = null;
-        setLoadFailed(true);
+        failInitialization(error);
       }
     }).catch((error) => {
-      console.error("[MapSurface] Failed to load the themed map", error);
-      setLoadFailed(true);
+      failInitialization(error);
     });
 
     return () => {
       cancelled = true;
       mapLifecycleRef.current += 1;
-      removeTrackpadPan?.();
       mapStyleRequestRef.current += 1;
       appliedMapThemeRef.current = null;
-      closeActivePopup();
-      clearNativeMarkerRestoreTimeout();
-      for (const { marker } of markersRef.current) marker.remove();
-      markersRef.current = [];
-      if (mapRef.current) disposeMapInstance(mapRef.current);
-      mapRef.current = null;
-      setShellMoving(false);
+      releaseMap();
     };
-  }, [applyMapThemeStyle, clearNativeMarkerRestoreTimeout, closeActivePopup, interactionMode, interactive, setShellMoving]);
+  }, [applyMapThemeStyle, clearNativeMarkerRestoreTimeout, closeActivePopup, geographicMapMode, interactionMode, interactive, setShellMoving]);
 
   useEffect(() => {
     applyMapThemeStyle(resolvedThemeId);


### PR DESCRIPTION
(AI Generated).

The demo disposed its live map on every MapLibre error, including recoverable tile and glyph failures. Keep that map and its camera alive. Use the existing location grid for preparation or initialization failures and explicit GPU initialization failure.

Cancel the scheduled initial resize during cleanup, detach owned listeners, and ignore obsolete loader failures. Handle a partial MapLibre constructor without leaving its canvas in the component. No retries, dependencies, geographic assets or photograph changes.

Seven focused component cases cover resource errors, preparation and constructor failure, partial teardown, GPU failure, pending resize and stale async work. Together with the existing MapSurface coverage, all 16 tests pass. Headless browser injection confirmed that real failed tile requests preserve the same canvas and working panning, while blocked WebGL initialization produces 129 fallback markers with zero live canvases or user alerts. Both cases leave zero map canvases after navigation away.

Continues draft #1970 and refines #1966. Production deployment still requires Level 6. The full local feature gate passed: root typechecks, 520 UI tests, PWA build and typecheck, 452 PWA tests, 874 Desktop tests and nine Desktop browser smoke checks.

Both map cases also passed against the [actual hosted candidate](https://freed-a58zfxkmx-aubreyfs-projects.vercel.app/map?freed-demo=1). Vercel deployment `dpl_28SDRtSHrvk8VSi5MKyZs6GkNAD5` is Ready in `aubreyfs-projects/freed-pwa`, and the served application contains head `fa85ffb08a839a900c20fb633657115c370759f1`. Recoverable failure preserved the canvas, rendering and panning; fatal WebGL initialization showed 129 grid markers with no canvas or user alerts. Both cases cleaned up on navigation. Exact-head GitHub validation is queued; this PR is not merged.