### PR TITLE
fix: report checkpoint import progress

### DIFF
--- a/docs/PHASE-4-SYNC.md
+++ b/docs/PHASE-4-SYNC.md
@@ -343,3 +343,7 @@ adding Drive requests or changing enrollment admission.
 PWA sync reports its current local-checkpoint, Drive discovery, checkpoint import,
 follower-sync, and view-refresh stage while the pass is running. This keeps an
 unsettled pass attributable without adding provider calls or changing admission.
+
+Checkpoint import progress separates immutable object download and verification,
+local selection comparison, staging, page storage, activation, and cleanup.
+Only bounded counts and byte totals enter the local progress display.

--- a/packages/pwa/src/lib/library-core-runtime.test.ts
+++ b/packages/pwa/src/lib/library-core-runtime.test.ts
@@ -500,9 +500,23 @@ describe("PWA Library Core bounded scanner", () => {
       controlFileId: "control-runtime-recovery",
       libraryId,
     });
-    const writer = Object.freeze({ beginImport: vi.fn() });
+    const writer = Object.freeze({
+      prepareImport: vi.fn().mockResolvedValue("import"),
+      beginImport: vi.fn(), appendPage: vi.fn(),
+      finalizeImport: vi.fn().mockResolvedValue({ checkpointDigest: "verified" }),
+      abortImport: vi.fn(),
+    });
+    const readImmutable = vi.fn().mockResolvedValue(Uint8Array.of(1));
+    mocks.createCloudAdapter.mockReturnValue({ readImmutable });
     mocks.createNormalizedCheckpointWriter.mockReturnValue(writer);
-    mocks.importCheckpoint.mockResolvedValue({ status: "already_complete" });
+    mocks.importCheckpoint.mockImplementation(async (input) => {
+      await input.adapter.readImmutable(pointer.manifest);
+      expect(await input.writer.prepareImport({}, pointer.manifest)).toBe("import");
+      await input.writer.beginImport({});
+      await input.writer.appendPage(0, []);
+      expect(await input.writer.finalizeImport({})).toEqual({ checkpointDigest: "verified" });
+      return { status: "imported" };
+    });
     mocks.readNormalizedCheckpointReceipt.mockResolvedValue({
       receipt: { ...SELECTED_RECEIPT, libraryId, writerActorId: writerId },
     });
@@ -553,12 +567,20 @@ describe("PWA Library Core bounded scanner", () => {
       "Reading the local Library checkpoint.",
       "Finding the published Library in Google Drive.",
       "Importing the verified Library checkpoint.",
+      `Downloading checkpoint object 1 (${pointer.manifest.descriptor.byteLength.toLocaleString()} bytes).`,
+      "Verifying the downloaded checkpoint object.",
+      "Comparing the downloaded checkpoint with this device.",
+      "Opening local checkpoint staging.",
+      "Storing checkpoint page 1 (0 records).",
+      "Verifying and activating the staged checkpoint.",
       "Checking device enrollment and syncing edits.",
       "Refreshing the local Library view.",
     ]);
-    expect(mocks.importCheckpoint).toHaveBeenCalledWith(
-      expect.objectContaining({ writer }),
-    );
+    expect(readImmutable).toHaveBeenCalledWith(pointer.manifest);
+    expect(writer.prepareImport).toHaveBeenCalledWith({}, pointer.manifest);
+    expect(writer.beginImport).toHaveBeenCalledWith({});
+    expect(writer.appendPage).toHaveBeenCalledWith(0, []);
+    expect(writer.finalizeImport).toHaveBeenCalledWith({});
     expect(mocks.createNormalizedCheckpointWriter).toHaveBeenCalledWith(
       expect.objectContaining({
         checkpointGeneration: 9,

--- a/packages/pwa/src/lib/library-core-runtime.ts
+++ b/packages/pwa/src/lib/library-core-runtime.ts
@@ -1311,20 +1311,51 @@ export async function syncPwaLibraryCoreFromGoogleDrive(input: {
     signal: input.signal,
   });
   const controlRevision = sha256LowerHex(discovered.control.bytes);
+  const checkpointWriter = createPwaNormalizedCheckpointWriter({
+    checkpointGeneration: pointer.generation,
+    controlRevision,
+    installedAt: Date.now(),
+    writerActorId: pointer.writerId,
+  });
+  let checkpointObjectCount = 0;
   input.onSyncStage?.("Importing the verified Library checkpoint.");
   await importLibraryCoreNormalizedCheckpointV2({
-    adapter,
+    adapter: {
+      async readImmutable(reference) {
+        checkpointObjectCount += 1;
+        input.onSyncStage?.(`Downloading checkpoint object ${checkpointObjectCount.toLocaleString()} (${reference.descriptor.byteLength.toLocaleString()} bytes).`);
+        const bytes = await adapter.readImmutable(reference);
+        input.onSyncStage?.("Verifying the downloaded checkpoint object.");
+        return bytes;
+      },
+    },
     generation: pointer.generation,
     libraryId: pointer.libraryId,
     manifest: pointer.manifest,
     storageEpoch: pointer.storageEpoch,
     subtle: crypto.subtle,
-    writer: createPwaNormalizedCheckpointWriter({
-      checkpointGeneration: pointer.generation,
-      controlRevision,
-      installedAt: Date.now(),
-      writerActorId: pointer.writerId,
-    }),
+    writer: {
+      async prepareImport(manifest, reference) {
+        input.onSyncStage?.("Comparing the downloaded checkpoint with this device.");
+        return await checkpointWriter.prepareImport?.(manifest, reference) ?? "import";
+      },
+      async beginImport(header) {
+        input.onSyncStage?.("Opening local checkpoint staging.");
+        return await checkpointWriter.beginImport(header);
+      },
+      async appendPage(pageIndex, records) {
+        input.onSyncStage?.(`Storing checkpoint page ${(pageIndex + 1).toLocaleString()} (${records.length.toLocaleString()} records).`);
+        return await checkpointWriter.appendPage(pageIndex, records);
+      },
+      async finalizeImport(receipt) {
+        input.onSyncStage?.("Verifying and activating the staged checkpoint.");
+        return await checkpointWriter.finalizeImport(receipt);
+      },
+      async abortImport() {
+        input.onSyncStage?.("Discarding the incomplete checkpoint stage.");
+        await checkpointWriter.abortImport?.();
+      },
+    },
   });
   let enrollmentDiscovery: LibraryCoreEnrollmentDiscoverySummaryV2 | null = null;
   input.onSyncStage?.("Checking device enrollment and syncing edits.");


### PR DESCRIPTION
(AI Generated).

## Summary
- Distinguish checkpoint downloads, verification, local selection, staging, page writes and activation in PWA sync diagnostics. Preserve existing calls, arguments, results and authority checks.

## Testing
- Full local feature validation and 44 focused PWA tests passed. Existing fixture verifies stage order and transparent call forwarding; no local WebKit runner.