### PR TITLE
fix: enable initialized demo Library queries

### DIFF
--- a/.github/workflows/showcase-capture.yml
+++ b/.github/workflows/showcase-capture.yml
@@ -8,6 +8,7 @@ on:
       - '.github/workflows/release.yml'
       - 'scripts/*showcase*.mjs'
       - 'scripts/lib/release-showcase-assets.mjs'
+      - 'packages/pwa/src/App.tsx'
       - 'packages/ui/src/components/friends/**'
       - 'packages/ui/src/index.css'
 

--- a/docs/PHASE-6-PWA.md
+++ b/docs/PHASE-6-PWA.md
@@ -75,6 +75,10 @@ or local sample activation, including an empty Library. Missing storage does
 not become a successful query result or a fabricated checkpoint. WebKit covers
 setup, sample activation, and reopening the selected Library after reload.
 
+The anonymous demo enables queries after its checked sample checkpoint finishes
+initializing. It does not require an authenticated follower receipt; ordinary
+devices retain the selected-checkpoint guard. App changes run the showcase check.
+
 Worker restart allows a bounded three-second wait for the previous browser lock
 to release, while another live tab still retains exclusive ownership. Checkpoint
 replacement retains same-epoch enrollment and follower replay records. Settings

--- a/packages/pwa/src/App.tsx
+++ b/packages/pwa/src/App.tsx
@@ -260,6 +260,9 @@ function App() {
   const initialize = useAppStore((state) => state.initialize);
   const isInitialized = useAppStore((state) => state.isInitialized);
   const hasSelectedLibrary = useAppStore((state) => state.hasSelectedLibrary);
+  // The anonymous demo activates its own checked fixture before initialization.
+  // It intentionally has no authenticated follower checkpoint receipt.
+  const canQueryLibrary = hasSelectedLibrary || (IS_DEMO && isInitialized);
   const initializationBlocker = useAppStore(
     (state) => state.initializationBlocker,
   );
@@ -579,7 +582,7 @@ function App() {
       NewsletterSettingsContent: PwaNewsletterSignup,
       LegalSettingsContent: IS_DEMO ? null : PwaLegalSettingsSection,
       FeedEmptyState: PwaFeedEmptyState,
-      LibrarySetupState: hasSelectedLibrary ? undefined : PwaLibrarySetupState,
+      LibrarySetupState: canQueryLibrary ? undefined : PwaLibrarySetupState,
       XSettingsContent: PwaXSettings,
       FacebookSettingsContent: PwaFacebookSettings,
       InstagramSettingsContent: PwaInstagramSettings,
@@ -646,7 +649,7 @@ function App() {
         ? undefined
         : executePwaLibraryCoreScopeAction,
       readFeedSignalCounts: readPwaLibraryCoreFeedSignalCounts,
-      readLibraryFacetSummary: !hasSelectedLibrary ? undefined : IS_DEMO
+      readLibraryFacetSummary: !canQueryLibrary ? undefined : IS_DEMO
         ? async () =>
             projectDemoFacetReads(await readPwaLibraryCoreFacetSummary())
         : readPwaLibraryCoreFacetSummary,
@@ -681,7 +684,7 @@ function App() {
         : appendPwaLibraryCorePersonReachOut,
       upsertLibraryAccount: IS_DEMO ? undefined : upsertPwaLibraryCoreAccount,
       readLibraryAccountDetail: readPwaLibraryCoreAccountDetail,
-      queryLibraryCore: hasSelectedLibrary ? queryPwaNormalizedLibrary : undefined,
+      queryLibraryCore: canQueryLibrary ? queryPwaNormalizedLibrary : undefined,
       mutateDeviceGraphLayout: IS_DEMO ? mutateFreedDemoGraphLayout : mutatePwaDeviceGraphLayout,
       mutateDeviceContacts: IS_DEMO ? undefined : mutatePwaDeviceContactSync,
       queryDeviceContacts: queryPwaDeviceContacts,
@@ -697,7 +700,7 @@ function App() {
         : readPwaLibraryCoreItemDetail,
       bugReporting: pwaBugReporting,
     }),
-    [checkForUpdates, handleFactoryReset, hasSelectedLibrary, releaseChannel, setReleaseChannel],
+    [canQueryLibrary, checkForUpdates, handleFactoryReset, releaseChannel, setReleaseChannel],
   );
 
   if (!legalResolved) {


### PR DESCRIPTION
(AI Generated).

The new-device query guard also blocked the anonymous demo because its checked sample checkpoint has no authenticated follower receipt. The demo initialized successfully but displayed zero items, blocking production showcase capture.

Allow demo queries after initialization while keeping verified-checkpoint selection mandatory for ordinary devices. Add App.tsx to the existing all-theme showcase workflow triggers so this startup path is checked before future promotions. The capture script and its readiness, media, and rendering assertions remain unchanged.

Validation: all six local capture views passed with 500 items, WebGPU Friends rendering and two-column mobile Stories. Feature validation passed PWA build, type checks, 461 PWA tests and roadmap checks. All 19 release-governance tests passed. Local macOS WebKit was not run under the owner restriction; hosted durability and showcase checks remain required.

## Provider Review
- Status: Draft publication was requested. Provider authority is validated, but no ready transition was requested.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `05163802e6f5826b1b6a9e97d6829c2dad6f0f28`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-demo-readiness-20260909`
- Provider review decision: `behavior_approved`
- Provider review artifact: `2783675e33b772f96479a5a116556faa7414575e043d4435619738aaf36e16fe`
- Providers: other
- Observable behavior: Enable bounded queries for the anonymous demo only after checked sample initialization. Restore the existing public demo image and map loads that empty query gating prevented. Real PWA devices retain receipt-verified selection guards. No authenticated provider calls, retry changes, polling changes, key changes or durable authority changes.
- Fingerprinting risk: Existing anonymous demo image and map requests resume; no additional request pattern or authenticated social-provider exposure.
- Lowest profile alternative: Use the existing isolated anonymous demo and unchanged capture network allowlist.

Files bound into this provider review:
- `packages/pwa/src/App.tsx`