### PR TITLE
fix: preserve approved social preview bytes

### DIFF
--- a/website/scripts/generate-social-preview.mjs
+++ b/website/scripts/generate-social-preview.mjs
@@ -36,8 +36,34 @@ const template = await readFile(resolve(website, "scripts/social-preview/templat
 if (template.split("{{PHONE_IMAGE}}").length !== 2) {
   throw new Error("The social preview template must contain exactly one phone image slot.");
 }
-const svg = template.replace("{{PHONE_IMAGE}}", phone.toString("base64"));
-const png = await sharp(Buffer.from(svg)).png().toBuffer();
+const source = {
+  releaseTag: showcase.releaseTag ?? null,
+  sourceCommit: showcase.sourceCommit,
+  animationUrl: ember.animation.url,
+  animationSha256: ember.animation.sha256,
+  capture: ember.captures[frame].file,
+  frame,
+  crop: framing.crop,
+  templateSha256: hash(template),
+};
+// Native rasterizers can differ by one channel level across CPU architectures.
+// Preserve the reviewed PNG bytes while its verified source and design match.
+// A new screenshot, crop, or template always invalidates this reuse.
+let png;
+try {
+  const previous = await readJson("src/data/social-preview.json");
+  if (JSON.stringify(previous.source) === JSON.stringify(source) &&
+      /^\/social\/freed-[a-f0-9]{12}\.png$/.test(previous.url)) {
+    const candidate = await readFile(resolve(website, "public", previous.url.slice(1)));
+    if (hash(candidate) === previous.sha256) png = candidate;
+  }
+} catch (error) {
+  if (error.code !== "ENOENT") throw error;
+}
+if (!png) {
+  const svg = template.replace("{{PHONE_IMAGE}}", phone.toString("base64"));
+  png = await sharp(Buffer.from(svg)).png().toBuffer();
+}
 const { width, height } = await sharp(png).metadata();
 if (width !== 1200 || height !== 630) throw new Error("Social preview must be 1200 by 630.");
 const digest = hash(png);
@@ -46,16 +72,7 @@ const record = {
   url, width, height,
   alt: "Freed: Take Back Your Feed. Social feeds in one local app. Open source and free forever. Ember phone preview.",
   sha256: digest,
-  source: {
-    releaseTag: showcase.releaseTag ?? null,
-    sourceCommit: showcase.sourceCommit,
-    animationUrl: ember.animation.url,
-    animationSha256: ember.animation.sha256,
-    capture: ember.captures[frame].file,
-    frame,
-    crop: framing.crop,
-    templateSha256: hash(template),
-  },
+  source,
 };
 const output = resolve(website, "public", url.slice(1));
 const recordPath = resolve(website, "src/data/social-preview.json");

--- a/website/scripts/social-preview/README.md
+++ b/website/scripts/social-preview/README.md
@@ -2,7 +2,8 @@
 
 Run `npm run generate:social-preview` from `website/` whenever showcase screenshots
 are regenerated or their active mapping changes. The normal website build also
-runs it. `npm run check:social-preview` verifies the checked-in output without
+runs it. Unchanged source and template hashes preserve the reviewed PNG bytes
+across build platforms; refreshed screenshots or design changes regenerate it. `npm run check:social-preview` verifies the checked-in output without
 writing files.
 
 The generator selects the mobile Stories frame from the homepage's active Ember


### PR DESCRIPTION
(AI Generated).

Preserve the approved social PNG when its verified screenshot, crop, and SVG template are unchanged. Vercel's native rasterizer differed from the local output by 11 channel values, each by one level, which changed the image URL despite an unchanged design.

Changed screenshot or template hashes still regenerate the tile. This keeps production bytes identical to the approved asset without preventing future screenshot refreshes.

Validation: full website build; unchanged-input byte preservation; changed-frame regeneration; generator freshness checks; instruction and skill validators. No visual design changes.
