### PR TITLE
chore: promote dev into main for production release

### DIFF
--- a/docs/PHASE-8-FRIENDS.md
+++ b/docs/PHASE-8-FRIENDS.md
@@ -939,3 +939,10 @@ Isolated editorial follow-up on September 6: accepted sample Stories now carry c
 ## Demo relationships and graph pins
 
 Search promotions use the existing demo care-change path and read the current linked person before offering a promotion. Unlinked accounts keep navigation but cannot create a person, promote, or open a person map in the demo. Graph pins use the registered device-layout mutation in the memory-only demo SQLite worker. Pin and care changes are serialized; a care checkpoint replacement preserves pinned coordinates. Reload clears both kinds of edits.
+
+Google Contacts expired-token recovery accepts the observed HTTP 400 response
+with the exact expired-token message as well as HTTP 410. Recovery starts one
+fresh paginated read without the old sync token or partial incremental results.
+Unrelated HTTP 400 failures still propagate, and a failed full read does not
+retry recursively. The current synchronization schedule and credentials remain
+unchanged. Browser and native-adapter fixtures cover this boundary.

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -45,7 +45,7 @@
     {
       "id": 8,
       "status": "current",
-      "reviewedAt": "2026-09-09",
+      "reviewedAt": "2026-09-10",
       "source": "docs/PHASE-8-FRIENDS.md"
     },
     {

--- a/packages/desktop/src/lib/google-contacts-platform.test.ts
+++ b/packages/desktop/src/lib/google-contacts-platform.test.ts
@@ -56,6 +56,15 @@ describe("desktop Google Contacts platform fetch", () => {
     });
   });
 
+  it("recovers the native expired-token response without repeating the stale token", async () => {
+    invokeMock.mockResolvedValueOnce({ status: 400, headers: [], bodyB64: btoa(JSON.stringify({ error: { message: "Sync token is expired. Clear local cache and retry call without the sync token." } })) })
+      .mockResolvedValueOnce({ status: 200, headers: [], bodyB64: btoa(JSON.stringify({ connections: [], nextSyncToken: "fresh" })) });
+    const { fetchGoogleContactsViaTauri } = await import("./google-contacts");
+    await expect(fetchGoogleContactsViaTauri("access-token", "expired")).resolves.toMatchObject({ nextSyncToken: "fresh", contacts: [] });
+    expect(invokeMock).toHaveBeenCalledTimes(2);
+    expect(new URL(invokeMock.mock.calls[1][1].url).searchParams.has("syncToken")).toBe(false);
+  });
+
   it("preserves native transport failures", async () => {
     invokeMock.mockRejectedValueOnce("Google Contacts request failed: dns error");
 

--- a/packages/desktop/src/lib/google-contacts.test.ts
+++ b/packages/desktop/src/lib/google-contacts.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   fetchGoogleContacts,
   mergeContactChanges,
+  fetchGoogleContactsWithPageFetcher,
 } from "@freed/shared/google-contacts";
 import { createContactAccountFromGoogleContact } from "@freed/shared/google-contacts-automation";
 
@@ -55,10 +56,10 @@ describe("google contacts helpers", () => {
     expect(result.contacts[0].name.displayName).toBe("Jane Doe");
   });
 
-  it("fetchGoogleContacts retries with a full sync when the token expires", async () => {
+  it.each([410, 400])("fetchGoogleContacts retries with a full sync after expired token status %s", async (status) => {
     const fetchMock = vi
       .spyOn(globalThis, "fetch")
-      .mockResolvedValueOnce(new Response("gone", { status: 410 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ error: { message: "Sync token is expired. Clear local cache and retry call without the sync token." } }), { status }))
       .mockResolvedValueOnce(
         new Response(
           JSON.stringify({
@@ -78,6 +79,36 @@ describe("google contacts helpers", () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(result.contacts).toHaveLength(1);
     expect(result.nextSyncToken).toBe("fresh-sync");
+    expect(new URL(String(fetchMock.mock.calls[1][0])).searchParams.has("syncToken")).toBe(false);
+  });
+
+  it("discards incremental pages and their cursor before full recovery", async () => {
+    const pageFetcher = vi.fn()
+      .mockResolvedValueOnce({ connections: [{ resourceName: "people/stale" }, { resourceName: "people/deleted", metadata: { deleted: true } }], nextPageToken: "incremental-page" })
+      .mockRejectedValueOnce(Object.assign(new Error("Google Contacts API failed (400): Sync token is expired. Clear local cache and retry call without the sync token."), { status: 400 }))
+      .mockResolvedValueOnce({ connections: [{ resourceName: "people/fresh" }], nextPageToken: "fresh-page" })
+      .mockResolvedValueOnce({ connections: [], nextSyncToken: "replacement" });
+    const result = await fetchGoogleContactsWithPageFetcher("token", "expired", pageFetcher);
+    expect(result.contacts.map(contact => contact.resourceName)).toEqual(["people/fresh"]);
+    expect(result.deleted).toEqual([]);
+    expect(result.nextSyncToken).toBe("replacement");
+    expect(pageFetcher).toHaveBeenCalledTimes(4);
+    expect(pageFetcher.mock.calls[2][1].has("syncToken")).toBe(false);
+    expect(pageFetcher.mock.calls[2][1].has("pageToken")).toBe(false);
+    expect(pageFetcher.mock.calls[3][1].get("pageToken")).toBe("fresh-page");
+  });
+
+  it.each([400, 410])("does not repeat failed full recovery after status %s", async status => {
+    const failure = Object.assign(new Error("Sync token is expired. Clear local cache and retry call without the sync token."), { status });
+    const pageFetcher = vi.fn().mockRejectedValue(failure);
+    await expect(fetchGoogleContactsWithPageFetcher("token", "expired", pageFetcher)).rejects.toBe(failure);
+    expect(pageFetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("preserves unrelated HTTP 400 errors without retry", async () => {
+    const pageFetcher = vi.fn().mockRejectedValue(Object.assign(new Error("Invalid personFields"), { status: 400 }));
+    await expect(fetchGoogleContactsWithPageFetcher("token", "retained", pageFetcher)).rejects.toThrow("Invalid personFields");
+    expect(pageFetcher).toHaveBeenCalledTimes(1);
   });
 
   it("mergeContactChanges replaces updated contacts and removes deleted ones", () => {

--- a/packages/shared/src/google-contacts.ts
+++ b/packages/shared/src/google-contacts.ts
@@ -45,6 +45,8 @@ function parseContact(raw: NonNullable<GoogleContactsConnectionsResponse["connec
   };
 }
 
+const EXPIRED_SYNC_TOKEN_MESSAGE = "Sync token is expired. Clear local cache and retry call without the sync token.";
+
 async function fetchPage(
   accessToken: string,
   params: URLSearchParams
@@ -55,7 +57,12 @@ async function fetchPage(
   });
   if (!res.ok) {
     const status = res.status;
-    throw Object.assign(new Error(`People API error ${status}`), { status });
+    let expiredSyncToken = false;
+    if (status === 400) {
+      const body = await res.json().catch(() => null) as { error?: { message?: string } } | null;
+      expiredSyncToken = body?.error?.message === EXPIRED_SYNC_TOKEN_MESSAGE;
+    }
+    throw Object.assign(new Error(`People API error ${status}`), { status, expiredSyncToken });
   }
   return res.json() as Promise<GoogleContactsConnectionsResponse>;
 }
@@ -97,12 +104,15 @@ export async function fetchGoogleContactsWithPageFetcher(
       pageToken = page.nextPageToken;
     } while (pageToken);
   } catch (err: unknown) {
-    // 410 GONE = expired syncToken, fall back to full sync
+    // Restart once without either the expired sync token or partial page state.
     if (
       typeof err === "object" &&
       err !== null &&
       "status" in err &&
-      (err as { status: number }).status === 410 &&
+      ((err as { status: number }).status === 410 ||
+        ((err as { status: number }).status === 400 &&
+          (("expiredSyncToken" in err && err.expiredSyncToken === true) ||
+            (err instanceof Error && err.message.endsWith(EXPIRED_SYNC_TOKEN_MESSAGE))))) &&
       syncToken
     ) {
       return fetchGoogleContactsWithPageFetcher(accessToken, null, pageFetcher);


### PR DESCRIPTION
(AI Generated).

## Summary
- Promote one immutable dev product snapshot into `main` before a production release.
- Base main SHA: `7e8a285b99f78d6cc0b209891cf69bbf1d80eb1d`
- Source dev SHA: `c2c36f892413657fafcec1631f7206e82f941238`

## Testing
- `node scripts/validate-main-pr.mjs --base-ref=origin/main --head-ref=HEAD --head-branch=chore/promote-dev-to-main-contacts-recovery --snapshot-ref=c2c36f892413657fafcec1631f7206e82f941238`
- CI

## Provider Review
- Status: Draft publication was requested. Provider authority is validated, but no ready transition was requested.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `2108375a99ff91960bf6fa04b869b660ecd7dc5d`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `contacts-expired-token-20260910`
- Provider review decision: `behavior_approved`
- Provider review artifact: `e6d26d4660e71f36708f13c9146b7019deac1ea8897431b3712bcb9f0819720a`
- Providers: other
- Observable behavior: On the exact observed Google Contacts HTTP400 expired-sync-token response, retry once with a fresh paginated read without the stale token or partial incremental results. Keep the current schedule, endpoints and credentials. Other400errors and failures of the fresh read propagate.
- Fingerprinting risk: One fresh paginated People API read can increase request volume during expired-token recovery; no schedule or social-provider changes.
- Lowest profile alternative: Deterministic browser and native-adapter fixtures before one installed recovery observation.

Files bound into this provider review:
- `packages/shared/src/google-contacts.ts`