### PR TITLE
fix: finish vision layout and button clipping

### DIFF
--- a/website/src/app/manifesto/ManifestoContent.tsx
+++ b/website/src/app/manifesto/ManifestoContent.tsx
@@ -204,7 +204,7 @@ export default function ManifestoContent() {
               whileHover={{ scale: 1.05 }}
               whileTap={{ scale: 0.95 }}
               href="/vision"
-              className="btn-primary text-base px-8 py-3"
+              className="btn-primary inline-flex items-center justify-center text-base px-8 py-3"
             >
               Share the Vision
             </motion.a>

--- a/website/src/app/vision/HeroArtwork.tsx
+++ b/website/src/app/vision/HeroArtwork.tsx
@@ -1,4 +1,18 @@
+"use client";
+
 import styles from "./artwork.module.css";
+
+function FeedRow({ y, image = false }: { y: number; image?: boolean }) {
+  return (
+    <g transform={`translate(0 ${y})`}>
+      <circle cx="17" cy="10" r="5" fill="var(--theme-heading-accent)" opacity=".55" />
+      <path d="M29 7H66M29 14H52" stroke="var(--theme-text-secondary)" strokeWidth="2" opacity=".55" />
+      <path d={image ? "M12 24H69M12 31H58" : "M12 24H112M12 31H94"}
+        stroke="var(--theme-text-secondary)" strokeWidth="2" opacity=".45" />
+      {image && <rect x="81" y="3" width="31" height="31" rx="3" fill="var(--theme-heading-accent)" opacity=".25" />}
+    </g>
+  );
+}
 
 export default function HeroArtwork() {
   return (
@@ -6,7 +20,7 @@ export default function HeroArtwork() {
       <svg
         viewBox="0 0 500 460"
         role="img"
-        aria-label="Stories fold into paper birds and take flight through an open frame"
+        aria-label="A feed of stories becomes paper airplanes flying through an open frame"
       >
         <defs>
           <linearGradient id="flight-paper" x1="0" y1="0" x2="1" y2="1">
@@ -43,29 +57,17 @@ export default function HeroArtwork() {
           strokeDasharray="3 9"
           opacity=".6"
         />
-        <g transform="translate(55 285) rotate(-14)">
-          <rect
-            width="126"
-            height="88"
-            rx="5"
-            fill="var(--theme-bg-surface)"
-            stroke="var(--theme-border-strong)"
-          />
-          <rect
-            x="13"
-            y="15"
-            width="31"
-            height="27"
-            rx="3"
-            fill="var(--theme-heading-accent)"
-            opacity=".4"
-          />
-          <path
-            d="M55 19H109M55 28H96M55 37H104M13 58H110M13 68H90"
-            stroke="var(--theme-text-secondary)"
-            strokeWidth="3"
-            opacity=".5"
-          />
+        <g transform="translate(55 267) rotate(-14)">
+          <>
+              <rect width="126" height="132" rx="5" fill="var(--theme-bg-surface)" stroke="var(--theme-border-strong)" />
+              <path d="M12 12H44M96 12H113" stroke="var(--theme-heading-accent)" strokeWidth="3" opacity=".6" />
+              <FeedRow y={22} image />
+              <FeedRow y={65} />
+              <g opacity=".3">
+                <circle cx="17" cy="118" r="5" fill="var(--theme-heading-accent)" />
+                <path d="M29 115H66M29 122H99" stroke="var(--theme-text-secondary)" strokeWidth="2" />
+              </g>
+          </>
         </g>
         <g transform="translate(150 226) rotate(-15)">
           <path d="M0 45L135 0L80 100L56 61Z" fill="url(#flight-paper)" />

--- a/website/src/app/vision/VisionMilestones.tsx
+++ b/website/src/app/vision/VisionMilestones.tsx
@@ -103,7 +103,7 @@ export default function VisionMilestones() {
     >
       <div className={styles.heading}>
         <div>
-          <h2 id="milestones-title">Current status: working software.</h2>
+          <h2 id="milestones-title">Current status: working software</h2>
           <p>
             Read your sources in Freed today. Follow what we’re building next.
           </p>

--- a/website/src/app/vision/VisionVariants.tsx
+++ b/website/src/app/vision/VisionVariants.tsx
@@ -14,8 +14,8 @@ export default function VisionVariants() {
         <section className={styles.hero} aria-labelledby="vision-title">
           <div>
             <h1 id="vision-title">
-              Your feed. Your rules.{" "}
-              <span className={styles.headlineAccent}>Your life.</span>
+              Your feed Your rules{" "}
+              <span className={styles.headlineAccent}>Your life</span>
             </h1>
             <p className={styles.intro}>
               Follow the people and ideas you care about. Decide for yourself what
@@ -25,26 +25,26 @@ export default function VisionVariants() {
           <HeroArtwork />
         </section>
         <section className={styles.mission} id="mission-review" aria-labelledby="mission-title">
-          <h2 id="mission-title">A healthier commons for the next generation.</h2>
-          <p>The places where we share ideas shape the world we inherit. Freed starts with a feed you control. Our ambition is a social commons where people can think freely and learn from one another.</p>
+          <h2 id="mission-title">A healthier commons for the next generation</h2>
+          <p>Freed puts independent thought and learning from one another at the heart of social media.</p>
         </section>
         <section className={styles.principles} aria-label="Freed’s commitments">
           <article>
-            <h3>Control your feed.</h3>
+            <h3>Control your feed</h3>
             <p>Your sources and ranking, under your control.</p>
           </article>
           <article>
-            <h3>Keep your library private.</h3>
+            <h3>Keep your library private</h3>
             <p>Your private library lives on your computer.</p>
           </article>
           <article>
-            <h3>Follow across platforms.</h3>
+            <h3>Follow across platforms</h3>
             <p>Follow people and ideas across platforms in one feed.</p>
           </article>
         </section>
         <VisionMilestones />
         <section className={styles.openSource} aria-labelledby="open-source-title">
-          <h2 id="open-source-title">Look under the hood.</h2>
+          <h2 id="open-source-title">Look under the hood</h2>
           <div>
             <p className={styles.openSourceIntro}>Evaluate the work for yourself. Freed’s public, MIT-licensed code makes our choices about privacy and your feed open to scrutiny.</p>
             <p className={styles.openPromise}>
@@ -58,7 +58,7 @@ export default function VisionVariants() {
           </div>
         </section>
         <section className={styles.support} id="support" aria-labelledby="support-title">
-          <h2 id="support-title">Follow our progress.</h2>
+          <h2 id="support-title">Follow our progress</h2>
           <div>
             <p>Considering supporting Freed? Subscribe for new builds and major progress as the work develops.</p>
             <div className={styles.communityActions}>
@@ -71,7 +71,7 @@ export default function VisionVariants() {
         </section>
         <section className={styles.invitation} id="copy-review" aria-labelledby="invitation-title">
           <div>
-            <h2 id="invitation-title">Help more people take back their attention.</h2>
+            <h2 id="invitation-title">Help more people take back their attention</h2>
             <p>Freed is working software with more to build. We’re looking for backers to fund development and partners to bring Freed to new audiences.</p>
           </div>
           <div className={styles.invitationActions}>

--- a/website/src/app/vision/milestones.module.css
+++ b/website/src/app/vision/milestones.module.css
@@ -19,29 +19,28 @@
   outline-offset: 4px;
 }
 .rail {
-  /* Start at the content inset; end at the last card without trailing space. */
+  /* Match both scroll endpoints to the centered content rail. */
   --rail-inset: max(clamp(1.5rem, 4vw, 3rem), calc((100vw - 76rem) / 2 + 3rem));
   width: 100vw;
   margin-left: calc(50% - 50vw);
-  scroll-padding-left: var(--rail-inset);
+  scroll-padding-inline: var(--rail-inset);
   overflow-x: auto;
   overscroll-behavior-x: contain;
-  scroll-snap-type: x mandatory;
   scrollbar-width: none;
   padding-bottom: 1rem;
 }
 .list {
-  display: flex;
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 18rem;
   gap: 1.25rem;
   list-style: none;
   margin: 0;
-  padding: 0 0 0 var(--rail-inset);
+  padding: 0 var(--rail-inset);
   width: max-content;
-  min-width: 100%;
 }
 .list > li {
-  flex: 0 0 18rem;
-  scroll-snap-align: start;
+  min-width: 0;
 }
 .card {
   height: 100%;
@@ -125,8 +124,8 @@
     font-size: 0.95rem;
     max-width: 26ch;
   }
-  .list > li {
-    flex-basis: min(17rem, 80vw);
+  .list {
+    grid-auto-columns: min(17rem, 80vw);
   }
   .heading {
     align-items: flex-start;

--- a/website/src/app/vision/variants.module.css
+++ b/website/src/app/vision/variants.module.css
@@ -1,7 +1,7 @@
 .page {
   max-width: 76rem;
   margin: auto;
-  padding: 10rem clamp(1.5rem, 4vw, 3rem) 5rem;
+  padding: 10rem clamp(1.5rem, 4vw, 3rem) 8rem;
   color: var(--theme-text-primary);
 }
 .page h1,
@@ -51,7 +51,7 @@
   grid-template-columns: 1.25fr 1fr;
   align-items: center;
   gap: 4rem;
-  padding-bottom: 5rem;
+  padding-bottom: 3rem;
 }
 .page .intro {
   font-size: clamp(1.1rem, 1.8vw, 1.35rem);
@@ -103,8 +103,10 @@
   padding: 1rem 0 3.5rem;
 }
 .principles article {
-  border-left: 2px solid var(--theme-heading-accent);
-  padding-left: 1.2rem;
+  text-align: center;
+}
+.principles p {
+  margin-inline: auto;
 }
 .principles p {
   max-width: 26ch;
@@ -135,12 +137,12 @@
 @media (max-width: 760px) {
   .page {
     padding-top: 7rem;
-    padding-bottom: 5rem;
+    padding-bottom: 6.5rem;
   }
   .hero {
     grid-template-columns: 1fr;
     gap: 3rem;
-    padding-bottom: 3rem;
+    padding-bottom: 2rem;
   }
   .page h1 {
     max-width: 15ch;
@@ -334,3 +336,38 @@
 }
 
 .mission, .invitation { scroll-margin-top: 7rem; }
+
+@media (min-width: 761px) {
+  .principles {
+    max-width: 58rem;
+    margin-inline: auto;
+    gap: 0;
+  }
+  .principles article {
+    position: relative;
+    padding-inline: 1.2rem;
+  }
+  .principles article + article::before {
+    content: "";
+    position: absolute;
+    left: 0;
+    top: 15%;
+    height: 70%;
+    border-left: 1px solid var(--theme-border-subtle);
+  }
+  .openSource,
+  .support {
+    max-width: 58rem;
+    margin-left: auto;
+    margin-right: 0;
+  }
+  .openSource,
+  .support {
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.7fr);
+    gap: clamp(2rem, 4vw, 4rem);
+  }
+}
+
+.page > .mission ~ section {
+  margin-top: clamp(1rem, 2vw, 1.5rem);
+}

--- a/website/src/components/Navigation.tsx
+++ b/website/src/components/Navigation.tsx
@@ -7,6 +7,7 @@ import { usePathname } from "next/navigation";
 import { motion, AnimatePresence } from "framer-motion";
 import { useState, useEffect, useRef, useLayoutEffect } from "react";
 import { Tooltip } from "@freed/ui/components/Tooltip";
+import { useNewsletter } from "@/context/NewsletterContext";
 import {
   NAV_INDICATOR_SPRING,
   NAV_INDICATOR_THICKNESS,
@@ -57,6 +58,7 @@ function isActive(itemPath: string, pathname: string): boolean {
 
 export default function Navigation() {
   const pathname = usePathname();
+  const { openModal } = useNewsletter();
   const [captionIndex, setCaptionIndex] = useState(0);
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
@@ -190,7 +192,7 @@ export default function Navigation() {
       {/* Sliding underline - only animates horizontally */}
       {underlineStyle.width > 0 && (
         <motion.span
-          className="absolute top-[calc(100%-1px)] bg-text-primary pointer-events-none"
+          className="absolute top-[calc(100%-7px)] bg-text-primary pointer-events-none"
           initial={false}
           animate={{
             left: underlineStyle.left,
@@ -211,6 +213,9 @@ export default function Navigation() {
         <FaPlay aria-hidden="true" className="h-2.5 w-2.5 shrink-0" />
         Live Demo
       </DemoLink>
+      <button onClick={() => openModal()} className="btn-primary px-6 py-3 whitespace-nowrap">
+        Get Freed
+      </button>
       </div>
     </div>
   );
@@ -298,6 +303,9 @@ export default function Navigation() {
                 <FaPlay aria-hidden="true" className="h-2.5 w-2.5 shrink-0" />
                 Live Demo
               </DemoLink>
+              <button onClick={() => openModal()} className="btn-primary whitespace-nowrap" style={{ padding: ".5rem .75rem" }}>
+                Get Freed
+              </button>
               </div>}
               {mobileHamburger}
             </div>
@@ -365,6 +373,9 @@ export default function Navigation() {
                     <FaPlay aria-hidden="true" className="h-3 w-3 shrink-0" />
                     Live Demo
                   </DemoLink>
+                  <button onClick={() => { openModal(); setMobileMenuOpen(false); }} className="btn-primary px-6 py-3 whitespace-nowrap">
+                    Get Freed
+                  </button>
                 </motion.div>
               </div>
             </motion.div>


### PR DESCRIPTION
(AI Generated).

Finish the reviewed vision-page layout and copy: use the scrolling-feed illustration, tighten the mission paragraph, remove heading periods, adjust section spacing and widths, and center the benefit columns with short neutral dividers. Use an explicit grid track for roadmap cards with matching content-rail insets at both scroll endpoints and no mandatory snapping.

Restore the shared navbar's Get Freed buttons and original behavior, with only the requested 6px upward underline adjustment. Keep Get Freed absent from the vision hero. Make the manifesto's Share the Vision link inline-flex so its animated shine is clipped inside the button.

Validation: owner-reviewed local preview and focused browser geometry checks. The final production build passed, including lint, TypeScript, static pages, and feed generation. Roadmap source and status data are unchanged.
