### PR TITLE
fix: match follower enrollment certificates by request digest

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -327,3 +327,10 @@ The coordinator records a bounded diagnostic and publishes no certificate for th
 rejected request. Other native, authority, cancellation, and transport failures
 still stop the pass. Recovery of a device whose retained request itself conflicts
 with its accepted enrollment remains a separate verification requirement.
+
+Google Drive follower certificate discovery matches the retained request against
+the complete certificate digest, not the distinct nested enrollment-body digest.
+Actor identity and request matching remain exact; SQLite still verifies the
+canonical certificate, signatures, capabilities, and current authority before
+enrollment. The transport fixture uses different digest fields to protect this
+boundary.

--- a/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.test.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.test.ts
@@ -57,6 +57,7 @@ function descriptor(digest = "55".repeat(32) as LibraryCoreLowercaseHex64) {
 function certificateBytes(input: {
   readonly actorId: string;
   readonly enrollmentRequestDigest: string;
+  readonly enrollmentBodyDigest?: string;
 }): Uint8Array {
   return encodeLibraryCoreCanonicalValue({
     authority_signature: "66".repeat(64),
@@ -64,9 +65,9 @@ function certificateBytes(input: {
       actor_enrollment_body: {
         actor_id: input.actorId,
       },
-      enrollment_body_digest: input.enrollmentRequestDigest,
+      enrollment_body_digest: input.enrollmentBodyDigest ?? "77".repeat(32),
     },
-    certificate_digest: "77".repeat(32),
+    certificate_digest: input.enrollmentRequestDigest,
   });
 }
 
@@ -113,6 +114,8 @@ describe("Google Drive normalized follower transport", () => {
     const wrongDigest = certificateBytes({
       actorId,
       enrollmentRequestDigest: "88".repeat(32),
+      // Matching only the inner enrollment body must not select this certificate.
+      enrollmentBodyDigest: enrollmentRequestDigest,
     });
     const wrongActor = certificateBytes({
       actorId: "99".repeat(32),

--- a/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.ts
@@ -61,7 +61,11 @@ function enrollmentCertificateIdentity(bytes: Uint8Array): Readonly<{
   const actorId = (
     enrollmentBody as Readonly<Record<string, LibraryCoreCanonicalValue>>
   ).actor_id;
-  const enrollmentRequestDigest = body.enrollment_body_digest;
+  // The retained request binds the complete capability certificate body,
+  // not the different digest of its nested actor enrollment body.
+  const enrollmentRequestDigest = (
+    value as Readonly<Record<string, LibraryCoreCanonicalValue>>
+  ).certificate_digest;
   return typeof actorId === "string" &&
     typeof enrollmentRequestDigest === "string"
     ? Object.freeze({ actorId, enrollmentRequestDigest })


### PR DESCRIPTION
(AI Generated).

## Summary
- Match the complete certificate digest and actor against the retained enrollment request so a valid Google Drive certificate can reach existing SQLite verification. Reject inner-only digest matches.

## Testing
- Corrected regression fixture fails old implementation and passes fixed implementation, 3 tests; validate:feature passed. Local WebKit durability excluded under owner restriction, hosted verification required.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `b59c2c6de68e74f45d73dd618906069c93d95d39`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `enrollment-certificate-digest-20260910`
- Provider review decision: `behavior_approved`
- Provider review artifact: `e20a4411dec3210385e2b1a006b07548218c5b3f801b2b43ec3f2df0ee56c146`
- Providers: other
- Observable behavior: Select the Google Drive enrollment certificate by the complete retained certificate digest and exact actor, then allow existing verified follower synchronization at unchanged endpoints and cadence.
- Fingerprinting risk: Resuming previously blocked sync can increase successful existing Drive reads and writes; no new cadence or social-provider traffic.
- Lowest profile alternative: Offline deterministic refusal and valid actor fixtures before existing authenticated sync.

Files bound into this provider review:
- `packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.test.ts`
- `packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.ts`