### PR TITLE
style: refine vision copy and roadmap presentation

### DIFF
--- a/website/next.config.ts
+++ b/website/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   // Disable x-powered-by header
   poweredByHeader: false,
+  allowedDevOrigins: ["aubrey-paseo.tail285f88.ts.net"],
   transpilePackages: ["@freed/shared", "@freed/ui"],
   env: {
     NEXT_PUBLIC_TURNSTILE_SITE_KEY: process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY,

--- a/website/src/app/vision/VisionMilestones.tsx
+++ b/website/src/app/vision/VisionMilestones.tsx
@@ -5,7 +5,6 @@ import { PlanProofLink } from "@/components/PlanProofLink";
 import {
   FaRss,
   FaCodeBranch,
-  FaXTwitter,
   FaDesktop,
   FaRegUser,
   FaRegBookmark,
@@ -16,28 +15,21 @@ import styles from "./milestones.module.css";
 
 // Selected phases from the validated production manifest. Status is read from
 // the snapshot, never inferred from these concise presentation descriptions.
-// RSS and X are separate delivered milestones within completed phase 2.
+// The combined feed card follows phase 7: broader social capture remains in progress.
 const milestones = [
   {
     phase: 1,
-    title: "Built the foundation",
+    title: "Build the foundation",
     description:
       "An open-source core, a public home for Freed, and the shared library behind the apps.",
     icon: FaCodeBranch,
   },
   {
-    phase: 2,
-    title: "Brought RSS into Freed",
+    phase: 7,
+    title: "Bring your feeds together",
     description:
-      "Feed discovery, article capture, and subscription imports connect readers to the open web.",
+      "Facebook, Instagram, X, RSS, and more in one library. Capture reliability remains active work.",
     icon: FaRss,
-  },
-  {
-    phase: 2,
-    title: "Connected X",
-    description:
-      "Posts from X join the library, with your following feed and controls for choosing accounts.",
-    icon: FaXTwitter,
   },
   {
     phase: 5,

--- a/website/src/app/vision/VisionVariants.tsx
+++ b/website/src/app/vision/VisionVariants.tsx
@@ -1,40 +1,16 @@
 "use client";
 
-import { FaRegStar, FaRegEnvelope } from "react-icons/fa6";
+import { FaGithub, FaRegEnvelope } from "react-icons/fa6";
 import { useNewsletter } from "@/context/NewsletterContext";
 import VisionMilestones from "./VisionMilestones";
 import HeroArtwork from "./HeroArtwork";
 import styles from "./variants.module.css";
 
-function CommunityActions() {
+export default function VisionVariants() {
   const { openModal } = useNewsletter();
   return (
-    <div className={styles.communityActions}>
-      <a
-        className="btn-primary"
-        href="https://github.com/freed-project/freed"
-        target="_blank"
-        rel="noopener noreferrer"
-      >
-        <FaRegStar aria-hidden="true" />
-        Star on GitHub
-      </a>
-      <button
-        type="button"
-        className="btn-secondary"
-        onClick={() => openModal({ detailsOpen: true })}
-      >
-        <FaRegEnvelope aria-hidden="true" />
-        Subscribe to the newsletter
-      </button>
-    </div>
-  );
-}
-
-export default function VisionVariants() {
-  return (
     <>
-      <div className={styles.page} data-vision-variant="everyday">
+      <div className={styles.page} data-vision-variant="backer-focused">
         <section className={styles.hero} aria-labelledby="vision-title">
           <div>
             <h1 id="vision-title">
@@ -45,116 +21,62 @@ export default function VisionVariants() {
               Follow the people and ideas you care about. Decide for yourself what
               deserves your attention.
             </p>
-            <CommunityActions />
           </div>
           <HeroArtwork />
         </section>
-        <section className={styles.mission} aria-labelledby="mission-title">
-          <h2 id="mission-title">
-            Future humans deserve healthy social commons.
-          </h2>
-          <p>
-            We’re building open-source software that gives people authority over
-            the information shaping their minds. A feed you control is a start.
-            A culture that protects that freedom is the ambition.
-          </p>
+        <section className={styles.mission} id="mission-review" aria-labelledby="mission-title">
+          <h2 id="mission-title">A healthier commons for the next generation.</h2>
+          <p>The places where we share ideas shape the world we inherit. Freed starts with a feed you control. Our ambition is a social commons where people can think freely and learn from one another.</p>
         </section>
         <section className={styles.principles} aria-label="Freed’s commitments">
           <article>
-            <h3>You choose.</h3>
+            <h3>Control your feed.</h3>
             <p>Your sources and ranking, under your control.</p>
           </article>
           <article>
-            <h3>You keep it.</h3>
+            <h3>Keep your library private.</h3>
             <p>Your private library lives on your computer.</p>
           </article>
           <article>
-            <h3>Bring it together.</h3>
+            <h3>Follow across platforms.</h3>
             <p>Follow people and ideas across platforms in one feed.</p>
           </article>
         </section>
         <VisionMilestones />
-        <section
-          className={styles.openSource}
-          aria-labelledby="open-source-title"
-        >
-          <div className={styles.openSourceHeading}>
-            <h2 id="open-source-title">Open source.</h2>
-            <p>Trust should be earned.</p>
-          </div>
+        <section className={styles.openSource} aria-labelledby="open-source-title">
+          <h2 id="open-source-title">Look under the hood.</h2>
           <div>
-            <p className={styles.openSourceIntro}>
-              Freed’s code is public and MIT licensed. Our choices about privacy
-              and how your feed works are open to scrutiny.
-            </p>
+            <p className={styles.openSourceIntro}>Evaluate the work for yourself. Freed’s public, MIT-licensed code makes our choices about privacy and your feed open to scrutiny.</p>
             <p className={styles.openPromise}>
               Your private data and attention are never the product. Investors
               receive no control over your ranking.
             </p>
+            <div className={styles.communityActions}>
+              <a className="btn-secondary" href="https://github.com/freed-project/freed"
+                target="_blank" rel="noopener noreferrer"><FaGithub aria-hidden="true" />Explore the code</a>
+            </div>
           </div>
         </section>
-        <section
-          className={styles.support}
-          id="support"
-          aria-labelledby="support-title"
-        >
+        <section className={styles.support} id="support" aria-labelledby="support-title">
+          <h2 id="support-title">Follow our progress.</h2>
           <div>
-            <h2 id="support-title">Help this grow.</h2>
-            <p>
-              Follow the progress, show your support, or help fund the work
-              ahead.
-            </p>
-          </div>
-          <div className={styles.supportPaths}>
-            <article>
-              <h3>Stay in the loop.</h3>
-              <p>
-                Subscribe for new builds and major progress. Star Freed on
-                GitHub to show your support.
-              </p>
-              <CommunityActions />
-            </article>
-            <article>
-              <h3>Help make it happen.</h3>
-              <p>
-                If you can fund development, sponsor work, or help Freed reach
-                more people, talk with Aubrey.
-              </p>
-              <div className={styles.communityActions}>
-                <a
-                  className="btn-primary"
-                  href="https://aubreyfalconer.com"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  Talk with Aubrey
-                </a>
-              </div>
-            </article>
+            <p>Considering supporting Freed? Subscribe for new builds and major progress as the work develops.</p>
+            <div className={styles.communityActions}>
+              <button type="button" className="btn-secondary"
+                onClick={() => openModal({ detailsOpen: true })}>
+                <FaRegEnvelope aria-hidden="true" />Subscribe to the newsletter
+              </button>
+            </div>
           </div>
         </section>
-        <section
-          className={styles.invitation}
-          aria-labelledby="invitation-title"
-        >
+        <section className={styles.invitation} id="copy-review" aria-labelledby="invitation-title">
           <div>
-            <h2 id="invitation-title">
-              Give the next generation a mind of its own.
-            </h2>
-            <p>
-              Subscribe to follow the work. Star Freed to show your support.
-              Talk with Aubrey if you can help bring this vision to more people.
-            </p>
+            <h2 id="invitation-title">Help more people take back their attention.</h2>
+            <p>Freed is working software with more to build. We’re looking for backers to fund development and partners to bring Freed to new audiences.</p>
           </div>
           <div className={styles.invitationActions}>
-            <CommunityActions />
-            <a
-              className="btn-primary"
-              href="https://aubreyfalconer.com"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Talk with Aubrey
+            <a className="btn-primary" href="https://aubreyfalconer.com"
+              target="_blank" rel="noopener noreferrer">Connect with Aubrey
               <svg viewBox="0 0 20 20" aria-hidden="true">
                 <path d="M4 10h11M11 6l4 4-4 4" />
               </svg>

--- a/website/src/app/vision/milestones.module.css
+++ b/website/src/app/vision/milestones.module.css
@@ -1,5 +1,4 @@
 .section {
-  border-top: 1px solid var(--theme-border-subtle);
   padding: 3.5rem 0;
   min-width: 0;
   scroll-margin-top: 6rem;
@@ -20,8 +19,7 @@
   outline-offset: 4px;
 }
 .rail {
-  /* The scroll viewport reaches both page edges. Padding belongs to the list
-     so the first card starts on the content rail and then scrolls out of it. */
+  /* Start at the content inset; end at the last card without trailing space. */
   --rail-inset: max(clamp(1.5rem, 4vw, 3rem), calc((100vw - 76rem) / 2 + 3rem));
   width: 100vw;
   margin-left: calc(50% - 50vw);
@@ -29,8 +27,7 @@
   overflow-x: auto;
   overscroll-behavior-x: contain;
   scroll-snap-type: x mandatory;
-  scrollbar-width: thin;
-  scrollbar-color: var(--theme-border-strong) transparent;
+  scrollbar-width: none;
   padding-bottom: 1rem;
 }
 .list {
@@ -38,7 +35,7 @@
   gap: 1.25rem;
   list-style: none;
   margin: 0;
-  padding: 0 var(--rail-inset);
+  padding: 0 0 0 var(--rail-inset);
   width: max-content;
   min-width: 100%;
 }
@@ -60,7 +57,6 @@
   align-items: center;
   justify-content: space-between;
   margin-bottom: 1.5rem;
-  border-bottom: 1px solid var(--theme-border-subtle);
   padding-bottom: 1.25rem;
 }
 .illustration > span {
@@ -140,3 +136,6 @@
     font-size: 2rem;
   }
 }
+
+/* Hide scroll chrome without disabling touch, trackpad, or keyboard scrolling. */
+.rail::-webkit-scrollbar { display: none; }

--- a/website/src/app/vision/variants.module.css
+++ b/website/src/app/vision/variants.module.css
@@ -90,7 +90,6 @@
   grid-template-columns: 1.15fr 1fr;
   gap: 4rem;
   align-items: center;
-  border-top: 1px solid var(--theme-border-subtle);
   padding: 3.5rem 0 2.5rem;
 }
 .mission > p {
@@ -113,7 +112,6 @@
   font-size: 0.95rem;
 }
 .support {
-  border-top: 1px solid var(--theme-border-subtle);
   padding: 3.5rem 0;
   display: grid;
   grid-template-columns: 0.8fr 1.7fr;
@@ -186,7 +184,6 @@
   gap: 4rem;
   align-items: center;
   padding: 2.5rem 0 3rem;
-  border-top: 1px solid var(--theme-border-subtle);
 }
 .covenant h2 {
   font-size: clamp(1.8rem, 3vw, 2.6rem);
@@ -197,7 +194,6 @@
   gap: 5rem;
   align-items: center;
   padding: 4rem 0 2rem;
-  border-top: 1px solid var(--theme-border-subtle);
 }
 .invitation h2 {
   font-size: clamp(2.75rem, 4.7vw, 4.8rem);
@@ -248,7 +244,6 @@
   display: grid;
   grid-template-columns: 0.8fr 1.7fr;
   gap: 4rem;
-  border-top: 1px solid var(--theme-border-subtle);
   padding: 3.5rem 0;
 }
 .openSourceHeading > p {
@@ -262,7 +257,6 @@
 }
 .page .openPromise {
   margin-top: 1.25rem;
-  border-top: 1px solid var(--theme-border-subtle);
   padding-top: 1.25rem;
   font-size: 0.9rem;
   max-width: 60ch;
@@ -338,3 +332,5 @@
   .hero h1, .hero .intro { margin-left: auto; margin-right: auto; }
   .hero .communityActions { justify-content: center; }
 }
+
+.mission, .invitation { scroll-margin-top: 7rem; }

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -7,7 +7,6 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { Tooltip } from "@freed/ui/components/Tooltip";
-import { useNewsletter } from "@/context/NewsletterContext";
 import {
   NAV_INDICATOR_SPRING,
   NAV_INDICATOR_THICKNESS,
@@ -58,7 +57,6 @@ function isActive(itemPath: string, pathname: string): boolean {
 
 export default function Navigation() {
   const pathname = usePathname();
-  const { openModal } = useNewsletter();
   const [captionIndex, setCaptionIndex] = useState(0);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
@@ -213,9 +211,6 @@ export default function Navigation() {
         <FaPlay aria-hidden="true" className="h-2.5 w-2.5 shrink-0" />
         Live Demo
       </DemoLink>
-      <button onClick={() => openModal()} className="btn-primary px-6 py-3 whitespace-nowrap">
-        Get Freed
-      </button>
       </div>
     </div>
   );
@@ -303,9 +298,6 @@ export default function Navigation() {
                 <FaPlay aria-hidden="true" className="h-2.5 w-2.5 shrink-0" />
                 Live Demo
               </DemoLink>
-              <button onClick={() => openModal()} className="btn-primary whitespace-nowrap" style={{ padding: ".5rem .75rem" }}>
-                Get Freed
-              </button>
               </div>}
               {mobileHamburger}
             </div>
@@ -373,9 +365,6 @@ export default function Navigation() {
                     <FaPlay aria-hidden="true" className="h-3 w-3 shrink-0" />
                     Live Demo
                   </DemoLink>
-                  <button onClick={() => { openModal(); setMobileMenuOpen(false); }} className="btn-primary px-6 py-3 whitespace-nowrap">
-                    Get Freed
-                  </button>
                 </motion.div>
               </div>
             </motion.div>

--- a/website/src/components/PlanProofLink.tsx
+++ b/website/src/components/PlanProofLink.tsx
@@ -4,13 +4,13 @@ const destinations = {
   plan: {
     href: "/roadmap",
     eyebrow: "Roadmap",
-    label: "See what we intend to build",
+    label: "See what we're building",
     arrowDirection: "forward",
   },
   proof: {
     href: "/changelog",
     eyebrow: "Updates",
-    label: "See what actually shipped",
+    label: "See what we shipped",
     arrowDirection: "back",
   },
 } as const;


### PR DESCRIPTION
(AI Generated).

Refine the vision page around distinct actions: explore the code, follow progress, and connect with Aubrey about backing development or reaching new audiences. Apply the selected Social Commons mission and Reach closing copy, remove the header Get Freed buttons and content dividers, add the GitHub icon, and hide the roadmap scrollbar while preserving scrolling.

Combine the RSS and X milestone cards into one broader feeds card covering Facebook, Instagram, X, RSS, and more. Use phase 7's existing In progress status for that broader scope, and use present-tense action headings. Update the roadmap/updates cross-links to “See what we're building” and “See what we shipped.”

Roadmap source remains 341e4ad82cc85bc708808333dc4416601cf0a5d3 from v26.9.900, manifest SHA-256 47e07850c76ead4a66bb14cabdbd50ebb3f4132009925350f62ef2239538ed0a. Existing phase 2 and phase 7 documentation and the full roadmap were checked for consistency; no source data changed.

Validation: focused ESLint, diff checks, and headless checks across all six themes at desktop/mobile widths covering selected copy, CTA icon, merged card status, keyboard scrolling, hidden scrollbar, and layout overflow. Production build passed, including lint, TypeScript, static page generation, and feed generation. Roadmap end boundaries were measured at 390px, 1280px, and 1920px; the last card ends at the viewport edge without trailing scroll space.
