### PR TITLE
fix: report active PWA sync stages

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -339,3 +339,7 @@ Pending PWA enrollment diagnostics expose only the device and request identity
 suffixes plus counts from the existing certificate discovery pass. They distinguish
 a missing device certificate from a different request for the same device without
 adding Drive requests or changing enrollment admission.
+
+PWA sync reports its current local-checkpoint, Drive discovery, checkpoint import,
+follower-sync, and view-refresh stage while the pass is running. This keeps an
+unsettled pass attributable without adding provider calls or changing admission.

--- a/docs/roadmap-status.json
+++ b/docs/roadmap-status.json
@@ -21,7 +21,7 @@
     {
       "id": 4,
       "status": "current",
-      "reviewedAt": "2026-09-10",
+      "reviewedAt": "2026-09-11",
       "source": "docs/PHASE-4-SYNC.md"
     },
     {

--- a/packages/pwa/src/lib/library-core-runtime.test.ts
+++ b/packages/pwa/src/lib/library-core-runtime.test.ts
@@ -543,11 +543,19 @@ describe("PWA Library Core bounded scanner", () => {
       };
     });
 
+    const onSyncStage = vi.fn();
     await expect(
-      syncPwaLibraryCoreFromGoogleDrive({ accessToken: "test-token" }),
+      syncPwaLibraryCoreFromGoogleDrive({ accessToken: "test-token", onSyncStage }),
     ).resolves.toEqual(
       expect.not.objectContaining({ items: expect.anything() }),
     );
+    expect(onSyncStage.mock.calls.map(([message]) => message)).toEqual([
+      "Reading the local Library checkpoint.",
+      "Finding the published Library in Google Drive.",
+      "Importing the verified Library checkpoint.",
+      "Checking device enrollment and syncing edits.",
+      "Refreshing the local Library view.",
+    ]);
     expect(mocks.importCheckpoint).toHaveBeenCalledWith(
       expect.objectContaining({ writer }),
     );

--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -1275,10 +1275,12 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
   readonly accessToken: string;
   readonly libraryId?: string;
   readonly signal?: AbortSignal;
+  readonly onSyncStage?: (message: string) => void;
 }): Promise<LibraryCoreRuntimeStateV1 & {
   readonly followerEnrollmentState: Awaited<ReturnType<typeof syncPwaLibraryCoreFollowerV2>>["enrollmentState"];
   readonly enrollmentDiscovery: LibraryCoreEnrollmentDiscoverySummaryV2 | null;
 }> {
+  input.onSyncStage?.("Reading the local Library checkpoint.");
   const selected = await readPwaNormalizedCheckpointReceipt();
   const retainedLibraryId = selected.receipt &&
     !selected.receipt.controlRevision.startsWith("preview:")
@@ -1286,6 +1288,7 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
   if (retainedLibraryId && input.libraryId && retainedLibraryId !== input.libraryId) {
     throw new Error("Reset this device before connecting a different Library");
   }
+  input.onSyncStage?.("Finding the published Library in Google Drive.");
   const discovered = await discoverPublishedGoogleDriveLibraryCoreControlV1({
     accessToken: input.accessToken,
     libraryId: retainedLibraryId ?? input.libraryId,
@@ -1308,6 +1311,7 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
     signal: input.signal,
   });
   const controlRevision = sha256LowerHex(discovered.control.bytes);
+  input.onSyncStage?.("Importing the verified Library checkpoint.");
   await importLibraryCoreNormalizedCheckpointV2({
     adapter,
     generation: pointer.generation,
@@ -1323,6 +1327,7 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
     }),
   });
   let enrollmentDiscovery: LibraryCoreEnrollmentDiscoverySummaryV2 | null = null;
+  input.onSyncStage?.("Checking device enrollment and syncing edits.");
   const followerReceipt = await syncPwaLibraryCoreFollowerV2(
     createGoogleDriveLibraryCoreNormalizedFollowerTransportV2({
       onEnrollmentDiscovery: (summary) => { enrollmentDiscovery = summary; },
@@ -1333,6 +1338,7 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
     }),
     { signal: input.signal },
   );
+  input.onSyncStage?.("Refreshing the local Library view.");
   return Object.freeze({
     ...await publishSelectedStateAfterLibraryCoreSync(),
     followerEnrollmentState: followerReceipt.enrollmentState,

--- a/packages/pwa/src/lib/sync.test.ts
+++ b/packages/pwa/src/lib/sync.test.ts
@@ -226,6 +226,7 @@ describe("PWA Library Core sync lifecycle", () => {
     );
     expect(mocks.syncLibraryCore).toHaveBeenNthCalledWith(2, {
       accessToken: "refreshed-access-token",
+      onSyncStage: expect.any(Function),
       signal: expect.any(AbortSignal),
     });
     expect(localStorage.getItem("freed_cloud_token_gdrive")).toBe(

--- a/packages/pwa/src/lib/sync.ts
+++ b/packages/pwa/src/lib/sync.ts
@@ -201,9 +201,10 @@ function isGoogleAuthenticationFailure(error: unknown): boolean {
 async function syncGoogleDriveWithFreshCredentials(
   accessToken: string,
   signal: AbortSignal,
+  onSyncStage: (message: string) => void,
 ): Promise<Awaited<ReturnType<typeof syncPwaLibraryCoreFromGoogleDrive>>> {
   try {
-    return await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal,
+    return await syncPwaLibraryCoreFromGoogleDrive({ accessToken, signal, onSyncStage,
       libraryId: localStorage.getItem(CLOUD_LIBRARY_KEY) ?? undefined });
   } catch (error) {
     if (!isGoogleAuthenticationFailure(error)) throw error;
@@ -223,6 +224,7 @@ async function syncGoogleDriveWithFreshCredentials(
     }
     return await syncPwaLibraryCoreFromGoogleDrive({
       accessToken: refreshedAccessToken,
+      onSyncStage,
       libraryId: localStorage.getItem(CLOUD_LIBRARY_KEY) ?? undefined,
       signal,
     });
@@ -262,7 +264,10 @@ async function performGoogleDriveSync(
   });
   let syncResult: Awaited<ReturnType<typeof syncGoogleDriveWithFreshCredentials>>;
   try {
-    syncResult = await syncGoogleDriveWithFreshCredentials(accessToken, signal);
+    syncResult = await syncGoogleDriveWithFreshCredentials(accessToken, signal, (message) => {
+      if (generation !== cloudGeneration || signal.aborted) return;
+      updateCloudProvider("gdrive", { statusMessage: message });
+    });
   } catch (error) {
     if (generation !== cloudGeneration || signal.aborted) throw error;
     if (error instanceof GoogleDriveLibrarySelectionRequiredError) {


### PR DESCRIPTION
(AI Generated).

## Summary
- Report local checkpoint, Drive discovery, checkpoint import, follower synchronization and view refresh while a PWA sync pass is running. This makes a stalled pass attributable without changing requests or admission.

## Testing
- Full local feature validation and 44 focused PWA tests passed. Local WebKit excluded per owner instruction; hosted WebKit required.

## Provider Review
- Status: Provider authority is validated for ready publication.
- Review action: none required. The provider-risk artifact records the behavior authority decision; this exact provider subdiff is the audit subject.
- Provider subdiff: `028e58116b3b5d8c24f0713594f73b3121033d59`
- Publication does not authorize new live provider traffic. Gate 1 behavior approval still applies when observable behavior changes.
- Provider review task: `pwa-sync-stage-diagnostics-20260911`
- Provider review decision: `diff_authorized`
- Provider review artifact: `46b90632bfa0443b77a34866a91c457ec8ee47bc93a20c613cce2286326b5719`
- Providers: other
- Observable behavior: Display bounded local progress messages before existing sync stages; no endpoint, request, retry, cadence, credential, identity or admission changes.
- Fingerprinting risk: None added: no endpoint, request count, cadence, cookie, header or provider action changes.
- Lowest profile alternative: Bounded diagnostics from the already fetched response and offline fixtures.

Files bound into this provider review:
- `packages/pwa/src/lib/sync.ts`