### PR TITLE
fix: await browser ownership release after worker termination

### DIFF
--- a/packages/pwa/src/lib/library-core-sqlite-worker.test.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-worker.test.ts
@@ -28,7 +28,49 @@ describe("demo worker storage isolation", () => {
     vi.stubEnv("VITE_FREED_DEMO", "0");
     vi.stubEnv("VITE_FREED_PWA_SQLITE_MEMORY_E2E", "0");
   });
-  afterEach(() => { vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+  afterEach(() => { vi.useRealTimers(); vi.unstubAllGlobals(); vi.unstubAllEnvs(); });
+
+  it.each(["released", "occupied", "rejected"])("bounds ownership acquisition when the previous worker is %s", async (outcome) => {
+    vi.useFakeTimers();
+    vi.stubEnv("VITE_FREED_PWA_SQLITE_MEMORY_E2E", "1");
+    let grant!: () => void;
+    let signal!: AbortSignal;
+    const lockRequest = vi.fn((_name, options, callback) => new Promise((resolve, reject) => {
+      signal = options.signal;
+      signal.addEventListener("abort", () => reject(new DOMException("aborted", "AbortError")), { once: true });
+      grant = () => resolve(callback({ name: _name, mode: "exclusive" }));
+      if (outcome === "rejected") reject(new Error("ownership service unavailable"));
+    }));
+    vi.stubGlobal("navigator", { locks: { request: lockRequest } });
+    vi.stubGlobal("location", new URL("https://app.freed.wtf/"));
+    vi.stubGlobal("name", "freed-library-core-sqlite");
+    vi.stubGlobal("onmessage", null);
+    const response = new Promise<{ ok: boolean; message?: string }>((resolve) => {
+      vi.stubGlobal("postMessage", resolve);
+    });
+    await import("./library-core-sqlite-worker");
+    (globalThis.onmessage as unknown as (event: MessageEvent) => void)({
+      data: createLibraryCoreSqliteWorkerRequest("open", "ownership-test"),
+      isTrusted: true, source: null, origin: "https://app.freed.wtf",
+    } as MessageEvent);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(lockRequest).toHaveBeenCalledOnce();
+    expect(storage.memoryOpen).not.toHaveBeenCalled();
+    if (outcome === "released") {
+      await vi.advanceTimersByTimeAsync(250);
+      grant();
+      expect((await response).ok).toBe(true);
+      await vi.advanceTimersByTimeAsync(4_000);
+      expect(signal.aborted).toBe(false);
+      expect(storage.memoryOpen).toHaveBeenCalledOnce();
+    } else {
+      await vi.advanceTimersByTimeAsync(3_000);
+      expect(await response).toMatchObject({ ok: false, message: outcome === "occupied"
+        ? "PWA Library SQLite is already open in another app window"
+        : "ownership service unavailable" });
+      expect(storage.memoryOpen).not.toHaveBeenCalled();
+    }
+  });
 
   it("serializes a read behind asynchronous database opening", async () => {
     let finishReconcile!: () => void;
@@ -86,7 +128,7 @@ describe("demo worker storage isolation", () => {
     } else {
       expect(lockRequest).toHaveBeenCalledExactlyOnceWith(
         "freed-library-core-sqlite-opfs-v1",
-        { ifAvailable: true, mode: "exclusive" }, expect.any(Function),
+        { signal: expect.any(AbortSignal), mode: "exclusive" }, expect.any(Function),
       );
       expect(storage.memoryOpen).not.toHaveBeenCalled();
       expect(storage.vaultStorage).not.toHaveBeenCalled();

--- a/packages/pwa/src/lib/library-core-sqlite-worker.ts
+++ b/packages/pwa/src/lib/library-core-sqlite-worker.ts
@@ -72,6 +72,10 @@ function isAcceptedWorkerMessage(event: MessageEvent<unknown>): boolean {
 
 async function acquireOwnership(): Promise<void> {
   if (!("locks" in navigator)) return;
+  const controller = new AbortController();
+  // Terminating a worker does not synchronously release its browser-owned lock.
+  // Queue behind that release, but never wait indefinitely for another tab.
+  const timeout = setTimeout(() => controller.abort(), 3_000);
   let resolveAcquired: (() => void) | null = null;
   let rejectAcquired: ((error: Error) => void) | null = null;
   const acquired = new Promise<void>((resolve, reject) => {
@@ -80,8 +84,9 @@ async function acquireOwnership(): Promise<void> {
   });
   ownershipTask = navigator.locks.request(
     PWA_LIBRARY_CORE_SQLITE_OWNERSHIP_LOCK,
-    { ifAvailable: true, mode: "exclusive" },
+    { signal: controller.signal, mode: "exclusive" },
     async (lock) => {
+      clearTimeout(timeout);
       if (!lock) {
         rejectAcquired?.(
           new Error("PWA Library SQLite is already open in another app window"),
@@ -93,7 +98,12 @@ async function acquireOwnership(): Promise<void> {
         releaseOwnership = resolve;
       });
     },
-  );
+  ).catch((error: unknown) => {
+    clearTimeout(timeout);
+    rejectAcquired?.(controller.signal.aborted
+      ? new Error("PWA Library SQLite is already open in another app window")
+      : error instanceof Error ? error : new Error("PWA Library SQLite ownership failed"));
+  });
   await acquired;
 }
 


### PR DESCRIPTION
(AI Generated).

## Summary
- A terminated Chromium worker can retain its origin Web Lock for more than one second. Immediate reopening then falsely reports that another app window owns the Library, including after an interrupted transaction.
- Queue the same exclusive lock request with a three-second deadline. Preserve real cross-tab exclusion, reject lock-service errors, and keep SQLite recovery and accepted data unchanged.

## Testing
- Nine Chromium OPFS durability scenarios passed, including interrupted-write recovery, cross-tab refusal, reset, actor-key reopening, offline content and corruption rejection. The original failure reproduced twice before the fix.
- Local feature validation passed root typechecks, PWA production build and 455 PWA unit tests with FREED_SKIP_PWA_OPFS_DURABILITY=true, honoring the owner restriction on local macOS WebKit. This draft requires hosted WebKit proof before readiness.