### PR TITLE
fix: isolate conflicting Drive enrollment requests

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -318,3 +318,12 @@ Drive acceptance remains required before claiming the release effective.
 - Freed Desktop native Library Core from Phase 5
 - PWA OPFS SQLite runtime from Phase 6
 - Existing Google Drive adapter behavior and authenticated app-data storage
+
+### Conflicting enrollment isolation
+
+A native rejection of changed actor enrollment bytes leaves that actor unchanged
+and does not stop independent device requests or accepted actor synchronization.
+The coordinator records a bounded diagnostic and publishes no certificate for the
+rejected request. Other native, authority, cancellation, and transport failures
+still stop the pass. Recovery of a device whose retained request itself conflicts
+with its accepted enrollment remains a separate verification requirement.

--- a/packages/desktop/src/lib/library-core-cloud-sync.test.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.test.ts
@@ -598,7 +598,7 @@ describe("SQLite Library Google Drive production wiring", () => {
     stopSqliteLibraryCloudSync();
   });
 
-  it("admits normalized follower transport and publishes signed results without the retired journal", async () => {
+  it.each(["clean", "string conflict", "Error conflict"])("admits normalized follower transport and publishes signed results with %s enrollment discovery", async (scenario) => {
     const libraryId = "ab".repeat(32);
     const storageEpochId = "cd".repeat(32);
     const actorId = "34".repeat(32);
@@ -619,14 +619,23 @@ describe("SQLite Library Google Drive production wiring", () => {
       },
       transportObjectId: "intent-segment-1",
     };
-    mocks.discoverEnrollmentRequests.mockResolvedValue([
-      { bytes: new TextEncoder().encode("enrollment-request") },
-    ]);
-    mocks.countersignNormalizedEnrollment.mockResolvedValue({
-      actorId,
-      authorityEpochId: storageEpochId,
-      canonicalEnrollmentCertificateJson: "{}",
-      libraryId,
+    const requestNames = scenario === "clean"
+      ? ["enrollment-request"]
+      : ["conflict-before", "enrollment-request", "conflict-after"];
+    mocks.discoverEnrollmentRequests.mockResolvedValue(
+      requestNames.map((name) => ({ bytes: new TextEncoder().encode(name) })),
+    );
+    mocks.countersignNormalizedEnrollment.mockImplementation(async (request: string) => {
+      if (request.startsWith("conflict-")) {
+        const message = "normalized follower actor replay changed";
+        throw scenario === "string conflict" ? message : new Error(message);
+      }
+      return {
+        actorId,
+        authorityEpochId: storageEpochId,
+        canonicalEnrollmentCertificateJson: "{}",
+        libraryId,
+      };
     });
     mocks.discoverActorEnrollments.mockResolvedValue([
       {
@@ -1401,6 +1410,27 @@ describe("SQLite Library Google Drive production wiring", () => {
     );
     expect(mocks.publish).not.toHaveBeenCalled();
     expect(mocks.writeNative).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    "normalized follower actor countersignature failed",
+    "normalized follower enrollment authority changed concurrently",
+    "database is locked",
+    "normalized follower actor replay changed unexpectedly",
+    Object.assign(new Error("normalized follower actor replay changed"), { name: "AbortError" }),
+  ])("stops enrollment discovery on unrelated refusal: %s", async (reason) => {
+    mocks.discoverEnrollmentRequests.mockResolvedValue([
+      { bytes: new TextEncoder().encode("enrollment-request") },
+      { bytes: new TextEncoder().encode("later-request") },
+    ]);
+    mocks.countersignNormalizedEnrollment.mockRejectedValueOnce(reason);
+    await expect(
+      publishCurrentSqliteLibraryToGoogleDrive({ accessToken: "token" }),
+    ).rejects.toThrow(reason instanceof Error ? reason.message : `countersign follower enrollment failed: ${reason}`);
+    expect(mocks.countersignNormalizedEnrollment).toHaveBeenCalledTimes(1);
+    expect(mocks.putImmutable).not.toHaveBeenCalled();
+    expect(mocks.discoverActorEnrollments).not.toHaveBeenCalled();
+    expect(mocks.publish).not.toHaveBeenCalled();
   });
 
   it("preserves a native string rejection with its publication stage", async () => {

--- a/packages/desktop/src/lib/library-core-cloud-sync.ts
+++ b/packages/desktop/src/lib/library-core-cloud-sync.ts
@@ -599,8 +599,26 @@ async function acceptPendingNormalizedFollowerEnrollments(input: {
       request.bytes,
     );
     const enrollment =
-      await tracedPublicationStage("countersign follower enrollment", () =>
-        countersignNormalizedLibraryFollowerActorRequest(canonical));
+      await tracedPublicationStage("countersign follower enrollment", async () => {
+        try {
+          return await countersignNormalizedLibraryFollowerActorRequest(canonical);
+        } catch (error) {
+          if (error instanceof Error && error.name === "AbortError") throw error;
+          const detail = error instanceof Error ? error.message : error;
+          if (detail !== "normalized follower actor replay changed") throw error;
+          // Native SQLite rejected this request without changing the enrolled
+          // actor. Keep the immutable conflict, but do not strand other actors.
+          const message = "Conflicting device enrollment rejected; continuing existing Library sync.";
+          log.warn(`[library-core-cloud] ${message}`);
+          recordCloudProviderEvent("gdrive", {
+            kind: "error",
+            stage: "upload",
+            message,
+          });
+          return null;
+        }
+      });
+    if (enrollment === null) continue;
     await tracedPublicationStage("publish follower enrollment", () => publishNormalizedActorEnrollment({
       adapter: input.adapter,
       enrollment,


### PR DESCRIPTION
(AI Generated).

## Summary
- A rejected repeat enrollment currently aborts every later request and accepted actor sync. Preserve the native rejection and existing identity while continuing independent work.
- Only the exact changed-actor replay refusal is isolated. Unknown errors, cancellation and publication failures still stop the pass. No rejected certificate is uploaded and polling remains unchanged.

## Testing
- 33 focused coordinator tests; feature gate passed881 Desktop unit tests,9 Chromium smoke workflows, types and roadmap.
- Native isolated preview app build passed without launching or accessing production keys. Live enrollment verification remains pending signed release.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `7e09c82e92d1760f3dabd5ee8db5f4916316dd14`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `enrollment-request-isolation-20260909`
- Provider review decision: `behavior_approved`
- Provider review artifact: `da9e843229e5e2d0c06669caf5d78514a66c78e1cf4ccf25ddb275e5aa348f4b`
- Providers: other
- Observable behavior: Reject the exact native changed-actor enrollment conflict without publishing its certificate, then continue independent requests and existing accepted actor sync through Google Drive at unchanged endpoints, polling interval and retry policy.
- Fingerprinting risk: Resuming previously blocked sync can increase successful existing Drive reads and writes; no new cadence or social-provider traffic.
- Lowest profile alternative: Offline deterministic refusal and valid actor fixtures before existing authenticated sync.

Files bound into this provider review:
- `packages/desktop/src/lib/library-core-cloud-sync.ts`