### PR TITLE
fix: restore vision hero punctuation

### DIFF
--- a/website/src/app/vision/VisionVariants.tsx
+++ b/website/src/app/vision/VisionVariants.tsx
@@ -14,8 +14,8 @@ export default function VisionVariants() {
         <section className={styles.hero} aria-labelledby="vision-title">
           <div>
             <h1 id="vision-title">
-              Your feed Your rules{" "}
-              <span className={styles.headlineAccent}>Your life</span>
+              Your feed. Your rules.{" "}
+              <span className={styles.headlineAccent}>Your life.</span>
             </h1>
             <p className={styles.intro}>
               Follow the people and ideas you care about. Decide for yourself what


### PR DESCRIPTION
(AI Generated).

Restore the three periods in the vision hero: “Your feed. Your rules. Your life.” Keep all other vision headings without periods.

Validation: production website build and rendered heading checks.
