### PR TITLE
fix: expose pending device enrollment diagnostics

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -334,3 +334,8 @@ Actor identity and request matching remain exact; SQLite still verifies the
 canonical certificate, signatures, capabilities, and current authority before
 enrollment. The transport fixture uses different digest fields to protect this
 boundary.
+
+Pending PWA enrollment diagnostics expose only the device and request identity
+suffixes plus counts from the existing certificate discovery pass. They distinguish
+a missing device certificate from a different request for the same device without
+adding Drive requests or changing enrollment admission.

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -21,7 +21,7 @@
     {
       "id": 4,
       "status": "current",
-      "reviewedAt": "2026-09-09",
+      "reviewedAt": "2026-09-10",
       "source": "docs/PHASE-4-SYNC.md"
     },
     {

--- a/packages/pwa/src/lib/library-core-runtime.test.ts
+++ b/packages/pwa/src/lib/library-core-runtime.test.ts
@@ -559,6 +559,7 @@ describe("PWA Library Core bounded scanner", () => {
       }),
     );
     expect(mocks.createFollowerTransport).toHaveBeenCalledWith({
+      onEnrollmentDiscovery: expect.any(Function),
       accessToken: "test-token",
       controlFileId: "control-runtime-recovery",
       libraryId,

--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -71,6 +71,7 @@ import type {
   SearchLibraryItems,
 } from "@freed/ui/context";
 import {
+  type LibraryCoreEnrollmentDiscoverySummaryV2,
   createGoogleDriveLibraryCoreAdapterV1,
   createGoogleDriveLibraryCoreNormalizedFollowerTransportV2,
   discoverPublishedGoogleDriveLibraryCoreControlV1,
@@ -1276,6 +1277,7 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
   readonly signal?: AbortSignal;
 }): Promise<LibraryCoreRuntimeStateV1 & {
   readonly followerEnrollmentState: Awaited<ReturnType<typeof syncPwaLibraryCoreFollowerV2>>["enrollmentState"];
+  readonly enrollmentDiscovery: LibraryCoreEnrollmentDiscoverySummaryV2 | null;
 }> {
   const selected = await readPwaNormalizedCheckpointReceipt();
   const retainedLibraryId = selected.receipt &&
@@ -1320,8 +1322,10 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
       writerActorId: pointer.writerId,
     }),
   });
+  let enrollmentDiscovery: LibraryCoreEnrollmentDiscoverySummaryV2 | null = null;
   const followerReceipt = await syncPwaLibraryCoreFollowerV2(
     createGoogleDriveLibraryCoreNormalizedFollowerTransportV2({
+      onEnrollmentDiscovery: (summary) => { enrollmentDiscovery = summary; },
       accessToken: input.accessToken,
       controlFileId: discovered.controlFileId,
       libraryId: pointer.libraryId,
@@ -1332,6 +1336,7 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
   return Object.freeze({
     ...await publishSelectedStateAfterLibraryCoreSync(),
     followerEnrollmentState: followerReceipt.enrollmentState,
+    enrollmentDiscovery,
   });
 }
 

--- a/packages/pwa/src/lib/sync.test.ts
+++ b/packages/pwa/src/lib/sync.test.ts
@@ -74,11 +74,15 @@ describe("PWA Library Core sync lifecycle", () => {
   });
 
   it("reports pending enrollment until the Primary admits this device", async () => {
-    mocks.syncLibraryCore.mockResolvedValueOnce({ followerEnrollmentState: "pending" });
+    mocks.syncLibraryCore.mockResolvedValueOnce({
+      followerEnrollmentState: "pending",
+      enrollmentDiscovery: { actorSuffix: "12345678", requestDigestSuffix: "abcdef12", certificateCount: 2, actorMatchCount: 1, exactMatchCount: 0 },
+    });
     await startCloudSync("gdrive", "stored-token");
     expect(mocks.updateCloudProvider).toHaveBeenLastCalledWith("gdrive", expect.objectContaining({
       status: "connected",
       statusMessage: "Library downloaded. Device enrollment pending.",
+      pendingReason: "Device ...12345678, request ...abcdef12. Certificates found: 2; for this device: 1; matching this request: 0.",
     }));
     expect(mocks.recordCloudProviderEvent).toHaveBeenLastCalledWith("gdrive", expect.objectContaining({ kind: "waiting" }));
     await syncCloudProviderNow("gdrive");

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -292,6 +292,10 @@ async function performGoogleDriveSync(
   if (generation !== cloudGeneration || signal.aborted) return;
   const now = Date.now();
   const enrollmentPending = syncResult.followerEnrollmentState !== "enrolled";
+  const discovery = syncResult.enrollmentDiscovery;
+  const enrollmentDetail = discovery
+    ? `Device ...${discovery.actorSuffix}, request ...${discovery.requestDigestSuffix}. Certificates found: ${discovery.certificateCount.toLocaleString()}; for this device: ${discovery.actorMatchCount.toLocaleString()}; matching this request: ${discovery.exactMatchCount.toLocaleString()}.`
+    : null;
   setCloudLibraryChoices(emptyLibraryChoices);
   updateCloudProvider("gdrive", {
     status: "connected",
@@ -304,7 +308,7 @@ async function performGoogleDriveSync(
       ? "Library downloaded. Device enrollment pending."
       : "SQLite Library synchronized.",
     pendingReason: enrollmentPending
-      ? "Open the Primary Freed Desktop and resolve any Drive sync error so this device can sync edits."
+      ? enrollmentDetail ?? "Open the Primary Freed Desktop and resolve any Drive sync error so this device can sync edits."
       : "Waiting for the next checkpoint, intent, or result change.",
     error: undefined,
   });

--- a/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.test.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.test.ts
@@ -71,11 +71,13 @@ function certificateBytes(input: {
   });
 }
 
-function createTransport(beforeProviderOperation = vi.fn()) {
+function createTransport(beforeProviderOperation = vi.fn(), onEnrollmentDiscovery = vi.fn()) {
   return {
     beforeProviderOperation,
+    onEnrollmentDiscovery,
     transport: createGoogleDriveLibraryCoreNormalizedFollowerTransportV2({
       accessToken: "token",
+      onEnrollmentDiscovery,
       beforeProviderOperation,
       controlFileId: "control-1",
       libraryId,
@@ -127,7 +129,7 @@ describe("Google Drive normalized follower transport", () => {
       { bytes: wrongActor },
       { bytes: exact },
     ]);
-    const { beforeProviderOperation, transport } = createTransport();
+    const { beforeProviderOperation, transport, onEnrollmentDiscovery } = createTransport();
     const source = Uint8Array.of(1, 2, 3);
     const candidate = {
       descriptor: descriptor(),
@@ -162,6 +164,25 @@ describe("Google Drive normalized follower transport", () => {
       source,
     });
     expect(beforeProviderOperation).toHaveBeenCalledTimes(3);
+    expect(onEnrollmentDiscovery).toHaveBeenLastCalledWith({
+      actorSuffix: actorId.slice(-8),
+      requestDigestSuffix: enrollmentRequestDigest.slice(-8),
+      certificateCount: 3,
+      actorMatchCount: 2,
+      exactMatchCount: 1,
+    });
+    mocks.discoverEnrollments.mockResolvedValue([{ bytes: wrongDigest }, { bytes: wrongActor }]);
+    await expect(transport.readEnrollmentCertificate({ actorId, enrollmentRequestDigest, libraryId, storageEpochId })).resolves.toBeNull();
+    expect(onEnrollmentDiscovery).toHaveBeenLastCalledWith({
+      actorSuffix: actorId.slice(-8), requestDigestSuffix: enrollmentRequestDigest.slice(-8),
+      certificateCount: 2, actorMatchCount: 1, exactMatchCount: 0,
+    });
+    mocks.discoverEnrollments.mockResolvedValue([]);
+    await expect(transport.readEnrollmentCertificate({ actorId, enrollmentRequestDigest, libraryId, storageEpochId })).resolves.toBeNull();
+    expect(onEnrollmentDiscovery).toHaveBeenLastCalledWith({
+      actorSuffix: actorId.slice(-8), requestDigestSuffix: enrollmentRequestDigest.slice(-8),
+      certificateCount: 0, actorMatchCount: 0, exactMatchCount: 0,
+    });
   });
 
   it("provisions one normalized intent head and fences every adapter operation", async () => {

--- a/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.ts
+++ b/packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.ts
@@ -20,7 +20,16 @@ import type {
 } from "./library-core-normalized-follower-sync.js";
 import type { LibraryCoreNormalizedHeadPublicationAdapterV2 } from "./library-core-normalized-segment-publication.js";
 
+export interface LibraryCoreEnrollmentDiscoverySummaryV2 {
+  readonly actorSuffix: string;
+  readonly requestDigestSuffix: string;
+  readonly certificateCount: number;
+  readonly actorMatchCount: number;
+  readonly exactMatchCount: number;
+}
+
 export interface GoogleDriveLibraryCoreNormalizedFollowerTransportOptionsV2 {
+  readonly onEnrollmentDiscovery?: (summary: LibraryCoreEnrollmentDiscoverySummaryV2) => void;
   readonly accessToken: string;
   readonly beforeProviderOperation?: () => void;
   readonly controlFileId: string;
@@ -160,16 +169,26 @@ export function createGoogleDriveLibraryCoreNormalizedFollowerTransportV2(
         libraryId: request.libraryId,
         signal: options.signal,
       });
-      return (
-        enrollments.find((candidate) => {
-          const identity = enrollmentCertificateIdentity(candidate.bytes);
-          return (
-            identity !== null &&
-            identity.actorId === request.actorId &&
-            identity.enrollmentRequestDigest === request.enrollmentRequestDigest
-          );
-        })?.bytes ?? null
-      );
+      let selected: Uint8Array | null = null;
+      let actorMatchCount = 0;
+      let exactMatchCount = 0;
+      for (const candidate of enrollments) {
+        const identity = enrollmentCertificateIdentity(candidate.bytes);
+        if (identity?.actorId !== request.actorId) continue;
+        actorMatchCount += 1;
+        if (identity.enrollmentRequestDigest !== request.enrollmentRequestDigest) continue;
+        exactMatchCount += 1;
+        selected = candidate.bytes;
+        break;
+      }
+      options.onEnrollmentDiscovery?.(Object.freeze({
+        actorSuffix: request.actorId.slice(-8),
+        requestDigestSuffix: request.enrollmentRequestDigest.slice(-8),
+        certificateCount: enrollments.length,
+        actorMatchCount,
+        exactMatchCount,
+      }));
+      return selected;
     },
     async openIntentAdapter(context) {
       beforeProviderOperation();


### PR DESCRIPTION
(AI Generated).

## Summary
- Show bounded device and request suffixes with certificate match counts when PWA enrollment remains pending, using the existing Drive discovery response. Preserve exact matching and all enrollment authority checks.

## Testing
- Full local feature validation passed; 47 focused tests and PWA typecheck passed. Local WebKit omitted per owner restriction; hosted WebKit remains required.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `b2bc55f87f1007d94f16c07182bb3ece9752478a`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `enrollment-diagnostics-20260910`
- Provider review decision: `diff_authorized`
- Provider review artifact: `c58c0309ea8f718519c5285f9a4bae00151a15bbe8ace4ac71448992e22c761d`
- Providers: other
- Observable behavior: Read-only local summary from existing Drive certificate discovery; unchanged requests and admission; no new provider traffic.
- Fingerprinting risk: None added: no endpoint, request count, cadence, cookie, header or provider action changes.
- Lowest profile alternative: Bounded diagnostics from the already fetched response and offline fixtures.

Files bound into this provider review:
- `packages/pwa/src/lib/sync.ts`
- `packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.test.ts`
- `packages/sync/src/cloud/library-core-google-drive-normalized-follower-transport.ts`